### PR TITLE
P1-05: Add adoption signal issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,108 @@
+name: Bug report
+description: Report a reproducible problem with image-drop-input.
+title: "bug: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please keep the reproduction small and include the environment where it fails.
+  - type: input
+    id: package-version
+    attributes:
+      label: Package version
+      description: The installed image-drop-input version.
+      placeholder: "0.2.x"
+    validations:
+      required: true
+  - type: input
+    id: react-version
+    attributes:
+      label: React version
+      placeholder: "18.3.1 or 19.0.0"
+    validations:
+      required: true
+  - type: input
+    id: framework-bundler
+    attributes:
+      label: Framework or bundler
+      description: Include the version when it matters.
+      placeholder: "Next.js 15, Vite 6, Rsbuild, Remix, plain React..."
+    validations:
+      required: true
+  - type: input
+    id: node-version
+    attributes:
+      label: Node version
+      placeholder: "20.18.1"
+    validations:
+      required: true
+  - type: input
+    id: browser
+    attributes:
+      label: Browser
+      placeholder: "Safari 18, Chrome 131, Firefox 133..."
+    validations:
+      required: true
+  - type: dropdown
+    id: upload-pattern
+    attributes:
+      label: Upload pattern
+      options:
+        - Local preview only
+        - Presigned PUT
+        - Multipart POST
+        - Raw PUT
+        - Custom adapter
+        - Not sure yet
+    validations:
+      required: true
+  - type: input
+    id: reproduction
+    attributes:
+      label: Reproduction repo or sandbox
+      description: A minimal reproduction is the fastest path to a fix.
+      placeholder: "https://github.com/you/minimal-repro"
+    validations:
+      required: false
+  - type: textarea
+    id: steps
+    attributes:
+      label: Minimal steps to reproduce
+      description: Include the smallest component or code path that triggers the problem.
+      placeholder: |
+        1. Render ImageDropInput with ...
+        2. Drop a ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: dropdown
+    id: regression
+    attributes:
+      label: Is this a regression?
+      options:
+        - Not sure
+        - "No"
+        - "Yes"
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional context
+      description: Logs, screenshots, storage provider details, or related constraints.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/mt4110/image-drop-input/security/policy
+    about: Please do not open a public issue for suspected vulnerabilities.
+  - name: Documentation and recipes
+    url: https://github.com/mt4110/image-drop-input/tree/main/docs
+    about: Check the docs and recipes before opening a new issue.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,80 @@
+name: Feature request
+description: Request an improvement tied to a real image input workflow.
+title: "feature: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement. Please describe the product workflow first; that makes it easier to keep the API small and predictable.
+  - type: dropdown
+    id: use-case
+    attributes:
+      label: Use case
+      options:
+        - Avatar
+        - CMS cover
+        - Thumbnail
+        - Admin form
+        - Product image
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: framework-bundler
+    attributes:
+      label: Framework or bundler
+      placeholder: "Next.js, Vite, Rsbuild, Remix, plain React..."
+    validations:
+      required: false
+  - type: dropdown
+    id: upload-pattern
+    attributes:
+      label: Upload pattern
+      options:
+        - Local preview only
+        - Presigned PUT
+        - Multipart POST
+        - Raw PUT
+        - Custom adapter
+        - Not sure yet
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What is hard, missing, or too easy to get wrong today?
+    validations:
+      required: true
+  - type: textarea
+    id: requested-behavior
+    attributes:
+      label: Requested behavior
+      description: Describe the smallest change that would help.
+    validations:
+      required: true
+  - type: textarea
+    id: workaround
+    attributes:
+      label: Current workaround
+      description: If you have one, share the code shape or docs you are leaning on now.
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Include libraries, local helpers, or API shapes you tried.
+    validations:
+      required: false
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Scope check
+      options:
+        - label: This request is for a single-image input workflow.
+          required: true
+        - label: This request does not require adding a cloud SDK to the runtime bundle.
+          required: true

--- a/.github/ISSUE_TEMPLATE/usage-report.yml
+++ b/.github/ISSUE_TEMPLATE/usage-report.yml
@@ -1,0 +1,96 @@
+name: Usage report
+description: Share real-world usage signals for product prioritization.
+title: "usage: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for sharing how image-drop-input is being used. These reports help prioritize docs, compatibility, and release polish. They are product signals, not a showcase requirement.
+  - type: dropdown
+    id: use-case
+    attributes:
+      label: Use case
+      options:
+        - Avatar
+        - CMS cover
+        - Thumbnail
+        - Admin form
+        - Product image
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: framework-bundler
+    attributes:
+      label: Framework or bundler
+      placeholder: "Next.js, Vite, Rsbuild, Remix, plain React..."
+    validations:
+      required: true
+  - type: dropdown
+    id: integration-mode
+    attributes:
+      label: Integration mode
+      options:
+        - Local preview only
+        - Upload after prepare
+        - Both local preview and upload
+        - Evaluating
+    validations:
+      required: true
+  - type: dropdown
+    id: upload-pattern
+    attributes:
+      label: Upload pattern
+      options:
+        - Local preview only
+        - Presigned PUT
+        - Multipart POST
+        - Raw PUT
+        - Custom adapter
+        - Not sure yet
+    validations:
+      required: true
+  - type: textarea
+    id: what-worked
+    attributes:
+      label: What worked well?
+      description: Short notes are fine. Focus on concrete integration details.
+    validations:
+      required: false
+  - type: textarea
+    id: pain-points
+    attributes:
+      label: Pain points, missing docs, or adoption blockers
+      description: What slowed adoption, caused uncertainty, or needed extra local code? Leave this blank if nothing blocked you.
+    validations:
+      required: false
+  - type: input
+    id: project-name
+    attributes:
+      label: Company or project name
+      description: Optional. Leave blank if the project should stay private.
+    validations:
+      required: false
+  - type: input
+    id: website-url
+    attributes:
+      label: Website URL
+      description: Optional. Share only if it is public and appropriate.
+      placeholder: "https://example.com"
+    validations:
+      required: false
+  - type: checkboxes
+    id: public-quotation
+    attributes:
+      label: Public quotation permission
+      description: GitHub issues are public. This controls whether maintainers may quote the report elsewhere.
+      options:
+        - label: Maintainers may quote this report publicly, using only the company/project name and URL I provided above.
+          required: false
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional context
+      description: Anything else that would help prioritize docs, compatibility, or release polish.
+    validations:
+      required: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,13 +11,27 @@ This project is intentionally small in scope:
 
 ## Before you start
 
-- open an issue for bug reports and concrete feature requests
-- use GitHub Discussions for broad ideas or usage questions if Discussions are enabled
+- use the bug report form for reproducible defects
+- use the feature request form for concrete product workflow improvements
+- use the usage report form to share real integration signals
+- do not open a public issue for suspected security vulnerabilities
 - open an issue first for larger concrete changes
 - keep pull requests focused
 - prefer the existing API and design language over new abstraction layers
 
 Please keep issues, pull requests, and review calm, respectful, and specific.
+
+## Issues and usage reports
+
+[Bug reports](https://github.com/mt4110/image-drop-input/issues/new?template=bug-report.yml) should include package, React, framework or bundler, Node, browser, upload pattern, expected behavior, actual behavior, and a minimal reproduction when possible.
+
+[Feature requests](https://github.com/mt4110/image-drop-input/issues/new?template=feature-request.yml) should start from the product workflow: what the image field needs to do, what is hard today, and the smallest behavior change that would help.
+
+[Usage reports](https://github.com/mt4110/image-drop-input/issues/new?template=usage-report.yml) are welcome when you are using or evaluating the package in a real product. They are product signal intake, not testimonial collection. Useful signals include use case, framework or bundler, local-preview-only versus upload integration, upload pattern, missing docs, and adoption blockers.
+
+Public quotation from a usage report is opt-in. Company name, project name, and website URL are optional.
+
+For suspected security vulnerabilities, do not open a public issue. Follow [SECURITY.md](./SECURITY.md) and share exploit details privately.
 
 ## Local setup
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Preview, validate, compress, and upload a single image safely before your form e
 
 **Built for:** avatars, CMS thumbnails, article covers, product images, and admin forms.
 
-[Demo](https://mt4110.github.io/image-drop-input/) · [Docs](./docs/README.md) · [Recipes](#recipes) · [Japanese README](./README.ja.md) · [Issues](https://github.com/mt4110/image-drop-input/issues)
+[Demo](https://mt4110.github.io/image-drop-input/) · [Docs](./docs/README.md) · [Recipes](#recipes) · [Usage reports](https://github.com/mt4110/image-drop-input/issues/new?template=usage-report.yml) · [Japanese README](./README.ja.md) · [Issues](https://github.com/mt4110/image-drop-input/issues)
 
 ![image-drop-input demo showing preview, prepared metadata, and upload state](./docs/assets/demo-light.png)
 
@@ -313,6 +313,12 @@ import {
 ```
 
 The root entry stays UI-first. Low-level utilities live under `/headless`.
+
+## Usage reports welcome
+
+Using this package in a real product? Open a [usage report](https://github.com/mt4110/image-drop-input/issues/new?template=usage-report.yml) so docs, compatibility, and release polish can be prioritized from real integrations.
+
+Useful reports include the use case, framework or bundler, upload pattern, and anything that slowed adoption. Public quotation is opt-in.
 
 ## When not to use this
 


### PR DESCRIPTION
## Summary

- Add structured bug report, feature request, and usage report issue forms.
- Add issue template config with security and docs contact links.
- Link usage reports from README and document bug, feature, usage, repro, and security reporting guidance in CONTRIBUTING.

## Why

This creates a lightweight intake path for real product signals without adding analytics, external services, runtime dependencies, or showcase claims.

## Validation

- Issue form YAML parse and lightweight schema checks
- README / CONTRIBUTING issue template link checks
- Existing `bug` and `enhancement` label checks
- `git diff --check`
- `npm run verify`