### PR TITLE
Sharpen pre-upload adoption flow

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,301 @@
+# image-drop-input
+
+[English README](./README.md) · [Demo](https://mt4110.github.io/image-drop-input/) · [Issues](https://github.com/mt4110/image-drop-input/issues)
+
+upload 前に起きる面倒なことを引き受ける、軽量な React 画像 input です。
+
+drop / browse / paste / preview / validate / compress / upload を、UI framework や cloud SDK に縛られずに組み込めます。
+
+## なぜ
+
+多くの upload component は「file を受け取る」ところで止まります。
+
+実際の product form では、それだけでは足りません。
+
+- 選択直後にローカル preview を出したい
+- 大きすぎる画像、小さすぎる画像、形式違いを弾きたい
+- upload 前に圧縮や WebP 変換をしたい
+- 一時 preview と保存済み URL を分けたい
+- S3 / R2 / GCS / Azure Blob / 独自 API につなぎたい
+- client bundle に cloud SDK を入れたくない
+- accessibility と差し替えやすさを保ちたい
+
+`image-drop-input` は、単なる uploader ではなく pre-upload image flow のための input です。
+
+名前には `drop` が入っていますが、価値は drag and drop だけではありません。upload 前に画像を安全に整えるための component です。
+
+## インストール
+
+```bash
+npm install image-drop-input react
+```
+
+default CSS を一度 import してください。
+
+```tsx
+import 'image-drop-input/style.css';
+```
+
+## 最短導入
+
+`upload` を省略すると、local-preview-only の画像 input として使えます。
+
+```tsx
+import { useState } from 'react';
+import {
+  ImageDropInput,
+  type ImageUploadValue
+} from 'image-drop-input';
+import 'image-drop-input/style.css';
+
+export function AvatarField() {
+  const [value, setValue] = useState<ImageUploadValue | null>(null);
+
+  return (
+    <ImageDropInput
+      value={value}
+      onChange={setValue}
+      accept="image/png,image/jpeg,image/webp"
+      maxBytes={5 * 1024 * 1024}
+      aspectRatio={1}
+    />
+  );
+}
+```
+
+## 何が入っているか
+
+| Feature | Included |
+| --- | --- |
+| Drag and drop | Yes |
+| Click-to-select | Yes |
+| Clipboard paste | Yes |
+| Local preview | Yes |
+| Preview dialog | Yes |
+| Validation | MIME, size, dimensions, pixel budget |
+| Transform hook | Yes |
+| Compression helper | Yes |
+| WebP conversion | Yes |
+| Presigned PUT upload | Yes |
+| Multipart POST upload | Yes |
+| Raw PUT upload | Yes |
+| Headless hook | Yes |
+| Runtime dependencies | React peer dependency only |
+
+## Image lifecycle
+
+```txt
+pick / drop / paste
+  -> validate
+  -> transform
+  -> validate again
+  -> preview
+  -> upload
+  -> commit
+```
+
+user に見えている preview と、DB に保存してよい画像参照は同じではありません。
+
+## Value model
+
+```ts
+type ImageUploadValue = {
+  src?: string;
+  previewSrc?: string;
+  fileName?: string;
+  mimeType?: string;
+  size?: number;
+  width?: number;
+  height?: number;
+  key?: string;
+};
+```
+
+- `src`: 保存済み、または共有可能な画像 URL
+- `previewSrc`: 一時的な local preview URL。多くの場合 `blob:` URL
+
+この 2 つを分けることで、「見た目は保存済みに見えるが実際は upload できていない」という事故を避けます。
+
+upload が失敗した場合、component は最後に commit 済みの値へ戻り、Retry では同じ prepared file を再送します。
+
+## Upload examples
+
+### Local preview only
+
+```tsx
+<ImageDropInput
+  value={value}
+  onChange={setValue}
+/>
+```
+
+### Presigned PUT
+
+```tsx
+import { createPresignedPutUploader } from 'image-drop-input/headless';
+
+const upload = createPresignedPutUploader({
+  async getTarget(file, context) {
+    const response = await fetch('/api/uploads/presign', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        fileName: context.fileName,
+        originalFileName: context.originalFileName,
+        mimeType: context.mimeType,
+        size: file.size
+      })
+    });
+
+    if (!response.ok) {
+      throw new Error('Failed to create upload URL.');
+    }
+
+    return response.json();
+  }
+});
+```
+
+presign endpoint は次の形を返してください。
+
+```ts
+type PresignedPutTarget = {
+  uploadUrl: string;
+  headers?: Record<string, string>;
+  publicUrl?: string;
+  objectKey?: string;
+};
+```
+
+package は upload URL から public URL を推測しません。`publicUrl` または `objectKey` を明示してください。
+
+### Multipart POST
+
+```ts
+import { createMultipartUploader } from 'image-drop-input/headless';
+
+const upload = createMultipartUploader({
+  endpoint: '/api/upload',
+  fieldName: 'file'
+});
+```
+
+### Raw PUT
+
+```ts
+import { createRawPutUploader } from 'image-drop-input/headless';
+
+const upload = createRawPutUploader({
+  endpoint: '/api/avatar',
+  publicUrl: '/avatars/current-user.jpg',
+  objectKey: 'avatars/current-user.jpg'
+});
+```
+
+## Transform と compression
+
+```tsx
+import { compressImage } from 'image-drop-input/headless';
+
+<ImageDropInput
+  value={value}
+  onChange={setValue}
+  transform={(file) =>
+    compressImage(file, {
+      maxWidth: 1600,
+      maxHeight: 1600,
+      quality: 0.86
+    })
+  }
+/>
+```
+
+WebP 変換もできます。
+
+```tsx
+<ImageDropInput
+  value={value}
+  onChange={setValue}
+  accept="image/png,image/jpeg,image/webp"
+  transform={async (file) => ({
+    file: await compressImage(file, {
+      maxWidth: 1600,
+      maxHeight: 1600,
+      outputType: 'image/webp',
+      quality: 0.86
+    }),
+    fileName: file.name.replace(/\.(png|jpe?g|webp)$/i, '.webp'),
+    mimeType: 'image/webp'
+  })}
+/>
+```
+
+validation は transform の前後で走ります。
+
+## よく使う props
+
+| Prop | Purpose |
+| --- | --- |
+| `value` | 現在の画像 value |
+| `onChange` | 次の画像 value を受け取る |
+| `upload` | optional upload adapter |
+| `transform` | optional pre-upload transform |
+| `accept` | 受け付ける MIME type / extension |
+| `maxBytes` | 最大 file size |
+| `minWidth` / `minHeight` | 最小画像寸法 |
+| `maxWidth` / `maxHeight` | 最大画像寸法 |
+| `maxPixels` | 最大 pixel 数 |
+| `disabled` | input を無効化 |
+| `removable` | remove action を有効化 |
+| `previewable` | preview dialog を有効化 |
+| `capture` | file input の camera capture hint |
+| `aspectRatio` | dropzone の aspect ratio |
+| `messages` | copy と aria label の上書き |
+| `classNames` | part-level class names |
+| `renderPlaceholder` / `renderActions` / `renderFooter` | 部分 render 差し替え |
+| `onError` / `onProgress` | error / progress callback |
+
+## Headless usage
+
+UI を自前で組みたい場合は `useImageDropInput()` を使います。
+
+```tsx
+import { useImageDropInput } from 'image-drop-input/headless';
+
+const imageInput = useImageDropInput({
+  accept: 'image/*',
+  maxBytes: 5 * 1024 * 1024
+});
+```
+
+headless API を wrapper 化する場合に使える `UseImageDropInputReturn` も export しています。
+
+## Multiple images
+
+この package は intentionally single-image first です。
+
+複数画像は、app 側で array state を持ち、item ごとに `ImageDropInput` または `useImageDropInput()` を使ってください。並び替え、削除、保存状態、upload orchestration は product 層で持つ方が破綻しにくいです。
+
+## When not to use this
+
+次が必要なら別 tool の方が向いています。
+
+- generic multi-file uploader
+- resumable / chunked upload
+- full crop / rotate / annotation editor
+- provider-specific SDK wrapper
+- Node-side image processing
+
+## 開発
+
+```bash
+npm ci
+npm run typecheck
+npm test
+npm run build:lib
+npm run build:examples
+npm run check:package
+npm pack --dry-run
+```
+
+今後の方針は [ROADMAP.md](./ROADMAP.md) に分けています。README は「今使える価値」に寄せています。

--- a/README.md
+++ b/README.md
@@ -1,45 +1,48 @@
 # image-drop-input
 
-[English README](./README_en.md)
+[Japanese README](./README.ja.md) · [Demo](https://mt4110.github.io/image-drop-input/) · [Issues](https://github.com/mt4110/image-drop-input/issues)
 
-軽量・高速・依存少なめの **React 向け画像アップロード入力コンポーネント** です。
+The image input for everything that happens before upload.
 
-ドラッグ & ドロップ、クリック選択、クリップボード貼り付け、ローカルプレビュー、プレビューダイアログ、画像圧縮、
-そして **Presigned URL / 独自 API** を使ったアップロードを、重い UI 依存や cloud SDK なしで扱えます。
+A lightweight React image input for the messy part before upload: drop, browse, paste, preview, validate, compress, and upload images without UI-framework or cloud-SDK lock-in.
 
-default skin はできるだけ静かに、そして dark mode / high contrast / reduced transparency / compact width でも
-面の役割が崩れにくいように設計しています。
+## Why
 
-## 特徴
+Most upload components stop at "give me a file".
 
-- React の peer dependency 以外に runtime dependency を持たない
-- 単一画像アップロードに必要な UX をひと通り持つ
-- `src` と `previewSrc` を分けて、保存対象と一時プレビューを混線させない
-- upload adapter を URL 文字列から推測せず、明示的な API で差し替えられる
-- root export は UI 寄り、低レベル API は `/headless` に分離
-- Vite / Rsbuild の両方で consumption を検証済み
+Real product forms usually need more:
 
-## Example
+- show a local preview immediately
+- reject images that are too large, too small, or the wrong type
+- compress or convert before upload
+- keep temporary preview state separate from persisted state
+- upload to S3, R2, GCS, Azure Blob, or your own API
+- avoid bundling a cloud SDK into the client
+- keep the UI accessible and replaceable
 
-Vite consumer example:
+`image-drop-input` is built around that full pre-upload flow.
 
-https://mt4110.github.io/image-drop-input/
+Despite the name, this is not only about drag and drop. It is about preparing an image safely before upload.
 
-## インストール
+It is not a generic file uploader. It is not a cloud provider SDK. It is not a full image editor.
+
+It is the product-safe image input you add to avatar fields, CMS thumbnails, article covers, product images, and admin screens.
+
+## Install
 
 ```bash
 npm install image-drop-input react
 ```
 
+Import the default CSS once:
+
 ```tsx
 import 'image-drop-input/style.css';
 ```
 
-> `react-dom` は多くの React Web アプリですでに入っています。まだ導入していない環境では、必要に応じて一緒に追加してください。
+## Quick Start
 
-## 最短導入
-
-`upload` を渡さなければ、ローカル preview 専用の入力として使えます。
+Use it as a local-preview-only image input:
 
 ```tsx
 import { useState } from 'react';
@@ -56,14 +59,52 @@ export function AvatarField() {
     <ImageDropInput
       value={value}
       onChange={setValue}
+      accept="image/png,image/jpeg,image/webp"
+      maxBytes={5 * 1024 * 1024}
       aspectRatio={1}
-      dropzoneStyle={{ minBlockSize: '20rem' }}
     />
   );
 }
 ```
 
-`onChange` では次のような value が返ります。
+Users can drag and drop an image, click to select one, paste from the clipboard, preview the selected image, and remove or replace it.
+
+## What You Get
+
+| Feature | Included |
+| --- | --- |
+| Drag and drop | Yes |
+| Click-to-select | Yes |
+| Clipboard paste | Yes |
+| Local preview | Yes |
+| Preview dialog | Yes |
+| Validation | MIME, size, dimensions, pixel budget |
+| Transform hook | Yes |
+| Compression helper | Yes |
+| WebP conversion | Yes |
+| Presigned PUT upload | Yes |
+| Multipart POST upload | Yes |
+| Raw PUT upload | Yes |
+| Headless hook | Yes |
+| Runtime dependencies | React peer dependency only |
+
+## The Image Lifecycle
+
+`image-drop-input` keeps the image flow explicit:
+
+```txt
+pick / drop / paste
+  -> validate
+  -> transform
+  -> validate again
+  -> preview
+  -> upload
+  -> commit
+```
+
+This matters because a user-visible preview is not always the same thing as a persisted image.
+
+## Value Model
 
 ```ts
 type ImageUploadValue = {
@@ -78,127 +119,40 @@ type ImageUploadValue = {
 };
 ```
 
-## 複数画像を扱うには
+### `src`
 
-この package は今のところ **単一画像入力に特化** しています。`multiple` prop や配列 value を直接持たせる設計にはしていません。
+A persisted or otherwise shareable image URL.
 
-複数枚を扱いたい場合は、`image-drop-input/headless` の helper を使って、`1つの dropzone + 親側の配列 state + 別置き preview` を組むのが自然です。
+Use this for values that can safely be stored in your database or sent back from your API.
+
+### `previewSrc`
+
+A temporary local preview URL, usually a `blob:` URL.
+
+Use this only for immediate UI feedback. Do not store it as your final image value.
+
+This separation keeps the UI honest:
+
+- if upload returns `src`, the component displays the persisted image
+- if upload returns only `key`, the temporary preview remains separate
+- if upload fails, the component returns to the last committed value and retry uploads the same prepared file
+
+## Upload Examples
+
+### Local Preview Only
+
+Omit `upload` when you only need selection and preview:
 
 ```tsx
-import { useEffect, useRef, useState } from 'react';
-import { validateImage } from 'image-drop-input/headless';
-
-const accept = 'image/png,image/jpeg,image/webp,.png,.jpg,.jpeg,.webp';
-
-type GalleryItem = {
-  id: string;
-  fileName: string;
-  previewSrc: string;
-};
-
-export function GalleryDropzone() {
-  const inputRef = useRef<HTMLInputElement>(null);
-  const previewUrlsRef = useRef(new Set<string>());
-  const [images, setImages] = useState<GalleryItem[]>([]);
-
-  useEffect(() => {
-    return () => {
-      for (const previewSrc of previewUrlsRef.current) {
-        URL.revokeObjectURL(previewSrc);
-      }
-
-      previewUrlsRef.current.clear();
-    };
-  }, []);
-
-  async function appendFiles(files: File[]) {
-    const nextImages: GalleryItem[] = [];
-
-    for (const file of files) {
-      await validateImage(file, { accept, maxBytes: 8 * 1024 * 1024 });
-      const previewSrc = URL.createObjectURL(file);
-
-      previewUrlsRef.current.add(previewSrc);
-
-      nextImages.push({
-        id: crypto.randomUUID(),
-        fileName: file.name,
-        previewSrc
-      });
-    }
-
-    setImages((current) => [...current, ...nextImages]);
-  }
-
-  return (
-    <>
-      <input
-        ref={inputRef}
-        type="file"
-        accept={accept}
-        multiple
-        hidden
-        onChange={(event) => {
-          const files = Array.from(event.currentTarget.files ?? []);
-
-          if (files.length === 0) {
-            return;
-          }
-
-          void appendFiles(files);
-          event.currentTarget.value = '';
-        }}
-      />
-      <button type="button" onClick={() => inputRef.current?.click()}>
-        Drop or browse PNG, JPEG, or WebP files
-      </button>
-      <div>{images.map((image) => <img key={image.id} src={image.previewSrc} alt={image.fileName} />)}</div>
-    </>
-  );
-}
+<ImageDropInput
+  value={value}
+  onChange={setValue}
+/>
 ```
 
-削除 UI を付ける場合は、そのタイミングでも対応する `previewSrc` を `URL.revokeObjectURL` してください。
+### Presigned PUT
 
-consumer examples では、単一画像版に加えて detached preview と one-dropzone / many-files の実装コードをそのまま見られるようにしています。
-
-## value の意味
-
-- `src`: 永続化済み、または共有可能な画像参照
-- `previewSrc`: 一時プレビュー用のローカル object URL
-
-この区別はかなり大事です。
-
-- upload が `src` を返したときは `src` が表示に使われます
-- upload が `key` だけを返したときは、`blob:` URL は `previewSrc` に残ります
-- upload 失敗時は draft preview を破棄して、最後に commit 済みの value に戻ります
-
-見た目だけ先に進んで、保存対象と UI がズレる事故を避けるためです。
-
-## よく使う props
-
-| prop | 役割 |
-| --- | --- |
-| `accept` | 受け付ける MIME。既定値は `image/*` |
-| `maxBytes` | 最大ファイルサイズ |
-| `minWidth` / `minHeight` | 最小画像寸法 |
-| `maxWidth` / `maxHeight` | 最大画像寸法 |
-| `maxPixels` | 最大ピクセル数 |
-| `aspectRatio` | dropzone のアスペクト比 |
-| `disabled` | 入力全体を無効化 |
-| `removable` | 削除操作の有効化。既定値は `true` |
-| `previewable` | preview dialog の有効化 |
-| `onError` | validation / upload error の受け取り |
-| `onProgress` | upload progress の受け取り |
-
-`previewable` を推奨しつつ、既存互換のために `zoomable` も残しています。
-ただし現在の機能は preview dialog であり、wheel / pinch / pan を含む本格的な zoom UI ではありません。
-
-## アップロードをつなぐ
-
-### 1. Presigned PUT
-
-S3 / R2 / GCS / Azure のような構成では、`/headless` の uploader factory を使うのが素直です。
+For S3, R2, GCS, Azure Blob, or similar object storage flows:
 
 ```tsx
 import { useState } from 'react';
@@ -225,7 +179,7 @@ const upload = createPresignedPutUploader({
     });
 
     if (!response.ok) {
-      throw new Error('Failed to get upload target.');
+      throw new Error('Failed to create upload URL.');
     }
 
     return response.json();
@@ -235,11 +189,18 @@ const upload = createPresignedPutUploader({
 export function AvatarUploader() {
   const [value, setValue] = useState<ImageUploadValue | null>(null);
 
-  return <ImageDropInput value={value} onChange={setValue} upload={upload} />;
+  return (
+    <ImageDropInput
+      value={value}
+      onChange={setValue}
+      upload={upload}
+      maxBytes={5 * 1024 * 1024}
+    />
+  );
 }
 ```
 
-`getTarget()` は次を返す想定です。
+Your presign endpoint should return:
 
 ```ts
 type PresignedPutTarget = {
@@ -250,12 +211,11 @@ type PresignedPutTarget = {
 };
 ```
 
-package 側は **「与えられた URL とヘッダーで PUT する」** だけに徹します。
-provider 判定や public URL の推測はしません。
+The package does not guess public URLs from upload URLs. Pass `publicUrl` or `objectKey` explicitly.
 
-### 2. Multipart POST
+### Multipart POST
 
-アプリケーションサーバーへ `multipart/form-data` で送る場合です。
+For classic application-server uploads:
 
 ```ts
 import { createMultipartUploader } from 'image-drop-input/headless';
@@ -266,32 +226,47 @@ const upload = createMultipartUploader({
 });
 ```
 
-既定では `src` / `publicUrl` / `url`、`key` / `objectKey` をゆるく拾います。
-レスポンス形状が違う場合は `mapResponse` で変換できます。
+If your response shape is custom, map it:
 
-### 3. Raw PUT
+```ts
+const upload = createMultipartUploader({
+  endpoint: '/api/upload',
+  fieldName: 'file',
+  mapResponse(body) {
+    const result = body as { imageUrl: string; imageKey: string };
 
-単純な PUT エンドポイントならこちらです。
+    return {
+      src: result.imageUrl,
+      key: result.imageKey
+    };
+  }
+});
+```
+
+### Raw PUT
+
+For a direct `PUT` endpoint:
 
 ```ts
 import { createRawPutUploader } from 'image-drop-input/headless';
 
 const upload = createRawPutUploader({
-  endpoint: 'https://upload.example.com/files/avatar.jpg',
-  publicUrl: 'https://cdn.example.com/avatar.jpg',
-  objectKey: 'avatars/avatar.jpg'
+  endpoint: '/api/avatar',
+  publicUrl: '/avatars/current-user.jpg',
+  objectKey: 'avatars/current-user.jpg'
 });
 ```
 
-## transform と圧縮
+## Transform And Compress Before Upload
 
-`transform` は `Blob | File | { file, fileName?, mimeType? }` を返せます。
-圧縮や変換は `/headless` の `compressImage()` を使うと扱いやすいです。
+Use `transform` when you want to modify the image before upload.
 
 ```tsx
 import { compressImage } from 'image-drop-input/headless';
 
 <ImageDropInput
+  value={value}
+  onChange={setValue}
   transform={(file) =>
     compressImage(file, {
       maxWidth: 1600,
@@ -302,73 +277,68 @@ import { compressImage } from 'image-drop-input/headless';
 />
 ```
 
-ファイル名や MIME を明示したい場合はこう返せます。
-
-```ts
-transform={async (file) => ({
-  file: await compressImage(file, { maxWidth: 1600, outputType: 'image/webp', quality: 0.86 }),
-  fileName: file.name.replace(/\.(png|jpe?g|webp)$/i, '.webp'),
-  mimeType: 'image/webp'
-})}
-```
-
-validation は transform 前後の両方で走るので、変換後の寸法や MIME も検証されます。
-
-## カスタマイズ
-
-### `messages` と `classNames`
-
-文言や aria-label は `messages`、各パーツの class hook は `classNames` で差し替えられます。
+Convert to WebP and update the file name:
 
 ```tsx
+import { compressImage } from 'image-drop-input/headless';
+
 <ImageDropInput
-  messages={{
-    placeholderTitle: 'プロフィール画像を選択',
-    placeholderDescription: 'ドラッグ、クリック、または貼り付け',
-    statusUploading: (percent) => `アップロード中 ${percent}%`
-  }}
-  classNames={{
-    root: 'profileImageInput',
-    dropzone: 'profileImageInput__surface',
-    actions: 'profileImageInput__actions',
-    status: 'profileImageInput__status',
-    dialog: 'profileImageInput__dialog'
-  }}
+  value={value}
+  onChange={setValue}
+  accept="image/png,image/jpeg,image/webp"
+  transform={async (file) => ({
+    file: await compressImage(file, {
+      maxWidth: 1600,
+      maxHeight: 1600,
+      outputType: 'image/webp',
+      quality: 0.86
+    }),
+    fileName: file.name.replace(/\.(png|jpe?g|webp)$/i, '.webp'),
+    mimeType: 'image/webp'
+  })}
 />
 ```
 
-### 部分レンダリング差し替え
+Validation runs before and after `transform`, so transformed files are checked too.
 
-`renderPlaceholder` / `renderActions` / `renderFooter` を使うと、コンポーネントを fork せずに
-必要な部分だけ差し替えられます。
+## Common Props
 
-```tsx
-<ImageDropInput
-  renderFooter={({ statusMessage, canRetryUpload, retryUpload }) => (
-    <div className="profileImageInput__footer">
-      <span>{statusMessage}</span>
-      {canRetryUpload ? (
-        <button type="button" onClick={retryUpload}>
-          再試行
-        </button>
-      ) : null}
-    </div>
-  )}
-/>
-```
+| Prop | Purpose |
+| --- | --- |
+| `value` | Current image value |
+| `onChange` | Receives the next image value |
+| `upload` | Optional upload adapter |
+| `transform` | Optional pre-upload image transform |
+| `accept` | Accepted MIME types or extensions |
+| `maxBytes` | Maximum file size |
+| `minWidth` / `minHeight` | Minimum image dimensions |
+| `maxWidth` / `maxHeight` | Maximum image dimensions |
+| `maxPixels` | Maximum pixel budget |
+| `disabled` | Disable the input |
+| `removable` | Enable remove actions |
+| `previewable` | Enable the preview dialog |
+| `capture` | Forward camera capture hints to the file input |
+| `aspectRatio` | Dropzone aspect ratio |
+| `className` | Root class name |
+| `classNames` | Part-level class names |
+| `style` / `rootStyle` / `dropzoneStyle` | Inline style hooks |
+| `messages` | Override UI copy and aria labels |
+| `renderPlaceholder` | Replace placeholder rendering |
+| `renderActions` | Replace action rendering |
+| `renderFooter` | Replace footer rendering |
+| `onError` | Receive validation and upload errors |
+| `onProgress` | Receive upload progress |
 
-default の actions / footer wrapper は click と keydown の伝播を吸収するので、
-custom button 側で毎回 `stopPropagation()` を書かなくても file dialog が暴発しにくくなっています。
+`zoomable` is still accepted for compatibility, but `previewable` is the clearer name for the current preview-dialog behavior.
 
-## headless API
+## Headless Usage
 
-UI を全面的に組み直したい場合は、`image-drop-input/headless` の
-`useImageDropInput()` を直接使えます。
+Use `useImageDropInput()` when you want to build your own UI.
 
 ```tsx
 import { useImageDropInput } from 'image-drop-input/headless';
 
-export function CustomImageField() {
+export function CustomImageInput() {
   const imageInput = useImageDropInput({
     accept: 'image/*',
     maxBytes: 5 * 1024 * 1024
@@ -387,6 +357,7 @@ export function CustomImageField() {
       <div
         role="button"
         tabIndex={0}
+        aria-disabled={imageInput.disabled}
         onClick={imageInput.openFileDialog}
         onKeyDown={imageInput.handleKeyDown}
         onDragOver={imageInput.handleDragOver}
@@ -395,7 +366,10 @@ export function CustomImageField() {
         onPaste={imageInput.handlePaste}
       >
         {imageInput.displaySrc ? (
-          <img src={imageInput.displaySrc} alt={imageInput.messages.selectedImageAlt} />
+          <img
+            src={imageInput.displaySrc}
+            alt={imageInput.messages.selectedImageAlt}
+          />
         ) : (
           <span>{imageInput.messages.placeholderTitle}</span>
         )}
@@ -407,22 +381,86 @@ export function CustomImageField() {
 }
 ```
 
-## root export と `/headless`
+The hook gives you the input ref, drag-and-drop handlers, paste handler, keyboard handler, display state, upload state, progress, retry, cancel, remove, and status message.
 
-root entry の `image-drop-input` は UI 寄りです。
+`UseImageDropInputReturn` is exported when you want to type a wrapper around the headless API.
+
+## Customization
+
+### Messages
+
+```tsx
+<ImageDropInput
+  messages={{
+    placeholderTitle: 'Choose a profile image',
+    placeholderDescription: 'Drop, browse, or paste',
+    statusUploading: (percent) => `Uploading ${percent}%`
+  }}
+/>
+```
+
+### Class Names
+
+```tsx
+<ImageDropInput
+  classNames={{
+    root: 'profileImageInput',
+    dropzone: 'profileImageInput__surface',
+    actions: 'profileImageInput__actions',
+    status: 'profileImageInput__status',
+    dialog: 'profileImageInput__dialog'
+  }}
+/>
+```
+
+### Partial Rendering
+
+```tsx
+<ImageDropInput
+  renderFooter={({ statusMessage, canRetryUpload, retryUpload }) => (
+    <div className="profileImageInput__footer">
+      <span>{statusMessage}</span>
+      {canRetryUpload ? (
+        <button type="button" onClick={retryUpload}>
+          Retry
+        </button>
+      ) : null}
+    </div>
+  )}
+/>
+```
+
+## Multiple Images
+
+This package is intentionally single-image first.
+
+For multiple images, keep array state in your app and render one `ImageDropInput` or one headless instance per item. That keeps ordering, deletion, persistence, and upload orchestration in the product layer where those decisions belong.
+
+## Accessibility Notes
+
+- The empty state is exposed as a keyboard-focusable button.
+- Enter and Space open the file dialog from the empty state.
+- Paste is supported on the dropzone.
+- Default action buttons have aria labels from `messages`.
+- The preview dialog uses `role="dialog"`, `aria-modal="true"`, Escape-to-close, focus trapping, and focus return.
+- The default UI stays intentionally quiet, and the headless API is available when you need a fully custom accessible surface.
+
+## Public Entrypoints
+
+| Import | Role |
+| --- | --- |
+| `image-drop-input` | UI component and UI-facing types |
+| `image-drop-input/headless` | Uploader factories, image processing, hooks, and validation helpers |
+| `image-drop-input/style.css` | Default CSS |
 
 ```ts
 import {
   ImageDropInput,
   type ImageDropInputProps,
   type ImageUploadValue,
-  type UploadAdapter,
-  type UploadContext,
-  type UploadResult
+  type UploadAdapter
 } from 'image-drop-input';
 ```
-
-低レベル API は `/headless` へ寄せています。
 
 ```ts
 import {
@@ -430,51 +468,41 @@ import {
   createMultipartUploader,
   createPresignedPutUploader,
   createRawPutUploader,
-  getImageMetadata,
   useImageDropInput,
-  validateImage
+  validateImage,
+  type UseImageDropInputReturn
 } from 'image-drop-input/headless';
 ```
 
-公開面を静かに保つために、この import 境界は意図的に分けています。
+The root entry stays UI-first. Low-level utilities live under `/headless`.
 
-## アクセシビリティと挙動メモ
+## When Not To Use This
 
-- empty state は `button` role を持ち、`Enter` / `Space` で file dialog を開けます
-- filled state は `group` として扱い、誤ってクリックだけで picker を開かないようにしています
-- `Delete` / `Backspace` で削除できます（`removable` が有効な場合）
-- 画像の paste に対応しています
-- preview dialog は `Escape` で閉じ、開いている間は focus を中に留めます
-- preview dialog は依存を増やさないため現状 portal ではなく inline 描画です
-- 祖先に `transform` / `filter` などの stacking context がある場合は、より app root に近い位置へ置くか、headless API で独自 dialog に差し替えてください
+Use another tool if you need:
 
-## 次のマイルストーン候補
+- a generic multi-file uploader
+- resumable or chunked uploads
+- drag sorting between lists
+- a full crop, rotate, or annotation editor
+- provider-specific SDK wrappers
+- Node-side image processing
 
-- ブラウザ標準の Canvas API を使った、SEO / AIO 向け派生画像の headless sizing helper
-- 出力プリセットは `1:1` / `4:3` / `16:9` を先に用意
-- 既定の出力幅は `1200px` を基準にそろえる
-- `image/webp` への変換、file name の差し替え、MIME 更新まで一貫して扱う
-- consumer example を `examples/vite` と `examples/rsbuild` の両方に追加して、導入差分をそのまま読めるようにする
+Use `image-drop-input` when you want one product-safe image input with validation, preview, transform, and explicit upload wiring.
 
-このスコープは「画像エディタを増築する」より、共有画像や記事サムネイルを静かに整えるための
-実用的な変換 helper と example を先に固める、という考え方です。
-
-## 開発
+## Development
 
 ```bash
 npm ci
-npm test
 npm run typecheck
+npm test
 npm run build:lib
 npm run build:examples
 npm run check:package
+npm pack --dry-run
 ```
 
-- example consumer は `examples/vite` と `examples/rsbuild` にあります
-- `npm run clean:share` で `node_modules` と生成物を落とせます
-- Node は `22.18+` か、それ以降のアクティブ LTS を推奨します
+Release planning lives in [ROADMAP.md](./ROADMAP.md), so this README can stay focused on what works today.
 
-## publish 前メモ
+## License
 
-- publish owner や GitHub repository を変える場合は、`package.json` の `name` / `homepage` / `bugs` / `repository` を一緒に更新してください
-- `npm pack --dry-run` と `npm run check:package` を最後に通すと安全です
+MIT

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,31 @@
+# Roadmap
+
+This project is strongest when it stays focused on one job: a product-safe React image input for the pre-upload image flow.
+
+## v0.2 Focus
+
+- Make `README.md` the primary English adoption page.
+- Keep the Japanese README as `README.ja.md`.
+- Keep the package positioned around pre-upload preview, validation, transform, upload, and commit.
+- Improve examples around local preview, WebP transform, compression, presigned upload, multipart upload, and headless UI.
+- Keep multi-image usage as an app-owned state pattern rather than a new primary component API.
+- Keep package metadata aligned with npm and GitHub discovery.
+
+## Not For v0.2
+
+- `multiple` prop
+- crop editor
+- chunked or resumable upload
+- provider SDK adapters
+- CLI generator
+- UI framework skins
+
+## Design Guardrails
+
+- React peer dependency only at runtime.
+- No cloud SDKs in the client bundle.
+- No UI framework dependency.
+- Single-image input first.
+- Explicit upload wiring instead of provider URL guessing.
+- `src` remains persisted or shareable state.
+- `previewSrc` remains temporary UI state.

--- a/examples/rsbuild/src/App.tsx
+++ b/examples/rsbuild/src/App.tsx
@@ -1,11 +1,16 @@
-import { ExampleApp } from '../../shared/ExampleApp';
+import { DemoApp } from '../../shared/demo-app';
 
 export function App() {
   return (
-    <ExampleApp
-      consumerName="Rsbuild consumer example"
-      uploadKey="example/rsbuild/cover-image.webp"
-      progressStops={[24, 78]}
+    <DemoApp
+      consumerName="Rsbuild"
+      consumerNote={{
+        en: 'This one reads the same published surface from an Rsbuild consumer, so bundler parity stays visible without changing the API story.',
+        jp: 'こちらは Rsbuild consumer から同じ公開面を読み、API の話を変えずに bundler parity を確認できます。'
+      }}
+      demoCommand="npm run demo:rsbuild"
+      alternateDemoCommand="npm run demo:vite"
+      uploadKeyPrefix="example/rsbuild"
     />
   );
 }

--- a/examples/shared/demo-app.tsx
+++ b/examples/shared/demo-app.tsx
@@ -550,7 +550,7 @@ function buildSnippet(flow: FlowMode, surface: SurfaceOption): string {
     '/>'
   ];
 
-  return lines.filter(Boolean).join('\n');
+  return lines.filter((line): line is string => line != null).join('\n');
 }
 
 function buildUploadPanel(

--- a/examples/shared/demo-app.tsx
+++ b/examples/shared/demo-app.tsx
@@ -1,0 +1,1272 @@
+import { useEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
+import { ImageDropInput, type ImageUploadValue } from 'image-drop-input';
+import {
+  compressImage,
+  createMultipartUploader,
+  createPresignedPutUploader,
+  createRawPutUploader,
+  useImageDropInput,
+  type UploadRequest,
+  type UploadResponse
+} from 'image-drop-input/headless';
+import 'image-drop-input/style.css';
+import './demo.css';
+
+type Locale = 'en' | 'jp';
+type FlowMode = 'preview' | 'presigned' | 'multipart' | 'raw';
+type SurfaceMode = 'avatar' | 'cover';
+
+type LocalizedText = {
+  en: string;
+  jp: string;
+};
+
+interface DemoAppProps {
+  consumerName: string;
+  consumerNote: LocalizedText;
+  demoCommand: string;
+  alternateDemoCommand: string;
+  uploadKeyPrefix: string;
+}
+
+interface SurfaceOption {
+  id: SurfaceMode;
+  aspectRatio: '1/1' | '16/9';
+  fileLabel: string;
+  maxWidth: number;
+  maxHeight: number;
+  accent: string;
+  dragLine: string;
+  focusRing: string;
+  title: LocalizedText;
+  description: LocalizedText;
+}
+
+interface FlowOption {
+  id: FlowMode;
+  title: LocalizedText;
+  description: LocalizedText;
+}
+
+interface UploadTrace {
+  context: {
+    fileName?: string;
+    originalFileName?: string;
+    mimeType?: string;
+    size: number;
+  };
+  target: {
+    uploadUrl: string;
+    headers: Record<string, string>;
+    publicUrl?: string;
+    objectKey?: string;
+  };
+  request: {
+    method: string;
+    url: string;
+    headers: Record<string, string>;
+    size?: number;
+  } | null;
+  response: {
+    status: number;
+    etag?: string;
+    body?: unknown;
+  } | null;
+}
+
+const SURFACES: SurfaceOption[] = [
+  {
+    id: 'cover',
+    aspectRatio: '16/9',
+    fileLabel: 'cover',
+    maxWidth: 1600,
+    maxHeight: 900,
+    accent: '#d46a47',
+    dragLine: 'rgba(212, 106, 71, 0.26)',
+    focusRing: 'rgba(212, 106, 71, 0.14)',
+    title: { en: 'Cover', jp: 'カバー' },
+    description: {
+      en: '16:9 for CMS covers, post headers, and editor surfaces.',
+      jp: 'CMS カバー、記事ヘッダー、エディタ画面向けの 16:9。'
+    }
+  },
+  {
+    id: 'avatar',
+    aspectRatio: '1/1',
+    fileLabel: 'avatar',
+    maxWidth: 1200,
+    maxHeight: 1200,
+    accent: '#15866a',
+    dragLine: 'rgba(21, 134, 106, 0.26)',
+    focusRing: 'rgba(21, 134, 106, 0.14)',
+    title: { en: 'Avatar', jp: 'アバター' },
+    description: {
+      en: '1:1 for settings, profiles, teams, and workspace icons.',
+      jp: '設定画面、プロフィール、チーム、ワークスペース icon 向けの 1:1。'
+    }
+  }
+];
+
+const FLOWS: FlowOption[] = [
+  {
+    id: 'preview',
+    title: { en: 'Preview only', jp: 'Preview only' },
+    description: {
+      en: 'No uploader attached. Good for forms that save later.',
+      jp: 'upload は付けず、後でまとめて保存するフォーム向け。'
+    }
+  },
+  {
+    id: 'presigned',
+    title: { en: 'Presigned PUT', jp: 'Presigned PUT' },
+    description: {
+      en: 'Mocked signed URL flow for S3, R2, GCS, or Azure Blob.',
+      jp: 'S3 / R2 / GCS / Azure Blob 向けの signed URL mock。'
+    }
+  },
+  {
+    id: 'multipart',
+    title: { en: 'Multipart POST', jp: 'Multipart POST' },
+    description: {
+      en: 'Classic app-server upload through FormData.',
+      jp: 'FormData で app server に渡す classic upload。'
+    }
+  },
+  {
+    id: 'raw',
+    title: { en: 'Raw PUT', jp: 'Raw PUT' },
+    description: {
+      en: 'Direct PUT endpoint that returns an object key only.',
+      jp: 'object key だけを返す direct PUT endpoint。'
+    }
+  }
+];
+
+const TEXT = {
+  title: {
+    en: 'Everything before upload, in one image field.',
+    jp: 'upload 前のすべてを、1 つの画像 field に。'
+  },
+  body: {
+    en: 'Drop, browse, or paste one image. This demo shows preview, validation, WebP transform, upload adapters, and commit state through the same exported surface npm users consume.',
+    jp: '画像を 1 枚 drop / browse / paste。preview、validation、WebP 変換、upload adapter、commit state まで、npm user と同じ export surface で確認できます。'
+  },
+  publishedSurface: { en: 'Published entrypoints', jp: '公開エントリポイント' },
+  singleImageFirst: { en: 'Single-image first', jp: 'single-image first' },
+  language: { en: 'Language', jp: '表示言語' },
+  liveDemo: { en: 'Live demo', jp: 'ライブ demo' },
+  stageTitle: {
+    en: 'The drop surface stays calm. The wiring stays explicit.',
+    jp: 'drop surface は静かに、つなぎ込みは明示的に。'
+  },
+  stageBody: {
+    en: 'Use the same component for local preview or for a publish-ready path. `previewSrc` remains local, while `src` appears only after the uploader resolves.',
+    jp: '同じ component を local preview にも publish-ready な流れにも使えます。`previewSrc` はローカルのまま保ち、`src` は uploader が返したあとにだけ現れます。'
+  },
+  useCase: { en: 'Use case', jp: '用途' },
+  flow: { en: 'Flow', jp: 'フロー' },
+  aspectRatio: { en: 'Aspect ratio', jp: 'アスペクト比' },
+  transform: { en: 'Transform', jp: '変換' },
+  upload: { en: 'Upload', jp: 'Upload' },
+  transformValue: { en: 'compressImage() -> webp', jp: 'compressImage() -> webp' },
+  uploadOff: { en: 'off', jp: 'なし' },
+  failNext: { en: 'Fail next upload', jp: '次の upload を失敗させる' },
+  failNextArmed: { en: 'Next upload will fail', jp: '次の upload は失敗します' },
+  failHint: {
+    en: 'Use this to verify the default error surface and retry action.',
+    jp: 'default error surface と retry action の確認に使えます。'
+  },
+  canvasHint: {
+    en: 'Paste works too. The preview dialog stays available, and the emitted value is visible on the right.',
+    jp: 'paste にも対応しています。preview dialog もそのまま使えて、右側で返り値を追えます。'
+  },
+  sourceTitle: { en: 'Published surface', jp: '公開面の見え方' },
+  sourceBody: {
+    en: 'This consumer imports the package the same way downstream apps will. No direct source imports are used here.',
+    jp: 'この consumer は downstream app と同じ import で package を読んでいます。source 直参照は使っていません。'
+  },
+  valueTitle: { en: 'Emitted value', jp: '返り値' },
+  valueBody: {
+    en: '`previewSrc` is local only. `src` appears only after the upload adapter returns.',
+    jp: '`previewSrc` はローカル専用です。`src` は upload adapter が返したあとにだけ入ります。'
+  },
+  uploadTitle: { en: 'Upload trace', jp: 'Upload trace' },
+  uploadBody: {
+    en: 'In preview-only mode there is no request. In upload modes, the mock keeps each adapter contract visible without leaving the browser.',
+    jp: 'preview-only ではリクエストは出ません。upload mode では、各 adapter contract をブラウザ内で見える形にしています。'
+  },
+  uploadIdle: {
+    en: 'Drop one image to inspect the upload context, signed target, and response stub.',
+    jp: '画像を 1 枚入れると、upload context と signed target、response stub を確認できます。'
+  },
+  previewIdle: {
+    en: 'Preview-only mode keeps `src` empty and never creates a network request.',
+    jp: 'preview-only では `src` は空のままで、ネットワークリクエストは発生しません。'
+  },
+  failedUpload: {
+    en: 'Demo upload failed. Retry uploads the same prepared file again.',
+    jp: 'demo upload に失敗しました。Retry は同じ prepared file を再送します。'
+  },
+  proofEyebrow: { en: 'What this demo proves', jp: 'この demo で確認できること' },
+  proofTitle: { en: 'Adoption checks without reading the source.', jp: 'source を読まずに採用判断する。' },
+  proofBody: {
+    en: 'The important product contracts are visible: preview is temporary, transform happens before upload, adapters are explicit, and failures can be retried.',
+    jp: '重要な product contract を見える化しています。preview は一時的、transform は upload 前、adapter は明示的、失敗時は retry 可能です。'
+  },
+  recipesEyebrow: { en: 'Examples', jp: 'Examples' },
+  recipesTitle: { en: 'Small recipes for the common paths.', jp: 'よくある導線を小さく確認する。' },
+  recipesBody: {
+    en: 'These snippets use only the published API: local preview, WebP transform, signed upload, multipart upload, raw PUT, and headless UI.',
+    jp: 'local preview、WebP transform、signed upload、multipart upload、raw PUT、headless UI を、公開 API だけで確認できます。'
+  },
+  headlessEyebrow: { en: 'Headless UI', jp: 'Headless UI' },
+  headlessTitle: { en: 'Own the markup, keep the pipeline.', jp: 'markup は自前で、pipeline はそのまま。' },
+  headlessBody: {
+    en: '`useImageDropInput()` exposes the state machine when the default surface is not the right fit.',
+    jp: 'default surface が合わない場合は、`useImageDropInput()` で state machine だけを使えます。'
+  },
+  headlessPlaceholder: { en: 'Drop, browse, or paste', jp: 'drop / browse / paste' },
+  headlessBrowse: { en: 'Browse', jp: 'Browse' },
+  headlessRemove: { en: 'Remove', jp: 'Remove' },
+  shipTitle: { en: 'Demo to publish', jp: 'demo から publish まで' },
+  shipBody: {
+    en: 'The demo command, the package check, and the publish command now line up in one short path.',
+    jp: 'demo 起動、package check、publish の順が、そのまま短い一本道になるようにそろえました。'
+  },
+  installStep: { en: 'Install', jp: 'Install' },
+  demoStep: { en: 'Run current demo', jp: '現在の demo を起動' },
+  parityStep: { en: 'Bundler parity', jp: '別 bundler でも確認' },
+  dryRunStep: { en: 'Dry-run publish', jp: 'publish dry-run' },
+  publishStep: { en: 'Publish', jp: 'Publish' },
+  demoStepCopy: {
+    en: 'Builds the library output first, then opens the consumer demo.',
+    jp: '先にライブラリ出力を組み立ててから、consumer demo を起動します。'
+  },
+  parityStepCopy: {
+    en: 'Use the second consumer when you want another bundler to read the same published surface.',
+    jp: '同じ公開面を別 bundler でも読ませたいときはこちらです。'
+  },
+  dryRunStepCopy: {
+    en: 'Runs the package checks and a dry pack so the tarball shape is visible before the real publish.',
+    jp: '実 publish の前に、package check と dry pack で tarball の形まで確認します。'
+  },
+  publishStepCopy: {
+    en: 'When you are happy with the package, this is the final command from the repo root.',
+    jp: 'package の状態に納得できたら、repo root から最後に打つコマンドです。'
+  },
+  browseLabel: { en: 'Choose image file', jp: '画像を選択' },
+  placeholderPreviewTitle: { en: 'Drop one image', jp: '画像を 1 枚ドロップ' },
+  placeholderPublishTitle: { en: 'Drop one image for upload', jp: 'upload 用の画像を 1 枚ドロップ' },
+  placeholderPreviewBody: {
+    en: 'Click or paste. The transformed image stays local.',
+    jp: 'クリックまたは paste。変換後の画像はローカルにとどまります。'
+  },
+  placeholderPublishBody: {
+    en: 'Click or paste. The transformed image is handed to the uploader mock.',
+    jp: 'クリックまたは paste。変換後の画像を uploader モックに渡します。'
+  },
+  idleStatusPreview: {
+    en: 'Drop, browse, or paste. No upload is attached.',
+    jp: 'drop / browse / paste。upload はまだ付いていません。'
+  },
+  idleStatusPublish: {
+    en: 'Drop, browse, or paste. The upload contract stays visible.',
+    jp: 'drop / browse / paste。upload の契約面が見える状態です。'
+  },
+  uploading: {
+    en: 'Uploading prepared image',
+    jp: '変換済み画像をアップロード中'
+  }
+} as const;
+
+const PROOF_ITEMS = [
+  {
+    title: { en: 'Preview is not persistence', jp: 'preview は保存ではない' },
+    body: {
+      en: '`previewSrc` stays local. `src` appears only when an adapter returns a persisted URL.',
+      jp: '`previewSrc` は local のままです。`src` は adapter が保存済み URL を返したときだけ入ります。'
+    }
+  },
+  {
+    title: { en: 'Transform runs first', jp: 'transform が先に走る' },
+    body: {
+      en: 'The selected image is compressed and converted to WebP before upload receives it.',
+      jp: '選択画像は upload に渡る前に圧縮され、WebP に変換されます。'
+    }
+  },
+  {
+    title: { en: 'Adapters stay explicit', jp: 'adapter は明示的' },
+    body: {
+      en: 'Presigned PUT, multipart POST, and raw PUT are wired without cloud SDKs or URL guessing.',
+      jp: 'Presigned PUT / multipart POST / raw PUT を、cloud SDK や URL 推測なしでつなぎます。'
+    }
+  },
+  {
+    title: { en: 'Errors are recoverable', jp: '失敗から戻れる' },
+    body: {
+      en: 'The failure toggle shows the default error surface and retry path.',
+      jp: '失敗 toggle で default error surface と retry path を確認できます。'
+    }
+  }
+] satisfies Array<{
+  title: LocalizedText;
+  body: LocalizedText;
+}>;
+
+const RECIPE_ITEMS = [
+  {
+    title: { en: 'Local preview', jp: 'Local preview' },
+    body: {
+      en: 'No uploader. The component emits a temporary preview value.',
+      jp: 'uploader なし。一時 preview value を返します。'
+    },
+    snippet: `<ImageDropInput
+  value={value}
+  onChange={setValue}
+/>`
+  },
+  {
+    title: { en: 'WebP transform', jp: 'WebP transform' },
+    body: {
+      en: 'Compress and convert before the file reaches upload.',
+      jp: 'upload に渡る前に圧縮と変換を行います。'
+    },
+    snippet: `transform={async (file) => ({
+  file: await compressImage(file, {
+    maxWidth: 1600,
+    maxHeight: 900,
+    outputType: 'image/webp',
+    quality: 0.86
+  }),
+  fileName: file.name.replace(/\\.[^.]+$/, '.webp'),
+  mimeType: 'image/webp'
+})}`
+  },
+  {
+    title: { en: 'Presigned PUT', jp: 'Presigned PUT' },
+    body: {
+      en: 'Use signed object-storage targets without bundling a provider SDK.',
+      jp: 'provider SDK を bundle せずに signed target へ PUT します。'
+    },
+    snippet: `const upload = createPresignedPutUploader({
+  async getTarget(file, context) {
+    return fetch('/api/uploads/presign', {
+      method: 'POST',
+      body: JSON.stringify({
+        fileName: context.fileName,
+        mimeType: context.mimeType
+      })
+    }).then((response) => response.json());
+  }
+});`
+  },
+  {
+    title: { en: 'Multipart POST', jp: 'Multipart POST' },
+    body: {
+      en: 'Send FormData to an application server and map the response.',
+      jp: 'FormData を app server に送り、response を mapping します。'
+    },
+    snippet: `const upload = createMultipartUploader({
+  endpoint: '/api/upload',
+  fieldName: 'file',
+  mapResponse(body) {
+    const result = body as { imageUrl: string; imageKey: string };
+    return { src: result.imageUrl, key: result.imageKey };
+  }
+});`
+  },
+  {
+    title: { en: 'Raw PUT', jp: 'Raw PUT' },
+    body: {
+      en: 'Upload to a direct endpoint and keep the returned object key explicit.',
+      jp: 'direct endpoint に upload し、object key を明示的に扱います。'
+    },
+    snippet: `const upload = createRawPutUploader({
+  endpoint: '/api/avatar',
+  objectKey: 'avatars/current-user.webp'
+});`
+  },
+  {
+    title: { en: 'Headless UI', jp: 'Headless UI' },
+    body: {
+      en: 'Bring your own markup while reusing the image input state machine.',
+      jp: 'markup は自前で、image input の state machine を再利用します。'
+    },
+    snippet: `const imageInput = useImageDropInput({
+  accept: 'image/*',
+  maxBytes: 5 * 1024 * 1024
+});`
+  }
+] satisfies Array<{
+  title: LocalizedText;
+  body: LocalizedText;
+  snippet: string;
+}>;
+
+const INPUT_CLASS_NAMES = {
+  dropzone: 'demo-idiDropzone',
+  preview: 'demo-idiPreview',
+  image: 'demo-idiImage',
+  overlay: 'demo-idiOverlay',
+  actions: 'demo-idiActions',
+  iconButton: 'demo-idiIconButton',
+  footer: 'demo-idiFooter',
+  status: 'demo-idiStatus',
+  errorSurface: 'demo-idiError',
+  footerButton: 'demo-idiFooterButton',
+  dialog: 'demo-idiDialog',
+  dialogImage: 'demo-idiDialogImage'
+} as const;
+
+function copy(locale: Locale, text: LocalizedText): string {
+  return text[locale];
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    window.setTimeout(resolve, ms);
+  });
+}
+
+function stripExtension(fileName: string): string {
+  return fileName.replace(/\.[^.]+$/, '');
+}
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function createPreparedFileName(fileName: string, surface: SurfaceOption): string {
+  const base = slugify(stripExtension(fileName)) || 'image';
+  return `${base}-${surface.fileLabel}.webp`;
+}
+
+function getFlowOption(flowMode: FlowMode): FlowOption {
+  return FLOWS.find((option) => option.id === flowMode) ?? FLOWS[0];
+}
+
+function getBlobFileName(file: Blob, fallback: string): string {
+  return 'name' in file && typeof file.name === 'string' && file.name.length > 0
+    ? file.name
+    : fallback;
+}
+
+function extractUploadBlob(body: UploadRequest['body']): Blob | null {
+  if (body instanceof Blob) {
+    return body;
+  }
+
+  for (const value of body.values()) {
+    if (value instanceof Blob) {
+      return value;
+    }
+  }
+
+  return null;
+}
+
+function summarizeUrl(url?: string): string | undefined {
+  if (!url) {
+    return undefined;
+  }
+
+  return url.startsWith('blob:') ? 'blob:<local-object-url>' : url;
+}
+
+function summarizeValue(value: ImageUploadValue | null, locale: Locale): Record<string, unknown> {
+  if (!value) {
+    return {
+      status: locale === 'en' ? 'idle' : '待機中'
+    };
+  }
+
+  return {
+    src: summarizeUrl(value.src),
+    previewSrc: summarizeUrl(value.previewSrc),
+    fileName: value.fileName,
+    mimeType: value.mimeType,
+    size: value.size,
+    width: value.width,
+    height: value.height,
+    key: value.key
+  };
+}
+
+function createAbortError(): Error {
+  if (typeof DOMException !== 'undefined') {
+    return new DOMException('The upload was aborted.', 'AbortError');
+  }
+
+  const error = new Error('The upload was aborted.');
+  error.name = 'AbortError';
+  return error;
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw createAbortError();
+  }
+}
+
+function buildSnippet(flow: FlowMode, surface: SurfaceOption): string {
+  const uploadFactory =
+    flow === 'presigned'
+      ? ', createPresignedPutUploader'
+      : flow === 'multipart'
+        ? ', createMultipartUploader'
+        : flow === 'raw'
+          ? ', createRawPutUploader'
+          : '';
+  const uploadLine =
+    flow === 'presigned'
+      ? '  upload={createPresignedPutUploader({ getTarget, request })}'
+      : flow === 'multipart'
+        ? '  upload={createMultipartUploader({ endpoint, fieldName, request, mapResponse })}'
+        : flow === 'raw'
+          ? '  upload={createRawPutUploader({ endpoint, objectKey, request })}'
+          : null;
+  const lines = [
+    "import { ImageDropInput } from 'image-drop-input';",
+    `import { compressImage${uploadFactory} } from 'image-drop-input/headless';`,
+    "import 'image-drop-input/style.css';",
+    '',
+    '<ImageDropInput',
+    `  aspectRatio="${surface.aspectRatio}"`,
+    '  previewable',
+    '  transform={async (file) => {',
+    '    const prepared = await compressImage(file, {',
+    `      maxWidth: ${surface.maxWidth},`,
+    `      maxHeight: ${surface.maxHeight},`,
+    "      outputType: 'image/webp',",
+    `      quality: ${flow === 'preview' ? '0.88' : '0.84'}`,
+    '    });',
+    '',
+    "    return { file: prepared, fileName: 'prepared-image.webp', mimeType: 'image/webp' };",
+    '  }}',
+    uploadLine,
+    '/>'
+  ];
+
+  return lines.filter(Boolean).join('\n');
+}
+
+function buildUploadPanel(
+  locale: Locale,
+  flow: FlowMode,
+  value: ImageUploadValue | null,
+  uploadTrace: UploadTrace | null
+): Record<string, unknown> {
+  if (flow === 'preview') {
+    return {
+      upload: false,
+      note: copy(locale, TEXT.previewIdle),
+      result: {
+        src: summarizeUrl(value?.src),
+        previewSrc: summarizeUrl(value?.previewSrc)
+      }
+    };
+  }
+
+  if (!uploadTrace) {
+    return {
+      upload: true,
+      adapter: copy(locale, getFlowOption(flow).title),
+      note: copy(locale, TEXT.uploadIdle)
+    };
+  }
+
+  return {
+    adapter: copy(locale, getFlowOption(flow).title),
+    context: uploadTrace.context,
+    target: {
+      ...uploadTrace.target,
+      publicUrl: summarizeUrl(uploadTrace.target.publicUrl)
+    },
+    request: uploadTrace.request,
+    response: uploadTrace.response,
+    result: {
+      src: summarizeUrl(value?.src),
+      key: value?.key
+    }
+  };
+}
+
+function createThemeStyle(surface: SurfaceOption): CSSProperties {
+  return {
+    '--idi-accent': surface.accent,
+    '--idi-drag-line': surface.dragLine,
+    '--idi-focus-ring': surface.focusRing,
+    '--idi-toolbar': 'rgba(249, 250, 251, 0.96)',
+    '--idi-line': 'rgba(22, 32, 51, 0.08)',
+    '--idi-line-strong': 'rgba(22, 32, 51, 0.14)',
+    '--idi-dropzone-background':
+      'linear-gradient(180deg, rgba(255, 255, 255, 0.99), rgba(244, 246, 248, 0.98))',
+    '--idi-placeholder-surface':
+      'linear-gradient(180deg, rgba(249, 250, 251, 0.98), rgba(241, 244, 246, 0.96))',
+    '--idi-shadow': '0 10px 24px rgba(15, 23, 42, 0.05)',
+    '--idi-shadow-hover': '0 16px 30px rgba(15, 23, 42, 0.06)',
+    '--idi-shadow-float': '0 8px 16px rgba(15, 23, 42, 0.06)',
+    '--idi-dialog-shadow': '0 24px 48px rgba(15, 23, 42, 0.16)'
+  } as CSSProperties;
+}
+
+function HeadlessCustomDemo({ locale }: { locale: Locale }) {
+  const [value, setValue] = useState<ImageUploadValue | null>(null);
+  const imageInput = useImageDropInput({
+    accept: 'image/png,image/jpeg,image/webp',
+    maxBytes: 5 * 1024 * 1024,
+    messages: {
+      placeholderTitle: copy(locale, TEXT.headlessPlaceholder),
+      statusIdle: copy(locale, TEXT.idleStatusPreview)
+    },
+    onChange: setValue,
+    transform: async (file) => {
+      const prepared = await compressImage(file, {
+        maxWidth: 960,
+        maxHeight: 960,
+        outputType: 'image/webp',
+        quality: 0.84
+      });
+
+      return {
+        file: prepared,
+        fileName: `${slugify(stripExtension(file.name)) || 'image'}-headless.webp`,
+        mimeType: prepared.type || 'image/webp'
+      };
+    },
+    value
+  });
+
+  return (
+    <section className="demo-headless">
+      <div className="demo-sectionHeader">
+        <p className="demo-eyebrow">{copy(locale, TEXT.headlessEyebrow)}</p>
+        <h2 className="demo-sectionTitle">{copy(locale, TEXT.headlessTitle)}</h2>
+        <p className="demo-sectionBody">{copy(locale, TEXT.headlessBody)}</p>
+      </div>
+
+      <div className="demo-headlessGrid">
+        <div>
+          <input
+            ref={imageInput.inputRef}
+            className="demo-headlessInput"
+            type="file"
+            accept={imageInput.accept}
+            onChange={imageInput.handleInputChange}
+            hidden
+          />
+          <div
+            className="demo-headlessSurface"
+            data-dragging={imageInput.isDragging}
+            role="button"
+            tabIndex={0}
+            aria-disabled={imageInput.disabled}
+            onClick={imageInput.openFileDialog}
+            onKeyDown={imageInput.handleKeyDown}
+            onDragLeave={imageInput.handleDragLeave}
+            onDragOver={imageInput.handleDragOver}
+            onDrop={imageInput.handleDrop}
+            onPaste={imageInput.handlePaste}
+          >
+            {imageInput.displaySrc ? (
+              <img
+                className="demo-headlessImage"
+                src={imageInput.displaySrc}
+                alt={imageInput.messages.selectedImageAlt}
+                draggable={false}
+              />
+            ) : (
+              <span className="demo-headlessPlaceholder">
+                {imageInput.messages.placeholderTitle}
+              </span>
+            )}
+          </div>
+          <div className="demo-headlessControls">
+            <button type="button" onClick={imageInput.openFileDialog}>
+              {copy(locale, TEXT.headlessBrowse)}
+            </button>
+            <button
+              type="button"
+              disabled={!imageInput.displayValue}
+              onClick={imageInput.removeValue}
+            >
+              {copy(locale, TEXT.headlessRemove)}
+            </button>
+            <span>{imageInput.statusMessage}</span>
+          </div>
+        </div>
+
+        <pre className="demo-json">
+          {JSON.stringify(summarizeValue(imageInput.displayValue, locale), null, 2)}
+        </pre>
+      </div>
+    </section>
+  );
+}
+
+export function DemoApp({
+  consumerName,
+  consumerNote,
+  demoCommand,
+  alternateDemoCommand,
+  uploadKeyPrefix
+}: DemoAppProps) {
+  const [locale, setLocale] = useState<Locale>(() => {
+    if (typeof window === 'undefined') {
+      return 'en';
+    }
+
+    return window.localStorage.getItem('image-drop-input-demo-locale') === 'jp' ? 'jp' : 'en';
+  });
+  const [surfaceMode, setSurfaceMode] = useState<SurfaceMode>('cover');
+  const [flowMode, setFlowMode] = useState<FlowMode>('presigned');
+  const [value, setValue] = useState<ImageUploadValue | null>(null);
+  const [uploadTrace, setUploadTrace] = useState<UploadTrace | null>(null);
+  const [failNextUpload, setFailNextUpload] = useState(false);
+  const uploadPreviewUrlRef = useRef<string | null>(null);
+
+  const surface = SURFACES.find((option) => option.id === surfaceMode) ?? SURFACES[0];
+  const flow = getFlowOption(flowMode);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem('image-drop-input-demo-locale', locale);
+    }
+  }, [locale]);
+
+  useEffect(() => {
+    setValue(null);
+    setUploadTrace(null);
+    setFailNextUpload(false);
+
+    if (uploadPreviewUrlRef.current) {
+      URL.revokeObjectURL(uploadPreviewUrlRef.current);
+      uploadPreviewUrlRef.current = null;
+    }
+  }, [flowMode, surfaceMode]);
+
+  useEffect(() => {
+    return () => {
+      if (uploadPreviewUrlRef.current) {
+        URL.revokeObjectURL(uploadPreviewUrlRef.current);
+      }
+    };
+  }, []);
+
+  const upload = useMemo(() => {
+    if (flowMode === 'preview') {
+      return undefined;
+    }
+
+    const replacePreviewUrl = (file: Blob, fileName: string, mimeType: string): string => {
+      if (uploadPreviewUrlRef.current) {
+        URL.revokeObjectURL(uploadPreviewUrlRef.current);
+        uploadPreviewUrlRef.current = null;
+      }
+
+      const publicFile = new File([file], fileName, { type: mimeType });
+      const publicUrl = URL.createObjectURL(publicFile);
+
+      uploadPreviewUrlRef.current = publicUrl;
+      return publicUrl;
+    };
+
+    const recordRequest = (request: UploadRequest) => {
+      setUploadTrace((current) => {
+        if (!current) {
+          return current;
+        }
+
+        return {
+          ...current,
+          request: {
+            method: request.method,
+            url: request.url,
+            headers: request.headers ?? {},
+            size: extractUploadBlob(request.body)?.size
+          }
+        };
+      });
+    };
+
+    const runMockRequest = async (
+      request: UploadRequest,
+      body: unknown = {
+        ok: true,
+        consumer: consumerName
+      }
+    ): Promise<UploadResponse> => {
+      recordRequest(request);
+
+      for (const percent of [18, 42]) {
+        throwIfAborted(request.signal);
+        request.onProgress?.(percent);
+        await delay(120);
+      }
+
+      if (failNextUpload) {
+        setFailNextUpload(false);
+        setUploadTrace((current) => {
+          if (!current) {
+            return current;
+          }
+
+          return {
+            ...current,
+            response: {
+              status: 500,
+              body: {
+                ok: false,
+                message: copy(locale, TEXT.failedUpload)
+              }
+            }
+          };
+        });
+        throw new Error(copy(locale, TEXT.failedUpload));
+      }
+
+      for (const percent of [68, 100]) {
+        throwIfAborted(request.signal);
+        request.onProgress?.(percent);
+        await delay(120);
+      }
+
+      const response = {
+        status: 200,
+        statusText: 'OK',
+        headers: new Headers({
+          'content-type': 'application/json',
+          etag: '"demo-etag"'
+        }),
+        body
+      } satisfies UploadResponse;
+
+      setUploadTrace((current) => {
+        if (!current) {
+          return current;
+        }
+
+        return {
+          ...current,
+          response: {
+            status: response.status,
+            etag: response.headers.get('etag') ?? undefined,
+            body: response.body
+          }
+        };
+      });
+
+      return response;
+    };
+
+    if (flowMode === 'presigned') {
+      return createPresignedPutUploader({
+        async getTarget(file, context) {
+          const fileName =
+            context.fileName ??
+            createPreparedFileName(context.originalFileName ?? 'image', surface);
+          const mimeType = context.mimeType ?? file.type ?? 'image/webp';
+          const publicUrl = replacePreviewUrl(file, fileName, mimeType);
+          const target = {
+            uploadUrl: `https://uploads.example.test/${uploadKeyPrefix}/${fileName}`,
+            headers: {
+              'content-type': mimeType,
+              'x-demo-consumer': consumerName.toLowerCase()
+            },
+            publicUrl,
+            objectKey: `${uploadKeyPrefix}/${fileName}`
+          };
+
+          setUploadTrace({
+            context: {
+              fileName: context.fileName,
+              originalFileName: context.originalFileName,
+              mimeType: context.mimeType,
+              size: file.size
+            },
+            target,
+            request: null,
+            response: null
+          });
+
+          return target;
+        },
+        request: runMockRequest
+      });
+    }
+
+    if (flowMode === 'multipart') {
+      return createMultipartUploader({
+        endpoint: '/api/demo/upload',
+        fieldName: 'file',
+        async request(request): Promise<UploadResponse> {
+          const file = extractUploadBlob(request.body);
+          const fileName = file ? getBlobFileName(file, `${surface.fileLabel}.webp`) : `${surface.fileLabel}.webp`;
+          const mimeType = file?.type || request.headers?.['content-type'] || 'image/webp';
+          const publicUrl = file ? replacePreviewUrl(file, fileName, mimeType) : undefined;
+          const objectKey = `${uploadKeyPrefix}/multipart/${fileName}`;
+
+          setUploadTrace({
+            context: {
+              fileName,
+              originalFileName: fileName,
+              mimeType,
+              size: file?.size ?? 0
+            },
+            target: {
+              uploadUrl: request.url,
+              headers: request.headers ?? {},
+              publicUrl,
+              objectKey
+            },
+            request: null,
+            response: null
+          });
+
+          return runMockRequest(request, {
+            imageUrl: publicUrl,
+            imageKey: objectKey
+          });
+        },
+        mapResponse(body) {
+          const result = body as { imageUrl?: string; imageKey?: string };
+
+          return {
+            src: result.imageUrl,
+            key: result.imageKey,
+            response: body
+          };
+        }
+      });
+    }
+
+    return createRawPutUploader({
+      endpoint: `/api/demo/raw/${surface.fileLabel}`,
+      objectKey: `${uploadKeyPrefix}/raw/${surface.fileLabel}.webp`,
+      async request(request): Promise<UploadResponse> {
+        const file = extractUploadBlob(request.body);
+        const fileName = file ? getBlobFileName(file, `${surface.fileLabel}.webp`) : `${surface.fileLabel}.webp`;
+        const mimeType = file?.type || request.headers?.['content-type'] || 'image/webp';
+
+        if (uploadPreviewUrlRef.current) {
+          URL.revokeObjectURL(uploadPreviewUrlRef.current);
+          uploadPreviewUrlRef.current = null;
+        }
+
+        setUploadTrace({
+          context: {
+            fileName,
+            originalFileName: fileName,
+            mimeType,
+            size: file?.size ?? 0
+          },
+          target: {
+            uploadUrl: request.url,
+            headers: request.headers ?? {},
+            objectKey: `${uploadKeyPrefix}/raw/${surface.fileLabel}.webp`
+          },
+          request: null,
+          response: null
+        });
+
+        return runMockRequest(request);
+      }
+    });
+  }, [consumerName, failNextUpload, flowMode, locale, surface, uploadKeyPrefix]);
+
+  const messages = {
+    chooseFile: copy(locale, TEXT.browseLabel),
+    placeholderTitle:
+      flowMode !== 'preview'
+        ? copy(locale, TEXT.placeholderPublishTitle)
+        : copy(locale, TEXT.placeholderPreviewTitle),
+    placeholderDescription:
+      flowMode !== 'preview'
+        ? copy(locale, TEXT.placeholderPublishBody)
+        : copy(locale, TEXT.placeholderPreviewBody),
+    statusIdle:
+      flowMode !== 'preview'
+        ? copy(locale, TEXT.idleStatusPublish)
+        : copy(locale, TEXT.idleStatusPreview),
+    statusUploading: (percent: number) => {
+      const lead = copy(locale, TEXT.uploading);
+      return percent > 0 ? `${lead}... ${percent}%` : `${lead}...`;
+    }
+  };
+
+  const stepRows = [
+    {
+      label: copy(locale, TEXT.installStep),
+      command: 'npm install image-drop-input react react-dom',
+      copy: null
+    },
+    {
+      label: copy(locale, TEXT.demoStep),
+      command: demoCommand,
+      copy: copy(locale, TEXT.demoStepCopy)
+    },
+    {
+      label: copy(locale, TEXT.parityStep),
+      command: alternateDemoCommand,
+      copy: copy(locale, TEXT.parityStepCopy)
+    },
+    {
+      label: copy(locale, TEXT.dryRunStep),
+      command: 'npm run publish:check',
+      copy: copy(locale, TEXT.dryRunStepCopy)
+    },
+    {
+      label: copy(locale, TEXT.publishStep),
+      command: 'npm publish --access public',
+      copy: copy(locale, TEXT.publishStepCopy)
+    }
+  ];
+
+  return (
+    <main className="demo-shell">
+      <section className="demo-page">
+        <header className="demo-header">
+          <div className="demo-badges">
+            <span className="demo-badge">{consumerName}</span>
+            <span className="demo-badge demo-badgeStrong">{copy(locale, TEXT.publishedSurface)}</span>
+            <span className="demo-badge demo-badgeWarm">{copy(locale, TEXT.singleImageFirst)}</span>
+          </div>
+
+          <div className="demo-headerTop">
+            <div className="demo-headerCopy">
+              <h1 className="demo-title">{copy(locale, TEXT.title)}</h1>
+              <p className="demo-body">
+                {copy(locale, TEXT.body)} {copy(locale, consumerNote)}
+              </p>
+            </div>
+
+            <div className="demo-locale" aria-label={copy(locale, TEXT.language)}>
+              <span className="demo-localeLabel">{copy(locale, TEXT.language)}</span>
+              {(['en', 'jp'] as const).map((option) => (
+                <button
+                  key={option}
+                  className="demo-localeButton"
+                  data-active={locale === option}
+                  type="button"
+                  onClick={() => {
+                    setLocale(option);
+                  }}
+                >
+                  {option}
+                </button>
+              ))}
+            </div>
+          </div>
+        </header>
+
+        <section className="demo-workbench">
+          <div className="demo-stage">
+            <div className="demo-stageHeader">
+              <div>
+                <p className="demo-eyebrow">{copy(locale, TEXT.liveDemo)}</p>
+                <h2 className="demo-stageTitle">{copy(locale, TEXT.stageTitle)}</h2>
+                <p className="demo-stageDescription">{copy(locale, TEXT.stageBody)}</p>
+              </div>
+
+              <div className="demo-toolbar">
+                <div className="demo-toggleGroup">
+                  <span className="demo-toggleLabel">{copy(locale, TEXT.useCase)}</span>
+                  <div className="demo-toggleRow">
+                    {SURFACES.map((option) => (
+                      <button
+                        key={option.id}
+                        className="demo-toggleButton"
+                        data-active={surfaceMode === option.id}
+                        type="button"
+                        onClick={() => {
+                          setSurfaceMode(option.id);
+                        }}
+                      >
+                        <span className="demo-toggleTitle">{copy(locale, option.title)}</span>
+                        <span className="demo-toggleCopy">{copy(locale, option.description)}</span>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="demo-toggleGroup">
+                  <span className="demo-toggleLabel">{copy(locale, TEXT.flow)}</span>
+                  <div className="demo-toggleRow">
+                    {FLOWS.map((option) => (
+                      <button
+                        key={option.id}
+                        className="demo-toggleButton"
+                        data-active={flowMode === option.id}
+                        type="button"
+                        onClick={() => {
+                          setFlowMode(option.id);
+                        }}
+                      >
+                        <span className="demo-toggleTitle">{copy(locale, option.title)}</span>
+                        <span className="demo-toggleCopy">{copy(locale, option.description)}</span>
+                      </button>
+                    ))}
+                  </div>
+                  {flowMode !== 'preview' ? (
+                    <div className="demo-failureRow">
+                      <button
+                        className="demo-failureButton"
+                        data-active={failNextUpload}
+                        type="button"
+                        onClick={() => {
+                          setFailNextUpload((current) => !current);
+                        }}
+                      >
+                        {failNextUpload
+                          ? copy(locale, TEXT.failNextArmed)
+                          : copy(locale, TEXT.failNext)}
+                      </button>
+                      <span className="demo-failureHint">{copy(locale, TEXT.failHint)}</span>
+                    </div>
+                  ) : null}
+                </div>
+              </div>
+
+              <dl className="demo-metrics">
+                <div className="demo-metric">
+                  <dt>{copy(locale, TEXT.aspectRatio)}</dt>
+                  <dd>{surface.aspectRatio}</dd>
+                </div>
+                <div className="demo-metric">
+                  <dt>{copy(locale, TEXT.transform)}</dt>
+                  <dd>{copy(locale, TEXT.transformValue)}</dd>
+                </div>
+                <div className="demo-metric">
+                  <dt>{copy(locale, TEXT.upload)}</dt>
+                  <dd>{flowMode === 'preview' ? copy(locale, TEXT.uploadOff) : copy(locale, flow.title)}</dd>
+                </div>
+              </dl>
+            </div>
+
+            <div className="demo-canvas">
+              <ImageDropInput
+                accept="image/png,image/jpeg,image/webp,image/avif"
+                aspectRatio={surface.aspectRatio}
+                classNames={INPUT_CLASS_NAMES}
+                dropzoneStyle={{ minBlockSize: surfaceMode === 'cover' ? '22rem' : '18rem' }}
+                maxBytes={12 * 1024 * 1024}
+                messages={messages}
+                onChange={setValue}
+                previewable
+                rootStyle={createThemeStyle(surface)}
+                transform={async (file) => {
+                  const prepared = await compressImage(file, {
+                    maxWidth: surface.maxWidth,
+                    maxHeight: surface.maxHeight,
+                    outputType: 'image/webp',
+                    quality: flowMode === 'preview' ? 0.88 : 0.84
+                  });
+
+                  return {
+                    file: prepared,
+                    fileName: createPreparedFileName(file.name, surface),
+                    mimeType: prepared.type || 'image/webp'
+                  };
+                }}
+                upload={upload}
+                value={value}
+              />
+
+              <p className="demo-canvasHint">{copy(locale, TEXT.canvasHint)}</p>
+            </div>
+          </div>
+
+          <aside className="demo-inspector">
+            <section className="demo-panel">
+              <div>
+                <h3 className="demo-panelTitle">{copy(locale, TEXT.sourceTitle)}</h3>
+                <p className="demo-panelBody">{copy(locale, TEXT.sourceBody)}</p>
+              </div>
+              <pre className="demo-code">{buildSnippet(flowMode, surface)}</pre>
+            </section>
+
+            <section className="demo-panel">
+              <div>
+                <h3 className="demo-panelTitle">{copy(locale, TEXT.valueTitle)}</h3>
+                <p className="demo-panelBody">{copy(locale, TEXT.valueBody)}</p>
+              </div>
+              <pre className="demo-json">{JSON.stringify(summarizeValue(value, locale), null, 2)}</pre>
+            </section>
+
+            <section className="demo-panel">
+              <div>
+                <h3 className="demo-panelTitle">{copy(locale, TEXT.uploadTitle)}</h3>
+                <p className="demo-panelBody">{copy(locale, TEXT.uploadBody)}</p>
+              </div>
+              <pre className="demo-json">
+                {JSON.stringify(buildUploadPanel(locale, flowMode, value, uploadTrace), null, 2)}
+              </pre>
+            </section>
+          </aside>
+        </section>
+
+        <section className="demo-proof">
+          <div className="demo-sectionHeader">
+            <p className="demo-eyebrow">{copy(locale, TEXT.proofEyebrow)}</p>
+            <h2 className="demo-sectionTitle">{copy(locale, TEXT.proofTitle)}</h2>
+            <p className="demo-sectionBody">{copy(locale, TEXT.proofBody)}</p>
+          </div>
+
+          <div className="demo-proofGrid">
+            {PROOF_ITEMS.map((item) => (
+              <article key={copy('en', item.title)} className="demo-proofCard">
+                <h3>{copy(locale, item.title)}</h3>
+                <p>{copy(locale, item.body)}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="demo-recipes">
+          <div className="demo-sectionHeader">
+            <p className="demo-eyebrow">{copy(locale, TEXT.recipesEyebrow)}</p>
+            <h2 className="demo-sectionTitle">{copy(locale, TEXT.recipesTitle)}</h2>
+            <p className="demo-sectionBody">{copy(locale, TEXT.recipesBody)}</p>
+          </div>
+
+          <div className="demo-recipeGrid">
+            {RECIPE_ITEMS.map((item) => (
+              <article key={copy('en', item.title)} className="demo-recipeCard">
+                <div>
+                  <h3>{copy(locale, item.title)}</h3>
+                  <p>{copy(locale, item.body)}</p>
+                </div>
+                <pre className="demo-code">{item.snippet}</pre>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <HeadlessCustomDemo locale={locale} />
+
+        <section className="demo-ship">
+          <div className="demo-shipHeader">
+            <p className="demo-eyebrow">{copy(locale, TEXT.shipTitle)}</p>
+            <h2 className="demo-shipTitle">{copy(locale, TEXT.shipTitle)}</h2>
+            <p className="demo-shipBody">{copy(locale, TEXT.shipBody)}</p>
+          </div>
+
+          <ol className="demo-stepList">
+            {stepRows.map((step) => (
+              <li key={step.command} className="demo-step">
+                <div>
+                  <div className="demo-stepLabel">{step.label}</div>
+                  {step.copy ? <div className="demo-stepCopy">{step.copy}</div> : null}
+                </div>
+                <code className="demo-command">{step.command}</code>
+              </li>
+            ))}
+          </ol>
+        </section>
+      </section>
+    </main>
+  );
+}

--- a/examples/shared/demo.css
+++ b/examples/shared/demo.css
@@ -1,0 +1,649 @@
+.demo-shell {
+  background: #eef2f4;
+  color: #162033;
+  min-height: 100vh;
+}
+
+.demo-page {
+  display: grid;
+  gap: 24px;
+  margin: 0 auto;
+  max-width: 1160px;
+  padding: 40px 20px 72px;
+}
+
+.demo-header {
+  display: grid;
+  gap: 14px;
+}
+
+.demo-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.demo-badge {
+  align-items: center;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(22, 32, 51, 0.08);
+  border-radius: 6px;
+  color: rgba(22, 32, 51, 0.72);
+  display: inline-flex;
+  font-size: 12px;
+  font-weight: 600;
+  gap: 6px;
+  line-height: 1;
+  padding: 8px 10px;
+}
+
+.demo-badgeStrong {
+  background: rgba(16, 143, 108, 0.1);
+  border-color: rgba(16, 143, 108, 0.18);
+  color: #0f6f56;
+}
+
+.demo-badgeWarm {
+  background: rgba(220, 96, 61, 0.1);
+  border-color: rgba(220, 96, 61, 0.18);
+  color: #a54d36;
+}
+
+.demo-headerTop {
+  align-items: flex-start;
+  display: flex;
+  gap: 16px;
+  justify-content: space-between;
+}
+
+.demo-headerCopy {
+  display: grid;
+  gap: 10px;
+  max-width: 48rem;
+}
+
+.demo-title {
+  font-size: 3.55rem;
+  font-weight: 600;
+  letter-spacing: 0;
+  line-height: 1.02;
+  margin: 0;
+  max-width: 11ch;
+  text-wrap: balance;
+}
+
+.demo-body {
+  color: rgba(22, 32, 51, 0.7);
+  font-size: 16px;
+  line-height: 1.7;
+  margin: 0;
+}
+
+.demo-locale {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.demo-localeLabel {
+  color: rgba(22, 32, 51, 0.58);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.demo-localeButton {
+  appearance: none;
+  background: rgba(255, 255, 255, 0.88);
+  border: 1px solid rgba(22, 32, 51, 0.08);
+  border-radius: 6px;
+  color: rgba(22, 32, 51, 0.72);
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0;
+  line-height: 1;
+  padding: 8px 10px;
+  text-transform: uppercase;
+}
+
+.demo-localeButton[data-active='true'] {
+  background: #162033;
+  border-color: #162033;
+  color: rgba(255, 255, 255, 0.96);
+}
+
+.demo-workbench,
+.demo-ship {
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(22, 32, 51, 0.08);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.demo-workbench {
+  display: grid;
+  grid-template-columns: minmax(0, 1.45fr) minmax(320px, 0.95fr);
+}
+
+.demo-stage {
+  display: grid;
+  gap: 20px;
+  padding: 24px;
+}
+
+.demo-stageHeader {
+  display: grid;
+  gap: 18px;
+}
+
+.demo-eyebrow {
+  color: rgba(22, 32, 51, 0.52);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0;
+  line-height: 1;
+  margin: 0;
+  text-transform: uppercase;
+}
+
+.demo-stageTitle {
+  font-size: 28px;
+  font-weight: 600;
+  letter-spacing: 0;
+  line-height: 1.1;
+  margin: 0;
+}
+
+.demo-stageDescription {
+  color: rgba(22, 32, 51, 0.7);
+  font-size: 15px;
+  line-height: 1.65;
+  margin: 0;
+  max-width: 40rem;
+}
+
+.demo-toolbar {
+  display: grid;
+  gap: 12px;
+}
+
+.demo-toggleGroup {
+  display: grid;
+  gap: 8px;
+}
+
+.demo-toggleLabel {
+  color: rgba(22, 32, 51, 0.54);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.demo-toggleRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.demo-failureRow {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.demo-failureButton {
+  appearance: none;
+  background: rgba(255, 255, 255, 0.96);
+  border: 1px solid rgba(22, 32, 51, 0.1);
+  border-radius: 6px;
+  color: rgba(22, 32, 51, 0.78);
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1;
+  padding: 10px 12px;
+}
+
+.demo-failureButton[data-active='true'] {
+  background: rgba(174, 54, 44, 0.1);
+  border-color: rgba(174, 54, 44, 0.24);
+  color: #8e3029;
+}
+
+.demo-failureHint {
+  color: rgba(22, 32, 51, 0.58);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.demo-toggleButton {
+  appearance: none;
+  background: rgba(242, 245, 247, 0.96);
+  border: 1px solid rgba(22, 32, 51, 0.08);
+  border-radius: 8px;
+  color: rgba(22, 32, 51, 0.72);
+  cursor: pointer;
+  display: grid;
+  gap: 2px;
+  min-width: 10.5rem;
+  padding: 12px 14px;
+  text-align: left;
+}
+
+.demo-toggleButton[data-active='true'] {
+  background: rgba(22, 32, 51, 0.96);
+  border-color: rgba(22, 32, 51, 0.96);
+  color: rgba(255, 255, 255, 0.96);
+}
+
+.demo-toggleTitle {
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0;
+  line-height: 1.2;
+}
+
+.demo-toggleCopy {
+  font-size: 12px;
+  line-height: 1.45;
+  opacity: 0.74;
+}
+
+.demo-metrics {
+  display: grid;
+  gap: 1px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin: 0;
+}
+
+.demo-metric {
+  background: rgba(242, 245, 247, 0.92);
+  padding: 12px 14px;
+}
+
+.demo-metric dt {
+  color: rgba(22, 32, 51, 0.52);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0;
+  line-height: 1;
+  margin: 0 0 8px;
+  text-transform: uppercase;
+}
+
+.demo-metric dd {
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0;
+  line-height: 1.4;
+  margin: 0;
+}
+
+.demo-canvas {
+  display: grid;
+  gap: 12px;
+}
+
+.demo-canvasHint {
+  color: rgba(22, 32, 51, 0.62);
+  font-size: 13px;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.demo-inspector {
+  border-left: 1px solid rgba(22, 32, 51, 0.08);
+  display: grid;
+}
+
+.demo-panel {
+  display: grid;
+  gap: 12px;
+  padding: 20px;
+}
+
+.demo-panel + .demo-panel {
+  border-top: 1px solid rgba(22, 32, 51, 0.08);
+}
+
+.demo-panelTitle {
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: 0;
+  line-height: 1.3;
+  margin: 0;
+}
+
+.demo-panelBody {
+  color: rgba(22, 32, 51, 0.66);
+  font-size: 13px;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.demo-code,
+.demo-json {
+  background: rgba(243, 246, 248, 0.98);
+  border: 1px solid rgba(22, 32, 51, 0.08);
+  border-radius: 6px;
+  color: rgba(22, 32, 51, 0.84);
+  font-family: 'SF Mono', 'Menlo', 'Monaco', monospace;
+  font-size: 12px;
+  line-height: 1.65;
+  margin: 0;
+  overflow-x: auto;
+  padding: 14px;
+}
+
+.demo-code {
+  white-space: pre;
+}
+
+.demo-json {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.demo-proof,
+.demo-recipes,
+.demo-headless {
+  display: grid;
+  gap: 18px;
+}
+
+.demo-sectionHeader {
+  display: grid;
+  gap: 9px;
+  max-width: 48rem;
+}
+
+.demo-sectionTitle {
+  font-size: 26px;
+  font-weight: 600;
+  letter-spacing: 0;
+  line-height: 1.15;
+  margin: 0;
+}
+
+.demo-sectionBody {
+  color: rgba(22, 32, 51, 0.68);
+  font-size: 15px;
+  line-height: 1.65;
+  margin: 0;
+}
+
+.demo-proofGrid,
+.demo-recipeGrid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.demo-proofCard,
+.demo-recipeCard {
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(22, 32, 51, 0.08);
+  border-radius: 8px;
+}
+
+.demo-proofCard {
+  display: grid;
+  gap: 8px;
+  padding: 18px;
+}
+
+.demo-proofCard h3,
+.demo-recipeCard h3 {
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: 0;
+  line-height: 1.3;
+  margin: 0;
+}
+
+.demo-proofCard p,
+.demo-recipeCard p {
+  color: rgba(22, 32, 51, 0.66);
+  font-size: 13px;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.demo-recipeCard {
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+  padding: 16px;
+}
+
+.demo-headlessGrid {
+  align-items: start;
+  display: grid;
+  gap: 16px;
+  grid-template-columns: minmax(0, 1fr) minmax(300px, 0.75fr);
+}
+
+.demo-headlessSurface {
+  align-items: center;
+  aspect-ratio: 1 / 1;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(242, 245, 247, 0.96));
+  border: 1px dashed rgba(22, 32, 51, 0.2);
+  border-radius: 8px;
+  cursor: pointer;
+  display: grid;
+  justify-items: center;
+  max-width: 24rem;
+  min-height: 15rem;
+  overflow: hidden;
+  padding: 18px;
+}
+
+.demo-headlessSurface[data-dragging='true'] {
+  background: rgba(21, 134, 106, 0.08);
+  border-color: rgba(21, 134, 106, 0.38);
+}
+
+.demo-headlessImage {
+  border-radius: 8px;
+  display: block;
+  height: 100%;
+  object-fit: cover;
+  width: 100%;
+}
+
+.demo-headlessPlaceholder {
+  color: rgba(22, 32, 51, 0.58);
+  font-size: 14px;
+  font-weight: 700;
+  line-height: 1.4;
+}
+
+.demo-headlessControls {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+.demo-headlessControls button {
+  appearance: none;
+  background: rgba(255, 255, 255, 0.96);
+  border: 1px solid rgba(22, 32, 51, 0.1);
+  border-radius: 6px;
+  color: rgba(22, 32, 51, 0.78);
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1;
+  padding: 10px 12px;
+}
+
+.demo-headlessControls button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
+.demo-headlessControls span {
+  color: rgba(22, 32, 51, 0.62);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.demo-ship {
+  display: grid;
+  gap: 0;
+}
+
+.demo-shipHeader {
+  display: grid;
+  gap: 10px;
+  padding: 22px 24px 18px;
+}
+
+.demo-shipTitle {
+  font-size: 24px;
+  font-weight: 600;
+  letter-spacing: 0;
+  line-height: 1.15;
+  margin: 0;
+}
+
+.demo-shipBody {
+  color: rgba(22, 32, 51, 0.68);
+  font-size: 15px;
+  line-height: 1.65;
+  margin: 0;
+  max-width: 44rem;
+}
+
+.demo-stepList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.demo-step {
+  align-items: center;
+  column-gap: 16px;
+  display: grid;
+  grid-template-columns: minmax(0, 180px) minmax(0, 1fr);
+  padding: 16px 24px;
+}
+
+.demo-step + .demo-step {
+  border-top: 1px solid rgba(22, 32, 51, 0.08);
+}
+
+.demo-stepLabel {
+  color: rgba(22, 32, 51, 0.72);
+  font-size: 13px;
+  font-weight: 700;
+  letter-spacing: 0;
+  line-height: 1.3;
+  text-transform: uppercase;
+}
+
+.demo-command {
+  background: rgba(243, 246, 248, 0.96);
+  border: 1px solid rgba(22, 32, 51, 0.08);
+  border-radius: 6px;
+  color: rgba(22, 32, 51, 0.86);
+  display: inline-flex;
+  font-family: 'SF Mono', 'Menlo', 'Monaco', monospace;
+  font-size: 13px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+  padding: 10px 12px;
+}
+
+.demo-stepCopy {
+  color: rgba(22, 32, 51, 0.6);
+  font-size: 13px;
+  line-height: 1.6;
+  margin-top: 8px;
+}
+
+.demo-idiDropzone {
+  border-radius: 8px;
+}
+
+.demo-idiPreview,
+.demo-idiImage,
+.demo-idiOverlay,
+.demo-idiError,
+.demo-idiDialog,
+.demo-idiDialogImage {
+  border-radius: 8px;
+}
+
+.demo-idiActions {
+  border-radius: 8px;
+  right: 0.75rem;
+  top: 0.75rem;
+}
+
+.demo-idiIconButton,
+.demo-idiStatus,
+.demo-idiFooterButton {
+  border-radius: 6px;
+}
+
+.demo-idiFooter {
+  inset-block-end: 0.75rem;
+  inset-inline: 0.75rem;
+}
+
+@media (max-width: 960px) {
+  .demo-workbench {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .demo-headlessGrid,
+  .demo-proofGrid,
+  .demo-recipeGrid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .demo-inspector {
+    border-left: 0;
+    border-top: 1px solid rgba(22, 32, 51, 0.08);
+  }
+}
+
+@media (max-width: 720px) {
+  .demo-page {
+    padding-inline: 16px;
+  }
+
+  .demo-headerTop {
+    flex-direction: column;
+  }
+
+  .demo-title {
+    font-size: 2.35rem;
+  }
+
+  .demo-stage,
+  .demo-panel,
+  .demo-shipHeader,
+  .demo-step {
+    padding-inline: 18px;
+  }
+
+  .demo-step {
+    gap: 10px;
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .demo-metrics {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}

--- a/examples/shared/demo.css.d.ts
+++ b/examples/shared/demo.css.d.ts
@@ -1,0 +1,3 @@
+declare const css: undefined;
+
+export default css;

--- a/examples/vite/src/App.tsx
+++ b/examples/vite/src/App.tsx
@@ -1,11 +1,16 @@
-import { ExampleApp } from '../../shared/ExampleApp';
+import { DemoApp } from '../../shared/demo-app';
 
 export function App() {
   return (
-    <ExampleApp
-      consumerName="Vite consumer example"
-      uploadKey="example/vite/cover-image.webp"
-      progressStops={[18, 74]}
+    <DemoApp
+      consumerName="Vite"
+      consumerNote={{
+        en: 'This one runs from a Vite consumer and exercises the published entrypoints rather than direct source imports.',
+        jp: 'これは Vite consumer から published entrypoints を読む構成で、source 直参照ではありません。'
+      }}
+      demoCommand="npm run demo:vite"
+      alternateDemoCommand="npm run demo:rsbuild"
+      uploadKeyPrefix="example/vite"
     />
   );
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "image-drop-input",
   "version": "0.1.1",
-  "description": "Lightweight React image uploader with preview, preview dialog, compression, and pluggable uploads.",
+  "description": "React image input for pre-upload preview, validation, compression, paste, and signed uploads.",
   "license": "MIT",
   "type": "module",
   "homepage": "https://mt4110.github.io/image-drop-input/",
@@ -44,13 +44,25 @@
   },
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "README.ja.md",
+    "ROADMAP.md"
   ],
   "keywords": [
     "react",
+    "react-component",
     "image-upload",
+    "image-input",
+    "image-preview",
+    "image-compression",
     "file-input",
     "drag-and-drop",
+    "clipboard-paste",
+    "presigned-url",
+    "s3",
+    "r2",
+    "webp",
+    "avatar-upload",
     "uploader"
   ],
   "sideEffects": [

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -7,7 +7,7 @@ export type {
 } from './react/customization';
 export { resolveImageDropInputMessages } from './react/customization';
 export { normalizeAspectRatio, resolveDisplaySrc, useImageDropInput } from './react/use-image-drop-input';
-export type { UseImageDropInputOptions } from './react/use-image-drop-input';
+export type { UseImageDropInputOptions, UseImageDropInputReturn } from './react/use-image-drop-input';
 export { compressImage } from './core/compress-image';
 export { createObjectUrl } from './core/create-object-url';
 export { getImageMetadata } from './core/get-image-metadata';

--- a/src/react/ImageDropInput.tsx
+++ b/src/react/ImageDropInput.tsx
@@ -3,6 +3,7 @@ import type {
   KeyboardEvent as ReactKeyboardEvent,
   MouseEvent as ReactMouseEvent
 } from 'react';
+import { useCallback, useEffect } from 'react';
 import { PreviewDialog } from './PreviewDialog';
 import type {
   ImageDropInputActionsRenderProps,
@@ -185,6 +186,22 @@ export function ImageDropInput({
     mergedDropzoneStyle.aspectRatio = normalizedAspectRatio;
   }
 
+  const openPreview = useCallback(() => {
+    if (!resolvedPreviewable || !displaySrc) {
+      return;
+    }
+
+    previewDialog.open();
+  }, [displaySrc, previewDialog.open, resolvedPreviewable]);
+
+  useEffect(() => {
+    if (resolvedPreviewable && displaySrc) {
+      return;
+    }
+
+    previewDialog.close();
+  }, [displaySrc, previewDialog.close, resolvedPreviewable]);
+
   const renderState = {
     disabled: isDisabled,
     displayValue,
@@ -227,7 +244,7 @@ export function ImageDropInput({
     ...renderState,
     cancelUpload,
     openFileDialog,
-    openPreview: previewDialog.open,
+    openPreview,
     previewable: resolvedPreviewable,
     removable,
     removeValue,
@@ -245,7 +262,7 @@ export function ImageDropInput({
           disabled={isDisabled}
           onClick={(event) => {
             event.stopPropagation();
-            previewDialog.open();
+            openPreview();
           }}
           aria-label={resolvedMessages.openPreview}
         >
@@ -428,7 +445,7 @@ export function ImageDropInput({
         ariaLabel={resolvedMessages.previewDialog}
         classNames={classNames}
         closeLabel={resolvedMessages.closePreview}
-        open={previewDialog.isOpen}
+        open={resolvedPreviewable && previewDialog.isOpen}
         src={displaySrc}
         onClose={previewDialog.close}
       />

--- a/src/react/use-image-drop-input.ts
+++ b/src/react/use-image-drop-input.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import type { ChangeEvent, ClipboardEvent, DragEvent, KeyboardEvent } from 'react';
+import type { ChangeEvent, ClipboardEvent, DragEvent, KeyboardEvent, RefObject } from 'react';
 import { createObjectUrl } from '../core/create-object-url';
 import { getImageMetadata } from '../core/get-image-metadata';
 import type { ImageDropInputMessages } from './customization';
@@ -104,6 +104,19 @@ function valueUsesUrl(value: ImageUploadValue | null | undefined, url: string): 
   return value?.src === url || value?.previewSrc === url;
 }
 
+interface PreparedUpload {
+  file: File;
+  originalFileName: string;
+  value: Omit<ImageUploadValue, 'key' | 'previewSrc' | 'src'>;
+}
+
+function createPreviewValue(preparedUpload: PreparedUpload, previewSrc: string): ImageUploadValue {
+  return {
+    ...preparedUpload.value,
+    previewSrc
+  };
+}
+
 export function normalizeAspectRatio(aspectRatio?: AspectRatioValue): string | number | undefined {
   if (typeof aspectRatio === 'undefined') {
     return undefined;
@@ -135,6 +148,32 @@ export interface UseImageDropInputOptions {
   onProgress?: (percent: number) => void;
 }
 
+export interface UseImageDropInputReturn {
+  accept?: string;
+  canRetryUpload: boolean;
+  cancelUpload: () => void;
+  clearError: () => void;
+  disabled: boolean;
+  displayValue: ImageUploadValue | null;
+  displaySrc?: string;
+  error: Error | null;
+  handleDragLeave: (event: DragEvent<HTMLElement>) => void;
+  handleDragOver: (event: DragEvent<HTMLElement>) => void;
+  handleDrop: (event: DragEvent<HTMLElement>) => Promise<void>;
+  handleInputChange: (event: ChangeEvent<HTMLInputElement>) => Promise<void>;
+  handleKeyDown: (event: KeyboardEvent<HTMLElement>) => void;
+  handlePaste: (event: ClipboardEvent<HTMLElement>) => Promise<void>;
+  inputRef: RefObject<HTMLInputElement | null>;
+  isDragging: boolean;
+  isUploading: boolean;
+  messages: ImageDropInputMessages;
+  openFileDialog: () => void;
+  progress: number;
+  removeValue: () => void;
+  retryUpload: () => void;
+  statusMessage: string;
+}
+
 export function useImageDropInput({
   accept,
   disabled,
@@ -152,7 +191,7 @@ export function useImageDropInput({
   transform,
   upload,
   value
-}: UseImageDropInputOptions) {
+}: UseImageDropInputOptions): UseImageDropInputReturn {
   const [internalValue, setInternalValue] = useState<ImageUploadValue | null>(value ?? null);
   const [draftValue, setDraftValue] = useState<ImageUploadValue | null>(null);
   const [error, setError] = useState<Error | null>(null);
@@ -163,7 +202,7 @@ export function useImageDropInput({
   const committedObjectUrlRef = useRef<ManagedObjectUrl | null>(null);
   const draftObjectUrlRef = useRef<ManagedObjectUrl | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
-  const retryableFileRef = useRef<File | null>(null);
+  const retryableUploadRef = useRef<PreparedUpload | null>(null);
   const runIdRef = useRef(0);
   const isControlled = typeof value !== 'undefined';
   const committedValue = isControlled ? value ?? null : internalValue;
@@ -190,7 +229,7 @@ export function useImageDropInput({
   }, []);
 
   const clearRetryableUpload = useCallback(() => {
-    retryableFileRef.current = null;
+    retryableUploadRef.current = null;
   }, []);
 
   const discardDraftValue = useCallback(() => {
@@ -304,6 +343,103 @@ export function useImageDropInput({
     setCommittedValue
   ]);
 
+  const uploadPrepared = useCallback(
+    async (preparedUpload: PreparedUpload, runId: number) => {
+      if (!upload) {
+        return;
+      }
+
+      try {
+        const objectUrl = createObjectUrl(preparedUpload.file);
+
+        if (!isCurrentRun(runId)) {
+          objectUrl.revoke();
+          return;
+        }
+
+        const previewValue = createPreviewValue(preparedUpload, objectUrl.url);
+
+        retryableUploadRef.current = preparedUpload;
+        draftObjectUrlRef.current = objectUrl;
+        setDraftValue(previewValue);
+        setIsUploading(true);
+
+        const abortController = new AbortController();
+        abortControllerRef.current = abortController;
+
+        const result = await upload(preparedUpload.file, {
+          signal: abortController.signal,
+          fileName: preparedUpload.value.fileName,
+          originalFileName: preparedUpload.originalFileName,
+          mimeType: preparedUpload.value.mimeType,
+          onProgress(percent) {
+            if (!isCurrentRun(runId)) {
+              return;
+            }
+
+            setProgress(percent);
+            onProgress?.(percent);
+          }
+        });
+
+        if (!isCurrentRun(runId)) {
+          return;
+        }
+
+        abortControllerRef.current = null;
+        setIsUploading(false);
+        setProgress(100);
+        clearRetryableUpload();
+
+        const nextValue: ImageUploadValue = {
+          ...preparedUpload.value,
+          key: result.key,
+          ...(result.src ? { src: result.src } : { previewSrc: previewValue.previewSrc }),
+        };
+
+        clearDraft();
+
+        if (result.src && result.src !== previewValue.previewSrc) {
+          releaseDraftObjectUrl();
+          setCommittedValue(nextValue);
+          return;
+        }
+
+        const ownedDraftUrl = draftObjectUrlRef.current;
+        draftObjectUrlRef.current = null;
+        setCommittedValue(nextValue, ownedDraftUrl);
+      } catch (nextError) {
+        if (!isCurrentRun(runId)) {
+          return;
+        }
+
+        if (isAbortError(nextError)) {
+          abortControllerRef.current = null;
+          resetTransientState();
+          return;
+        }
+
+        abortControllerRef.current = null;
+        setIsUploading(false);
+        setProgress(0);
+        discardDraftValue();
+        reportError(nextError);
+      }
+    },
+    [
+      clearDraft,
+      clearRetryableUpload,
+      discardDraftValue,
+      isCurrentRun,
+      onProgress,
+      releaseDraftObjectUrl,
+      reportError,
+      resetTransientState,
+      setCommittedValue,
+      upload
+    ]
+  );
+
   const handleFile = useCallback(
     async (file: File) => {
       if (disabled) {
@@ -347,6 +483,23 @@ export function useImageDropInput({
           return;
         }
 
+        const preparedUpload: PreparedUpload = {
+          file: transformedFile,
+          originalFileName: file.name,
+          value: {
+            fileName: transformedFile.name,
+            mimeType: transformedFile.type || file.type || undefined,
+            size: transformedFile.size,
+            width: metadata.width,
+            height: metadata.height
+          }
+        };
+
+        if (upload) {
+          await uploadPrepared(preparedUpload, runId);
+          return;
+        }
+
         const objectUrl = createObjectUrl(transformedFile);
 
         if (!isCurrentRun(runId)) {
@@ -355,74 +508,10 @@ export function useImageDropInput({
         }
 
         // Keep object URLs in previewSrc so src keeps its meaning as a persisted/shareable reference.
-        const previewValue: ImageUploadValue = {
-          previewSrc: objectUrl.url,
-          fileName: transformedFile.name,
-          mimeType: transformedFile.type || file.type || undefined,
-          size: transformedFile.size,
-          width: metadata.width,
-          height: metadata.height
-        };
+        const previewValue = createPreviewValue(preparedUpload, objectUrl.url);
 
-        if (!upload) {
-          clearRetryableUpload();
-          setCommittedValue(previewValue, objectUrl);
-          return;
-        }
-
-        retryableFileRef.current = file;
-        draftObjectUrlRef.current = objectUrl;
-        setDraftValue(previewValue);
-        setIsUploading(true);
-
-        const abortController = new AbortController();
-        abortControllerRef.current = abortController;
-
-        const result = await upload(transformedFile, {
-          signal: abortController.signal,
-          fileName: transformedFile.name,
-          originalFileName: file.name,
-          mimeType: transformedFile.type || file.type || undefined,
-          onProgress(percent) {
-            if (!isCurrentRun(runId)) {
-              return;
-            }
-
-            setProgress(percent);
-            onProgress?.(percent);
-          }
-        });
-
-        if (!isCurrentRun(runId)) {
-          return;
-        }
-
-        abortControllerRef.current = null;
-        setIsUploading(false);
-        setProgress(100);
         clearRetryableUpload();
-
-        const nextValue: ImageUploadValue = {
-          fileName: previewValue.fileName,
-          height: previewValue.height,
-          key: result.key,
-          mimeType: previewValue.mimeType,
-          size: previewValue.size,
-          width: previewValue.width,
-          ...(result.src ? { src: result.src } : { previewSrc: previewValue.previewSrc }),
-        };
-
-        clearDraft();
-
-        if (result.src && result.src !== previewValue.previewSrc) {
-          releaseDraftObjectUrl();
-          setCommittedValue(nextValue);
-          return;
-        }
-
-        const ownedDraftUrl = draftObjectUrlRef.current;
-        draftObjectUrlRef.current = null;
-        setCommittedValue(nextValue, ownedDraftUrl);
+        setCommittedValue(previewValue, objectUrl);
       } catch (nextError) {
         if (!isCurrentRun(runId)) {
           return;
@@ -445,7 +534,6 @@ export function useImageDropInput({
       accept,
       cancelActiveUpload,
       clearRetryableUpload,
-      discardDraftValue,
       disabled,
       isCurrentRun,
       maxBytes,
@@ -454,12 +542,12 @@ export function useImageDropInput({
       maxWidth,
       minHeight,
       minWidth,
-      onProgress,
       reportError,
       resetTransientState,
       setCommittedValue,
       transform,
-      upload
+      upload,
+      uploadPrepared
     ]
   );
 
@@ -574,16 +662,23 @@ export function useImageDropInput({
 
     return resolvedMessages.statusIdle;
   }, [displayValue?.fileName, error, isUploading, progress, resolvedMessages]);
-  const canRetryUpload = Boolean(upload && error && retryableFileRef.current && !isUploading);
+  const canRetryUpload = Boolean(upload && error && retryableUploadRef.current && !isUploading);
   const retryUpload = useCallback(() => {
-    const file = retryableFileRef.current;
+    const preparedUpload = retryableUploadRef.current;
 
-    if (disabled || isUploading || !file) {
+    if (disabled || isUploading || !preparedUpload) {
       return;
     }
 
-    void handleFile(file);
-  }, [disabled, handleFile, isUploading]);
+    const runId = ++runIdRef.current;
+    cancelActiveUpload();
+    discardDraftValue();
+    clearError();
+    setIsUploading(false);
+    setProgress(0);
+
+    void uploadPrepared(preparedUpload, runId);
+  }, [cancelActiveUpload, clearError, disabled, discardDraftValue, isUploading, uploadPrepared]);
   const displaySrc = resolveDisplaySrc(displayValue);
 
   return {

--- a/src/style.css
+++ b/src/style.css
@@ -181,7 +181,7 @@
 .idi-placeholderTitle {
   font-size: 1.02rem;
   font-weight: 600;
-  letter-spacing: -0.018em;
+  letter-spacing: 0;
   line-height: 1.3;
 }
 

--- a/tests/react/ImageDropInput.test.tsx
+++ b/tests/react/ImageDropInput.test.tsx
@@ -202,8 +202,10 @@ describe('ImageDropInput', () => {
   it('retries a failed upload from the dedicated error action', async () => {
     const user = userEvent.setup({ document: window.document });
     const onChange = vi.fn();
+    const preparedFile = new File(['prepared'], 'avatar.webp', { type: 'image/webp' });
+    const transform = vi.fn(async () => preparedFile);
     let attempt = 0;
-    const upload = vi.fn(async () => {
+    const upload = vi.fn(async (_file: Blob) => {
       attempt += 1;
 
       if (attempt === 1) {
@@ -216,7 +218,7 @@ describe('ImageDropInput', () => {
       };
     });
 
-    render(<ImageDropInput upload={upload} onChange={onChange} />);
+    render(<ImageDropInput upload={upload} transform={transform} onChange={onChange} />);
 
     await user.upload(
       screen.getByLabelText('Choose image file'),
@@ -231,11 +233,14 @@ describe('ImageDropInput', () => {
 
     await waitFor(() => {
       expect(upload).toHaveBeenCalledTimes(2);
+      expect(transform).toHaveBeenCalledTimes(1);
+      expect(upload.mock.calls[0]?.[0]).toBe(preparedFile);
+      expect(upload.mock.calls[1]?.[0]).toBe(preparedFile);
       expect(onChange).toHaveBeenLastCalledWith(
         expect.objectContaining({
           src: 'https://cdn.example.com/avatar.png',
           key: 'avatars/avatar.png',
-          fileName: 'avatar.png'
+          fileName: 'avatar.webp'
         })
       );
     });
@@ -519,46 +524,6 @@ describe('ImageDropInput', () => {
     expect(nextValue?.src).toBeUndefined();
   });
 
-  it('shows an explicit validation error when a non-image archive is dropped', async () => {
-    const onChange = vi.fn();
-
-    render(<ImageDropInput onChange={onChange} />);
-
-    const dropzone = screen.getByRole('button', { name: 'Image upload area' });
-    const file = new File(['hello'], 'archive.zip', { type: 'application/zip' });
-
-    fireEvent.drop(dropzone, { dataTransfer: createTransfer(file) });
-
-    await waitFor(() => {
-      expect(screen.getByRole('alert').textContent).toContain('Accepted file types: image files.');
-    });
-
-    expect(onChange).not.toHaveBeenCalled();
-  });
-
-  it('prefers an acceptable image when mixed files are dropped together', async () => {
-    const onChange = vi.fn();
-
-    render(<ImageDropInput onChange={onChange} accept="image/png" />);
-
-    const dropzone = screen.getByRole('button', { name: 'Image upload area' });
-    const textFile = new File(['hello'], 'notes.txt', { type: 'text/plain' });
-    const pngFile = new File(['hello'], 'photo.png', { type: 'image/png' });
-
-    fireEvent.drop(dropzone, { dataTransfer: createTransfer(textFile, pngFile) });
-
-    await waitFor(() => {
-      expect(onChange).toHaveBeenCalledWith(
-        expect.objectContaining({
-          previewSrc: 'blob:preview-url',
-          fileName: 'photo.png'
-        })
-      );
-    });
-
-    expect(screen.queryByRole('alert')).toBeNull();
-  });
-
   it('keeps local-only selections in previewSrc so src stays reserved for persisted references', async () => {
     const user = userEvent.setup({ document: window.document });
     const onChange = vi.fn();
@@ -648,6 +613,61 @@ describe('ImageDropInput', () => {
     await waitFor(() => {
       expect(screen.queryByRole('dialog', { name: 'Image preview' })).toBeNull();
     });
+  });
+
+  it('does not reopen a stale preview dialog after the image value is cleared', async () => {
+    const user = userEvent.setup({ document: window.document });
+    const { rerender } = render(
+      <ImageDropInput
+        value={{
+          src: 'https://cdn.example.com/avatar.png',
+          fileName: 'avatar.png'
+        }}
+      />
+    );
+
+    await user.click(screen.getByLabelText('Open preview'));
+    expect(await screen.findByRole('dialog', { name: 'Image preview' })).toBeTruthy();
+
+    rerender(<ImageDropInput value={null} />);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog', { name: 'Image preview' })).toBeNull();
+    });
+
+    rerender(
+      <ImageDropInput
+        value={{
+          src: 'https://cdn.example.com/new-avatar.png',
+          fileName: 'new-avatar.png'
+        }}
+      />
+    );
+
+    expect(screen.queryByRole('dialog', { name: 'Image preview' })).toBeNull();
+  });
+
+  it('keeps custom preview actions inert when previewable is disabled', async () => {
+    const user = userEvent.setup({ document: window.document });
+
+    render(
+      <ImageDropInput
+        previewable={false}
+        value={{
+          src: 'https://cdn.example.com/avatar.png',
+          fileName: 'avatar.png'
+        }}
+        renderActions={({ openPreview }) => (
+          <button type="button" aria-label="Custom preview" onClick={openPreview}>
+            Preview
+          </button>
+        )}
+      />
+    );
+
+    await user.click(screen.getByLabelText('Custom preview'));
+
+    expect(screen.queryByRole('dialog', { name: 'Image preview' })).toBeNull();
   });
 
   it('revokes object URLs when a local preview unmounts', async () => {
@@ -744,5 +764,45 @@ describe('ImageDropInput', () => {
 
     expect(footerClick).toHaveBeenCalledTimes(1);
     expect(inputClickSpy).not.toHaveBeenCalled();
+  });
+
+  it('shows an explicit validation error when a non-image archive is dropped', async () => {
+    const onChange = vi.fn();
+
+    render(<ImageDropInput onChange={onChange} />);
+
+    const dropzone = screen.getByRole('button', { name: 'Image upload area' });
+    const file = new File(['hello'], 'archive.zip', { type: 'application/zip' });
+
+    fireEvent.drop(dropzone, { dataTransfer: createTransfer(file) });
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert').textContent).toContain('Accepted file types: image files.');
+    });
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('prefers an acceptable image when mixed files are dropped together', async () => {
+    const onChange = vi.fn();
+
+    render(<ImageDropInput onChange={onChange} accept="image/png" />);
+
+    const dropzone = screen.getByRole('button', { name: 'Image upload area' });
+    const textFile = new File(['hello'], 'notes.txt', { type: 'text/plain' });
+    const pngFile = new File(['hello'], 'photo.png', { type: 'image/png' });
+
+    fireEvent.drop(dropzone, { dataTransfer: createTransfer(textFile, pngFile) });
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          previewSrc: 'blob:preview-url',
+          fileName: 'photo.png'
+        })
+      );
+    });
+
+    expect(screen.queryByRole('alert')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- Repositions the README around the pre-upload image flow and adds a Japanese README plus focused roadmap.
- Replaces the example surface with an adoption-oriented demo covering preview-only, presigned PUT, multipart POST, raw PUT, headless UI, failure, and retry paths.
- Tightens preview dialog behavior and makes retry resend the same prepared file after an upload failure.
- Exports `UseImageDropInputReturn` for typed headless wrappers and updates package metadata so the added docs ship in the npm tarball.

## Validation

- `npm test`
- `npm run typecheck`
- `npm run build:examples`
- `npm run check:package`
- `npm pack --dry-run`