### PR TITLE
chore: sync package face release checks

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -17,8 +17,8 @@
 - [ ] `package.json` and `package-lock.json` carry the intended version
 - [ ] `CHANGELOG.md` includes the release-facing notes
 - [ ] release-facing notes are included in the PR body
-- [ ] `npm run verify`
-- [ ] `npm run publish:check`
+- [ ] `npm run release:pr:check`
+- [ ] packed package contains the English canonical `README.md`, docs, license, dist files, and no local-only files
 - [ ] demo still looks right in the consumer you care about
 
 ## Publish Plan
@@ -28,6 +28,7 @@
 - [ ] run the `Release` workflow from `main`
 - [ ] leave `publish` off for rehearsal, then rerun with `publish` on
 - [ ] confirm the publish job used the `npm-publish` environment
+- [ ] confirm the npm package page version, README face, homepage, repository, bugs, docs link, and install snippet
 - [ ] confirm npm provenance is visible for the published version
 - [ ] after the first trusted publish, revoke the old npm automation token
 - [ ] after the first trusted publish, enable npm publishing access that requires 2FA and disallows tokens

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ npm test
 npm run build:lib
 npm run build:examples
 npm run check:package
-npm pack --dry-run
+npm run publish:check
 ```
 
 Release planning stays outside the npm package, so this README can stay focused on what works today.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -68,6 +68,9 @@ Use these sources for context:
    npm run release:pr:check
    ```
 
+   This includes the packed package face check: `npm pack --json --dry-run`, README inclusion,
+   package metadata links, and deny-list validation for files that must stay out of the published tarball.
+
 3. Add release-facing notes to the release PR body.
    Update `CHANGELOG.md` in the same PR.
 
@@ -82,7 +85,13 @@ Use these sources for context:
 
 6. After publishing, check the npm package page:
 
-   - the expected version is live
+   - the expected version matches `package.json` on `main`
+   - the README shown by npm starts with the English canonical face from `README.md`
+   - the install snippet is `npm install image-drop-input react`
+   - the homepage link opens the GitHub Pages demo
+   - the repository link opens `mt4110/image-drop-input`
+   - the bugs link opens the GitHub issue tracker
+   - the docs link from the README opens successfully
    - provenance is visible for the published version
    - the provenance details point back to the expected GitHub workflow run
 

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "smoke:consumer:root-types": "npm install --prefix consumer-fixtures/root-types --no-package-lock && npm run typecheck --prefix consumer-fixtures/root-types",
     "smoke:consumer:headless-cjs": "npm install --prefix consumer-fixtures/headless-cjs --no-package-lock && npm run smoke --prefix consumer-fixtures/headless-cjs",
     "smoke:consumer": "npm run pack:consumer-smoke && npm run smoke:consumer:root-types && npm run smoke:consumer:headless-cjs",
-    "publish:check": "npm pack --dry-run",
+    "publish:check": "node scripts/verify-pack-manifest.mjs",
     "release:pr:check": "npm run verify && npm run publish:check",
     "typecheck:examples": "npm run typecheck --workspace examples/vite && npm run typecheck --workspace examples/rsbuild",
     "typecheck": "tsc -p tsconfig.json --noEmit && npm run build:lib && npm run typecheck:examples",

--- a/scripts/prepare-release.mjs
+++ b/scripts/prepare-release.mjs
@@ -24,3 +24,4 @@ console.log('Next steps:');
 console.log('  1. Review package.json, package-lock.json, and CHANGELOG.md.');
 console.log('  2. Run: npm run release:pr:check');
 console.log(`  3. Open a release PR with the Release template and a neutral title like \`release: ${nextVersion}\`.`);
+console.log('  4. Follow RELEASING.md for the trusted publish rehearsal, publish run, and npm page check.');

--- a/scripts/verify-pack-manifest.mjs
+++ b/scripts/verify-pack-manifest.mjs
@@ -20,7 +20,7 @@ const expectedMetadata = [
 const requiredFiles = ['LICENSE', 'README.md', 'README.ja.md', 'package.json'];
 const requiredPrefixes = ['dist/', 'docs/'];
 const allowedFiles = new Set(requiredFiles);
-const allowedPrefixes = ['dist/', 'docs/'];
+const allowedPrefixes = requiredPrefixes;
 const deniedFiles = new Set([
   'OSS_FOUNDATION_PLAN.md',
   'README_en.md',
@@ -194,9 +194,7 @@ function verifyFiles(files) {
   for (const file of files) {
     if (isDeniedPackPath(file)) {
       fail(`Packed package must not include ${file}.`);
-    }
-
-    if (!isAllowedPackPath(file)) {
+    } else if (!isAllowedPackPath(file)) {
       fail(`Packed package includes unexpected file: ${file}.`);
     }
   }

--- a/scripts/verify-pack-manifest.mjs
+++ b/scripts/verify-pack-manifest.mjs
@@ -1,0 +1,243 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const npmExecutable = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const packageJsonPath = resolve(process.cwd(), 'package.json');
+const readmePath = resolve(process.cwd(), 'README.md');
+const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+const expectedTarballFilename = `${packageJson.name}-${packageJson.version}.tgz`;
+const expectedMetadata = [
+  ['homepage', packageJson.homepage, 'https://mt4110.github.io/image-drop-input/'],
+  ['repository.type', packageJson.repository?.type, 'git'],
+  [
+    'repository.url',
+    packageJson.repository?.url,
+    'git+https://github.com/mt4110/image-drop-input.git'
+  ],
+  ['bugs.url', packageJson.bugs?.url, 'https://github.com/mt4110/image-drop-input/issues']
+];
+const requiredFiles = ['LICENSE', 'README.md', 'README.ja.md', 'package.json'];
+const requiredPrefixes = ['dist/', 'docs/'];
+const allowedFiles = new Set(requiredFiles);
+const allowedPrefixes = ['dist/', 'docs/'];
+const deniedFiles = new Set([
+  'OSS_FOUNDATION_PLAN.md',
+  'README_en.md',
+  'REPO_PLAN.md',
+  'ROADMAP.md'
+]);
+const deniedPrefixes = [
+  '.github/',
+  '.private_docs/',
+  'examples/',
+  'meta/',
+  'tests/'
+];
+const deniedPatterns = [
+  /\.zip$/i,
+  /\.tgz$/i,
+  /\.tar$/i,
+  /\.tmp$/i,
+  /\.temp$/i,
+  /\.bak$/i,
+  /\.log$/i,
+  /~$/,
+  /(^|\/)\.DS_Store$/i,
+  /(^|\/)npm-debug\.log/i,
+  /(^|\/)(tmp|temp|\.tmp|\.temp)(\/|$)/i,
+  /(^|\/)(screenshot|screenshots|screen-shot)(\/|$)/i,
+  /(^|\/)Screen Shot \d{4}/i
+];
+const canonicalReadmeTitle = '# image-drop-input';
+const canonicalReadmeSummary =
+  'Preview, validate, compress, and upload a single image safely before your form ever submits.';
+const failures = [];
+
+function fail(message) {
+  failures.push(message);
+}
+
+function parsePackOutput(output) {
+  const jsonMatch = output.match(/(\[\s*(?:\{[\s\S]*\}\s*)?\])\s*$/);
+
+  if (!jsonMatch) {
+    fail('npm pack did not return a parseable JSON payload.');
+    return undefined;
+  }
+
+  try {
+    const parsed = JSON.parse(jsonMatch[1]);
+
+    if (!Array.isArray(parsed)) {
+      fail('npm pack did not return a JSON array.');
+      return undefined;
+    }
+
+    if (parsed.length !== 1) {
+      fail(`Expected npm pack to return one manifest, received ${parsed.length}.`);
+      return undefined;
+    }
+
+    if (!parsed[0] || typeof parsed[0] !== 'object') {
+      fail('npm pack returned an invalid manifest entry.');
+      return undefined;
+    }
+
+    return parsed[0];
+  } catch (error) {
+    fail(`npm pack returned invalid JSON: ${error.message}`);
+    return undefined;
+  }
+}
+
+function getPackedFilePaths(packResult) {
+  if (!Array.isArray(packResult.files)) {
+    fail('Expected npm pack manifest to include a files array.');
+    return new Set();
+  }
+
+  const files = new Set();
+
+  for (const [index, file] of packResult.files.entries()) {
+    if (!file?.path || typeof file.path !== 'string') {
+      fail(`Expected npm pack file entry ${index} to include a string path.`);
+      continue;
+    }
+
+    files.add(file.path);
+  }
+
+  return files;
+}
+
+function isAllowedPackPath(path) {
+  return allowedFiles.has(path) || allowedPrefixes.some((prefix) => path.startsWith(prefix));
+}
+
+function isDeniedPackPath(path) {
+  return (
+    deniedFiles.has(path) ||
+    deniedPrefixes.some((prefix) => path.startsWith(prefix)) ||
+    deniedPatterns.some((pattern) => pattern.test(path))
+  );
+}
+
+function verifyPackMetadata(packResult) {
+  if (packResult.name !== packageJson.name) {
+    fail(
+      `Expected package name ${packageJson.name}, received ${
+        packResult.name ?? '(missing)'
+      }.`
+    );
+  }
+
+  if (packResult.version !== packageJson.version) {
+    fail(
+      `Expected package version ${packageJson.version}, received ${
+        packResult.version ?? '(missing)'
+      }.`
+    );
+  }
+
+  if (packResult.filename !== expectedTarballFilename) {
+    fail(
+      `Expected tarball filename ${expectedTarballFilename}, received ${
+        packResult.filename ?? '(missing)'
+      }.`
+    );
+  }
+}
+
+function verifyPackageJsonMetadata() {
+  for (const [field, actual, expected] of expectedMetadata) {
+    if (actual !== expected) {
+      fail(
+        `Expected package.json ${field} to be ${expected}, received ${
+          actual ?? '(missing)'
+        }.`
+      );
+    }
+  }
+}
+
+function verifyReadmeFace(files) {
+  if (!files.has('README.md')) {
+    fail('Expected README.md to be included in the packed package.');
+    return;
+  }
+
+  const firstLines = readFileSync(readmePath, 'utf8').split(/\r?\n/).slice(0, 12);
+
+  if (firstLines[0] !== canonicalReadmeTitle) {
+    fail(`Expected README.md to start with the English canonical title: ${canonicalReadmeTitle}`);
+  }
+
+  if (!firstLines.includes(canonicalReadmeSummary)) {
+    fail('Expected README.md opening lines to include the English canonical summary.');
+  }
+}
+
+function verifyFiles(files) {
+  for (const file of requiredFiles) {
+    if (!files.has(file)) {
+      fail(`Expected ${file} to be included in the packed package.`);
+    }
+  }
+
+  for (const prefix of requiredPrefixes) {
+    if (![...files].some((file) => file.startsWith(prefix))) {
+      fail(`Expected at least one ${prefix} file to be included in the packed package.`);
+    }
+  }
+
+  for (const file of files) {
+    if (isDeniedPackPath(file)) {
+      fail(`Packed package must not include ${file}.`);
+    }
+
+    if (!isAllowedPackPath(file)) {
+      fail(`Packed package includes unexpected file: ${file}.`);
+    }
+  }
+}
+
+let packOutput = '';
+
+try {
+  packOutput = execFileSync(npmExecutable, ['pack', '--json', '--dry-run'], {
+    encoding: 'utf8'
+  });
+} catch (error) {
+  process.stdout.write(error.stdout ?? '');
+  process.stderr.write(error.stderr ?? '');
+  process.exit(error.status ?? 1);
+}
+
+const packResult = parsePackOutput(packOutput);
+
+if (packResult) {
+  const files = getPackedFilePaths(packResult);
+
+  verifyPackMetadata(packResult);
+  verifyPackageJsonMetadata();
+  verifyFiles(files);
+  verifyReadmeFace(files);
+
+  if (failures.length === 0) {
+    console.log(
+      `Verified pack manifest for ${packageJson.name}@${packageJson.version}: ` +
+        `${files.size} files, ${packResult.filename}.`
+    );
+  }
+}
+
+if (failures.length > 0) {
+  console.error('Package manifest verification failed:');
+
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+
+  process.exit(1);
+}

--- a/scripts/verify-pack-manifest.mjs
+++ b/scripts/verify-pack-manifest.mjs
@@ -3,6 +3,12 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 const npmExecutable = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const npmPackArgs = ['pack', '--json', '--dry-run', '--workspaces=false'];
+const npmWorkspaceConfigKeys = new Set([
+  'npm_config_include_workspace_root',
+  'npm_config_workspace',
+  'npm_config_workspaces'
+]);
 const packageJsonPath = resolve(process.cwd(), 'package.json');
 const readmePath = resolve(process.cwd(), 'README.md');
 const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
@@ -56,6 +62,18 @@ const failures = [];
 
 function fail(message) {
   failures.push(message);
+}
+
+function getRootPackEnv() {
+  const env = { ...process.env };
+
+  for (const key of Object.keys(env)) {
+    if (npmWorkspaceConfigKeys.has(key.toLowerCase())) {
+      delete env[key];
+    }
+  }
+
+  return env;
 }
 
 function parsePackOutput(output) {
@@ -203,8 +221,9 @@ function verifyFiles(files) {
 let packOutput = '';
 
 try {
-  packOutput = execFileSync(npmExecutable, ['pack', '--json', '--dry-run'], {
-    encoding: 'utf8'
+  packOutput = execFileSync(npmExecutable, npmPackArgs, {
+    encoding: 'utf8',
+    env: getRootPackEnv()
   });
 } catch (error) {
   process.stdout.write(error.stdout ?? '');


### PR DESCRIPTION
## Summary

- Add a pack manifest verifier that parses `npm pack --json --dry-run` and checks the public package face.
- Wire `publish:check` into the verifier so `release:pr:check` catches packed artifact drift before release.
- Update release docs and the release PR template with npm page verification steps after publish.

## Validation

- `npm run release:pr:check`
- `git diff --check`

## Notes

- No publish was performed.
- No runtime dependencies or public API changes were added.