### PR TITLE
release: 0.1.1

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,62 @@
+name: Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      NODE_VERSION: 22
+      GITHUB_PAGES: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Resolve npm version from packageManager
+        run: |
+          NPM_VERSION="$(node -p 'require("./package.json").packageManager.split("@")[1]')"
+          echo "NPM_VERSION=${NPM_VERSION}" >> "$GITHUB_ENV"
+
+      - name: Install pinned npm
+        run: npm install --global "npm@${NPM_VERSION}"
+
+      - run: npm --version
+      - run: npm ci
+      - run: npm run build:pages
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: examples/vite/dist
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    if: ${{ github.ref == 'refs/heads/main' }}
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ default skin はできるだけ静かに、そして dark mode / high contrast /
 - root export は UI 寄り、低レベル API は `/headless` に分離
 - Vite / Rsbuild の両方で consumption を検証済み
 
+## Example
+
+Vite consumer example:
+
+https://mt4110.github.io/image-drop-input/
+
 ## インストール
 
 ```bash
@@ -472,9 +478,3 @@ npm run check:package
 
 - publish owner や GitHub repository を変える場合は、`package.json` の `name` / `homepage` / `bugs` / `repository` を一緒に更新してください
 - `npm pack --dry-run` と `npm run check:package` を最後に通すと安全です
-
-## ひとことで
-
-**「全部入り uploader」を作るのではなく、単一画像に強い・速い・壊れにくい入力部品として磨く。**
-
-この package は、そのためのかなり静かな土台です。

--- a/README_en.md
+++ b/README_en.md
@@ -20,6 +20,12 @@ high contrast, reduced transparency, and compact container widths.
 - Keeps the root entry UI-first and lower-level APIs under `/headless`
 - Verified in both Vite and Rsbuild consumers
 
+## Example
+
+Vite consumer example:
+
+https://mt4110.github.io/image-drop-input/
+
 ## Install
 
 ```bash
@@ -473,8 +479,3 @@ npm run check:package
 
 - if you move the package to a different owner or GitHub repository, update `name`, `homepage`, `bugs`, and `repository` together in `package.json`
 - run `npm pack --dry-run` and `npm run check:package` as the last gate
-
-## One sentence
-
-This package is meant to be a **fast, quiet, dependable single-image input**,
-not an everything-and-the-kitchen-sink uploader.

--- a/examples/vite/vite.config.ts
+++ b/examples/vite/vite.config.ts
@@ -4,8 +4,10 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 const packageRoot = fileURLToPath(new URL('../..', import.meta.url));
+const base = process.env.GITHUB_PAGES === 'true' ? '/image-drop-input/' : '/';
 
 export default defineConfig({
+  base,
   plugins: [react()],
   resolve: {
     alias: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "image-drop-input",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "image-drop-input",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "workspaces": [
         "examples/*"

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "image-drop-input",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Lightweight React image uploader with preview, preview dialog, compression, and pluggable uploads.",
   "license": "MIT",
   "type": "module",
-  "homepage": "https://github.com/mt4110/image-drop-input#readme",
+  "homepage": "https://mt4110.github.io/image-drop-input/",
   "bugs": {
     "url": "https://github.com/mt4110/image-drop-input/issues"
   },
@@ -71,6 +71,7 @@
     "clean:share": "rm -rf node_modules dist coverage examples/vite/dist examples/rsbuild/dist examples/rsbuild/.rsbuild",
     "build:lib": "tsdown && node -e \"import { copyFileSync, mkdirSync } from 'node:fs'; mkdirSync('dist', { recursive: true }); copyFileSync('src/style.css', 'dist/style.css'); copyFileSync('src/core/style-css.d.ts', 'dist/style.css.d.ts');\"",
     "build:examples": "npm run build --workspace examples/vite && npm run build --workspace examples/rsbuild",
+    "build:pages": "GITHUB_PAGES=true npm run build --workspace examples/vite",
     "build": "npm run clean && npm run build:lib && npm run build:examples",
     "prepack": "npm run build:lib",
     "prepublishOnly": "npm run check:package",


### PR DESCRIPTION
## Summary

- release version: 0.1.1
- dist-tag: latest
- scope: patch release for README cleanup and the Pages demo

## Highlights

- remove the closing README copy that appears at the bottom of the npm package page
- add a GitHub Pages workflow for the Vite consumer example
- set the Vite Pages build base to `/image-drop-input/`
- point the package homepage and README example link to the Pages URL

## Checks

- [x] `package.json` and `package-lock.json` carry the intended version
- [x] `npm run release:pr:check`
- [x] `npm run build:pages`
- [x] Pages build emits `/image-drop-input/assets/...` paths
- [ ] GitHub Actions CI after PR creation

## Publish Plan

- [ ] merge to `main`
- [ ] make sure GitHub Pages is configured to deploy from GitHub Actions
- [ ] create and push signed tag `v0.1.1` from `main`
- [ ] create a draft GitHub Release for `v0.1.1`
- [ ] publish the GitHub Release so the release workflow publishes `image-drop-input@0.1.1`

## Notes

- breaking changes: none
- follow-up work: consider simplifying the release workflow so manual rehearsal cannot accidentally publish
