### PR TITLE
release: 0.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "image-drop-input",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "image-drop-input",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
       "workspaces": [
         "examples/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "image-drop-input",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Product-safe React image input for preview, validation, compression, paste, and signed uploads.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

- release version: `0.2.0`
- dist-tag: `latest`
- scope: root package (`image-drop-input`)

## Highlights

- sharpens the package around the pre-upload image flow with clearer adoption docs and recipe-based examples
- adds stable, localizable validation errors and explicit source/output byte-limit semantics
- makes filled-state keyboard, paste, and upload progress behavior more deterministic across the default component and headless API

## Checks

- [x] `package.json` and `package-lock.json` carry the intended version
- [x] release-facing notes are included in the PR body
- [x] `npm run verify`
- [x] `npm run publish:check`
- [ ] demo still looks right in the consumer you care about

## Publish Plan

- [ ] merge to `main`
- [ ] run the `Release` workflow from `main`
- [ ] leave `publish` off for rehearsal, then rerun with `publish` on

## Notes

- breaking changes: none intended; this is a minor release because the public adoption surface and validation semantics expanded meaningfully
- follow-up work: cut the signed `v0.2.0` tag and run the release workflow after merge
