### PR TITLE
chore: add consumer runtime smoke checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 permissions:
   contents: read
 jobs:
-  verify:
+  verify-maintainer:
     runs-on: ubuntu-latest
     env:
       NODE_VERSION: 22
@@ -36,3 +36,59 @@ jobs:
       - run: npm test
       - run: npm run build:examples
       - run: npm run check:package
+
+  pack-consumer-artifact:
+    runs-on: ubuntu-latest
+    env:
+      NODE_VERSION: 22
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+
+      - name: Resolve npm version from packageManager
+        run: |
+          NPM_VERSION="$(node -p 'require("./package.json").packageManager.split("@")[1]')"
+          echo "NPM_VERSION=${NPM_VERSION}" >> "$GITHUB_ENV"
+
+      - name: Install pinned npm
+        run: npm install --global "npm@${NPM_VERSION}"
+
+      - run: npm --version
+      - run: npm ci
+      - run: npm run pack:consumer-smoke
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: consumer-package
+          path: .artifacts/image-drop-input.tgz
+          if-no-files-found: error
+
+  consumer-smoke:
+    runs-on: ubuntu-latest
+    needs: pack-consumer-artifact
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version:
+          - 18.18.0
+          - 20.x
+          - 22.x
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: consumer-package
+          path: .artifacts
+
+      - run: npm --version
+      - run: npm run smoke:consumer:root-types
+      - run: npm run smoke:consumer:headless-cjs

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ pnpm-debug.log*
 # os
 .DS_Store
 Thumbs.db
+
+# private
+.private_docs
+.private_docs/*

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist/
 coverage/
 .nyc_output/
 .storybook-static/
+.artifacts/
 *.tgz
 
 # examples build cache

--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ Import the default CSS once:
 import 'image-drop-input/style.css';
 ```
 
+## Runtime support
+
+The package separates the repo toolchain from the install floor for apps that consume the published tarball.
+
+| Layer | Policy |
+| --- | --- |
+| Maintainer toolchain | Node 22.x with the npm version pinned by `packageManager`. This is for contributors running the full repo, examples, and release checks. |
+| Published package consumers | Node `>=18.18.0` for package install, type resolution, and CJS/ESM subpath loading. React is a peer dependency. |
+
+The library is built to ES2020 and keeps cloud SDKs out of the bundle. CI verifies the packed package in Node 18.18.x, 20.x, and 22.x without running the root repo install in those consumer jobs.
+
 ## 30-second quick start
 
 Use it as a local-preview-only image input:
@@ -297,6 +308,8 @@ Use another tool if you need:
 This package is intentionally single-image first.
 
 ## Development
+
+Development uses the maintainer toolchain above, which is intentionally stricter than the consumer install floor.
 
 ```bash
 npm ci

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -43,10 +43,23 @@ Use these sources for context:
    - first with `publish` turned off for a rehearsal
    - then with `publish` turned on for the real publish
 
+## Runtime support checks
+
+The repo maintainer toolchain is Node 22.x with the npm version pinned by `packageManager`.
+The published package consumer floor is Node `>=18.18.0`.
+
+Before publishing, keep both lanes green:
+
+- maintainer verification: `npm run release:pr:check`
+- packed consumer smoke: `npm run smoke:consumer`
+
+Do not change `engines.node` unless the packed tarball smoke fixtures support the new value.
+
 ## Commands
 
 ```bash
 npm run release:prepare -- patch
 npm run release:pr:check
+npm run smoke:consumer
 npm run publish:check
 ```

--- a/consumer-fixtures/headless-cjs/index.cjs
+++ b/consumer-fixtures/headless-cjs/index.cjs
@@ -1,0 +1,15 @@
+const headless = require('image-drop-input/headless');
+
+const requiredFunctions = [
+  'compressImage',
+  'createMultipartUploader',
+  'createPresignedPutUploader',
+  'createRawPutUploader',
+  'validateImage'
+];
+
+for (const name of requiredFunctions) {
+  if (typeof headless[name] !== 'function') {
+    throw new Error(`Expected headless ${name} export.`);
+  }
+}

--- a/consumer-fixtures/headless-cjs/package.json
+++ b/consumer-fixtures/headless-cjs/package.json
@@ -1,0 +1,10 @@
+{
+  "private": true,
+  "scripts": {
+    "smoke": "node index.cjs"
+  },
+  "dependencies": {
+    "image-drop-input": "file:../../.artifacts/image-drop-input.tgz",
+    "react": "18.2.0"
+  }
+}

--- a/consumer-fixtures/root-types/package.json
+++ b/consumer-fixtures/root-types/package.json
@@ -1,0 +1,15 @@
+{
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "image-drop-input": "file:../../.artifacts/image-drop-input.tgz",
+    "react": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "18.2.79",
+    "typescript": "5.6.3"
+  }
+}

--- a/consumer-fixtures/root-types/src/index.tsx
+++ b/consumer-fixtures/root-types/src/index.tsx
@@ -1,0 +1,19 @@
+import {
+  ImageDropInput,
+  type ImageDropInputProps,
+  type ImageUploadValue
+} from 'image-drop-input';
+import 'image-drop-input/style.css';
+
+const value: ImageUploadValue | null = null;
+
+const props: ImageDropInputProps = {
+  value,
+  onChange(nextValue) {
+    void nextValue;
+  }
+};
+
+const node = <ImageDropInput {...props} />;
+
+void node;

--- a/consumer-fixtures/root-types/tsconfig.json
+++ b/consumer-fixtures/root-types/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": [
+      "DOM",
+      "DOM.Iterable",
+      "ES2020"
+    ],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "noUncheckedSideEffectImports": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "vitest": "^4.1.2"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=18.18.0"
       },
       "peerDependencies": {
         "react": "^18.2.0 || ^19.0.0"

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
   },
   "packageManager": "npm@11.10.1",
   "engines": {
-    "node": ">=20"
+    "node": ">=18.18.0"
   },
   "workspaces": [
     "examples/*"
@@ -93,6 +93,10 @@
     "prepublishOnly": "npm run check:package",
     "release:prepare": "node scripts/prepare-release.mjs",
     "verify": "npm run typecheck && npm test && npm run build:examples && npm run check:package",
+    "pack:consumer-smoke": "npm run build:lib && node scripts/prepare-consumer-smoke-artifact.mjs",
+    "smoke:consumer:root-types": "npm install --prefix consumer-fixtures/root-types --no-package-lock && npm run typecheck --prefix consumer-fixtures/root-types",
+    "smoke:consumer:headless-cjs": "npm install --prefix consumer-fixtures/headless-cjs --no-package-lock && npm run smoke --prefix consumer-fixtures/headless-cjs",
+    "smoke:consumer": "npm run pack:consumer-smoke && npm run smoke:consumer:root-types && npm run smoke:consumer:headless-cjs",
     "publish:check": "npm pack --dry-run",
     "release:pr:check": "npm run verify && npm run publish:check",
     "typecheck:examples": "npm run typecheck --workspace examples/vite && npm run typecheck --workspace examples/rsbuild",

--- a/scripts/prepare-consumer-smoke-artifact.mjs
+++ b/scripts/prepare-consumer-smoke-artifact.mjs
@@ -1,0 +1,43 @@
+import { execFileSync } from 'node:child_process';
+import { mkdirSync, renameSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const artifactsDir = fileURLToPath(new URL('../.artifacts/', import.meta.url));
+const fixedTarballName = 'image-drop-input.tgz';
+
+rmSync(artifactsDir, {
+  force: true,
+  recursive: true
+});
+mkdirSync(artifactsDir, {
+  recursive: true
+});
+
+const packOutput = execFileSync(
+  'npm',
+  [
+    'pack',
+    '--json',
+    '--silent',
+    '--ignore-scripts',
+    '--pack-destination',
+    artifactsDir
+  ],
+  {
+    encoding: 'utf8'
+  }
+);
+const packResult = JSON.parse(packOutput);
+const tarballName = packResult[0]?.filename;
+
+if (!tarballName) {
+  throw new Error('npm pack did not return a tarball filename.');
+}
+
+const sourcePath = join(artifactsDir, tarballName);
+const targetPath = join(artifactsDir, fixedTarballName);
+
+renameSync(sourcePath, targetPath);
+
+console.log(`Prepared ${targetPath}`);


### PR DESCRIPTION
## Summary

- Split CI into maintainer verification, packed artifact creation, and consumer smoke jobs.
- Add packed-tarball consumer fixtures for root TypeScript imports, CSS subpath resolution, and headless CJS loading.
- Document the maintainer toolchain separately from the published package consumer floor.
- Lower `engines.node` to `>=18.18.0` based on packed tarball smoke coverage.

## Validation

- `npm run smoke:consumer`
- `npm run verify`
- `npx -y -p node@18.18.0 -p npm@9.8.1 npm run typecheck --prefix consumer-fixtures/root-types`
- `npx -y -p node@18.18.0 -p npm@9.8.1 npm run smoke --prefix consumer-fixtures/headless-cjs`