### PR TITLE
chore: add trusted publishing release safeguards

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -15,6 +15,7 @@
 ## Checks
 
 - [ ] `package.json` and `package-lock.json` carry the intended version
+- [ ] `CHANGELOG.md` includes the release-facing notes
 - [ ] release-facing notes are included in the PR body
 - [ ] `npm run verify`
 - [ ] `npm run publish:check`
@@ -22,9 +23,14 @@
 
 ## Publish Plan
 
+- [ ] npm Trusted Publisher is configured for `mt4110/image-drop-input`, workflow filename `release.yml`, and environment `npm-publish`
 - [ ] merge to `main`
 - [ ] run the `Release` workflow from `main`
 - [ ] leave `publish` off for rehearsal, then rerun with `publish` on
+- [ ] confirm the publish job used the `npm-publish` environment
+- [ ] confirm npm provenance is visible for the published version
+- [ ] after the first trusted publish, revoke the old npm automation token
+- [ ] after the first trusted publish, enable npm publishing access that requires 2FA and disallows tokens
 
 ## Notes
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,10 +39,19 @@ jobs:
 
       - run: npm --version
       - run: npm ci
-      - run: npm run typecheck
-      - run: npm test
-      - run: npm run build:examples
-      - run: npm run check:package
+      - run: npm run release:pr:check
+
+      - name: Pack publish artifact
+        run: |
+          mkdir -p .artifacts
+          npm pack --pack-destination .artifacts
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: npm-package
+          path: .artifacts/*.tgz
+          if-no-files-found: error
+          retention-days: 7
 
   publish:
     needs: verify
@@ -71,5 +80,11 @@ jobs:
 
       - run: npm --version
       - run: npm ci
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: npm-package
+          path: .artifacts
+
       - name: Publish to npm
-        run: npm publish --access public
+        run: npm publish .artifacts/*.tgz --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,14 +12,14 @@ on:
         default: false
         type: boolean
 
+env:
+  NODE_VERSION: 22.14.0
+
 jobs:
-  publish:
+  verify:
     runs-on: ubuntu-latest
-    env:
-      NODE_VERSION: 22
     permissions:
       contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@v4
 
@@ -43,7 +43,33 @@ jobs:
       - run: npm test
       - run: npm run build:examples
       - run: npm run check:package
-      - run: npm publish --access public
-        if: ${{ github.event_name == 'release' || inputs.publish == true || inputs.publish == 'true' }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  publish:
+    needs: verify
+    if: ${{ github.event_name == 'release' || github.event.inputs.publish == 'true' }}
+    runs-on: ubuntu-latest
+    environment: npm-publish
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: https://registry.npmjs.org
+          cache: npm
+
+      - name: Resolve npm version from packageManager
+        run: |
+          NPM_VERSION="$(node -p 'require("./package.json").packageManager.split("@")[1]')"
+          echo "NPM_VERSION=${NPM_VERSION}" >> "$GITHUB_ENV"
+
+      - name: Install pinned npm
+        run: npm install --global "npm@${NPM_VERSION}"
+
+      - run: npm --version
+      - run: npm ci
+      - name: Publish to npm
+        run: npm publish --access public

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+Notable changes for `image-drop-input` are tracked here.
+
+## Unreleased
+
+### Added
+
+- Added packed-package consumer smoke checks for the supported Node install floor.
+- Added tokenless npm trusted publishing release documentation, provenance verification steps, and a security policy.
+
+### Changed
+
+- Changed the release workflow to publish through npm Trusted Publishing instead of a long-lived npm token.
+- Changed the release PR checklist to include changelog, trusted publisher, provenance, and token revocation checks.
+
+### Fixed
+
+- Fixed GitHub Pages publishing to use the prepared Pages artifact.
+
+## 0.2.0 - 2026-04-24
+
+### Added
+
+- Added the public `image-drop-input` package with React UI, headless utilities, validation, transforms, and upload adapters.
+- Added Vite and Rsbuild examples plus package docs and upload recipes.
+
+### Changed
+
+- Positioned the package around a single product image field with explicit pre-upload state boundaries.
+- Kept React as a peer dependency and cloud SDKs out of the bundle.
+
+### Fixed
+
+- Hardened upload retry, progress, cancellation, validation guard, and filled dropzone interaction behavior before the release.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -3,6 +3,43 @@
 `image-drop-input` is the package that ships today.
 `web-image-prep` stays out of the release lane for now.
 
+## Release trust model
+
+The release workflow publishes with npm Trusted Publishing from GitHub Actions.
+The publish job uses OIDC through `id-token: write`; it does not use `NPM_TOKEN` or `NODE_AUTH_TOKEN`.
+
+Trusted publishing currently requires npm CLI `11.5.1` or newer and Node `22.14.0` or newer.
+This repository pins npm through `packageManager` and pins the release workflow to Node `22.14.0`.
+
+When a public package is published from this public repository through trusted publishing, npm generates provenance automatically.
+Do not add `--provenance` to the publish command unless npm changes that guidance.
+
+## One-time npm trusted publisher setup
+
+Before the first tokenless publish, configure the package on npmjs.com:
+
+1. Open the package settings for `image-drop-input`.
+2. Open **Trusted Publisher**.
+3. Choose **GitHub Actions**.
+4. Set **Organization or user** to `mt4110`.
+5. Set **Repository** to `image-drop-input`.
+6. Set **Workflow filename** to `release.yml`.
+7. Set **Environment name** to `npm-publish`.
+8. Save the trusted publisher configuration.
+9. Run the GitHub `Release` workflow from `main` with `publish` off as a rehearsal.
+10. Run the workflow again with `publish` on and confirm the publish succeeds.
+11. After a successful trusted publish, open package settings -> **Publishing access** and enable **Require two-factor authentication and disallow tokens**.
+12. Revoke the old automation publish token.
+
+Important details:
+
+- The npm workflow field is the filename only: `release.yml`, not `.github/workflows/release.yml`.
+- The trusted publisher fields are case-sensitive.
+- The npm environment field must match the GitHub Actions job environment: `npm-publish`.
+- The workflow must run on GitHub-hosted runners; self-hosted runners are not supported for this release path.
+- Publishing from a fork can fail if `package.json` `repository.url` does not exactly match the repository configured on npm.
+- Trusted publishing only covers `npm publish`. If this repo later adds private npm dependencies, installs may need a separate read-only token.
+
 ## Why not Changesets yet
 
 Changesets is a strong fit when the package being versioned lives under the workspace graph.
@@ -32,7 +69,7 @@ Use these sources for context:
    ```
 
 3. Add release-facing notes to the release PR body.
-   If this repository later adds a `CHANGELOG.md`, update it in the same PR.
+   Update `CHANGELOG.md` in the same PR.
 
 4. Open a pull request with the `Release` template.
    Use a short release branch and a neutral title such as `release/0.2.0` and `release: 0.2.0`.
@@ -40,12 +77,21 @@ Use these sources for context:
 
 5. After the release PR is merged to `main`, run the GitHub `Release` workflow:
 
-   - first with `publish` turned off for a rehearsal
-   - then with `publish` turned on for the real publish
+   - first with `publish` turned off for a rehearsal; this runs the verification job only
+   - then with `publish` turned on for the real publish; this enters the `npm-publish` environment and publishes with OIDC
+
+6. After publishing, check the npm package page:
+
+   - the expected version is live
+   - provenance is visible for the published version
+   - the provenance details point back to the expected GitHub workflow run
+
+For local verification, `npm audit signatures` can also be used from a project that installs the package version being checked.
 
 ## Runtime support checks
 
 The repo maintainer toolchain is Node 22.x with the npm version pinned by `packageManager`.
+The release workflow uses Node `22.14.0` so trusted publishing always has the required Node floor.
 The published package consumer floor is Node `>=18.18.0`.
 
 Before publishing, keep both lanes green:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -77,8 +77,8 @@ Use these sources for context:
 
 5. After the release PR is merged to `main`, run the GitHub `Release` workflow:
 
-   - first with `publish` turned off for a rehearsal; this runs the verification job only
-   - then with `publish` turned on for the real publish; this enters the `npm-publish` environment and publishes with OIDC
+   - first with `publish` turned off for a rehearsal; this runs the verification job and stores the checked package tarball as a short-lived workflow artifact
+   - then with `publish` turned on for the real publish; this enters the `npm-publish` environment and publishes that verified tarball with OIDC
 
 6. After publishing, check the npm package page:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes target the latest minor release line.
+If a fix lands before the next package release, it is prepared on `main` and shipped in the next release.
+
+## Reporting a Vulnerability
+
+Please do not open a public issue for a suspected vulnerability.
+Use GitHub private vulnerability reporting for this repository when it is available.
+If private reporting is not available, contact the maintainer privately before sharing exploit details in public.
+
+Include the affected package version, a minimal reproduction, impact, and any known workarounds.
+Reports that avoid public proof-of-concept exploit details are much easier to handle safely.
+
+## Publishing and Supply Chain
+
+Releases are published from `.github/workflows/release.yml` on GitHub-hosted runners using npm Trusted Publishing.
+The publish job uses GitHub OIDC with `id-token: write` and does not require a long-lived npm publish token.
+
+For public publishes from this public repository, npm provenance is generated automatically by trusted publishing.
+After the first successful trusted publish, the npm package should be configured to require two-factor authentication and disallow token publishing, and any old automation publish token should be revoked.
+
+## Product Security Boundaries
+
+The package keeps storage credentials and provider SDKs out of the client bundle.
+Signed upload URLs must be created by the consuming application backend.
+The package also does not infer a public URL from a signed upload URL; callers must provide a `publicUrl` or storage object key explicitly.
+
+Temporary `blob:` preview URLs are UI state only and should not be persisted as saved product data.

--- a/scripts/prepare-release.mjs
+++ b/scripts/prepare-release.mjs
@@ -21,6 +21,6 @@ const nextVersion = packageJson.version;
 console.log('');
 console.log(`Prepared release version ${nextVersion}.`);
 console.log('Next steps:');
-console.log('  1. Review package.json and package-lock.json.');
+console.log('  1. Review package.json, package-lock.json, and CHANGELOG.md.');
 console.log('  2. Run: npm run release:pr:check');
 console.log(`  3. Open a release PR with the Release template and a neutral title like \`release: ${nextVersion}\`.`);


### PR DESCRIPTION
## Summary

- Move the release workflow to tokenless npm Trusted Publishing with Node 22.14.0, `id-token: write`, and the `npm-publish` environment.
- Document the one-time npm Trusted Publisher setup, provenance checks, token revocation, and publishing access hardening.
- Add `SECURITY.md` and `CHANGELOG.md`, and update the release PR checklist and release prepare next steps.

## Checks

- [x] `git diff --check`
- [x] `actionlint`
- [x] `npm run release:pr:check`

## Manual follow-up

- Configure npm Trusted Publisher for `mt4110/image-drop-input` with workflow filename `release.yml` and environment `npm-publish` before the first tokenless publish.
- After the first successful trusted publish, confirm npm provenance, revoke the old automation token, and enable publishing access that requires 2FA and disallows tokens.