### PR TITLE
docs: clarify release follow-up checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -21,17 +21,32 @@
 - [ ] packed package contains the English canonical `README.md`, docs, license, dist files, and no local-only files
 - [ ] demo still looks right in the consumer you care about
 
-## Publish Plan
+## Publish Readiness
 
 - [ ] npm Trusted Publisher is configured for `mt4110/image-drop-input`, workflow filename `release.yml`, and environment `npm-publish`
+- [ ] the release workflow uses OIDC for publish and does not depend on `NPM_TOKEN` or `NODE_AUTH_TOKEN`
+
+## Publish Plan
+
 - [ ] merge to `main`
-- [ ] run the `Release` workflow from `main`
-- [ ] leave `publish` off for rehearsal, then rerun with `publish` on
+- [ ] run the `Release` workflow from `main` with `publish` off and confirm the rehearsal passed
+- [ ] rerun the `Release` workflow from `main` with `publish` on
 - [ ] confirm the publish job used the `npm-publish` environment
-- [ ] confirm the npm package page version, README face, homepage, repository, bugs, docs link, and install snippet
-- [ ] confirm npm provenance is visible for the published version
-- [ ] after the first trusted publish, revoke the old npm automation token
-- [ ] after the first trusted publish, enable npm publishing access that requires 2FA and disallows tokens
+
+## Post-publish Checks
+
+- [ ] npm package page version matches `package.json` on `main`
+- [ ] npm package page README starts with the English canonical `README.md`
+- [ ] npm install snippet is `npm install image-drop-input react`
+- [ ] npm homepage link opens the GitHub Pages demo
+- [ ] npm repository link opens `mt4110/image-drop-input`
+- [ ] npm bugs link opens the GitHub issue tracker
+- [ ] docs link from the npm README opens successfully
+- [ ] npm provenance is visible for the published version
+- [ ] npm provenance details point back to the expected GitHub workflow run
+- [ ] if this is the first trusted publish, the old npm automation token is revoked and removed from GitHub Actions secrets or environment secrets
+- [ ] if this is the first trusted publish, npm publishing access requires 2FA and disallows tokens
+- [ ] initial usage report follow-up is linked in Notes or explicitly queued
 
 ## Notes
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -83,7 +83,16 @@ Use these sources for context:
    - first with `publish` turned off for a rehearsal; this runs the verification job and stores the checked package tarball as a short-lived workflow artifact
    - then with `publish` turned on for the real publish; this enters the `npm-publish` environment and publishes that verified tarball with OIDC
 
-6. After publishing, check the npm package page:
+6. After publishing, complete the release follow-up checklist.
+
+   Trusted publishing confirmation:
+
+   - the npm Trusted Publisher UI shows `mt4110/image-drop-input`, workflow filename `release.yml`, and environment `npm-publish`
+   - the rehearsal workflow run from `main` passed with `publish` off
+   - the real publish run entered the `npm-publish` environment
+   - the publish job used OIDC and did not depend on `NPM_TOKEN` or `NODE_AUTH_TOKEN`
+
+   npm package face:
 
    - the expected version matches `package.json` on `main`
    - the README shown by npm starts with the English canonical face from `README.md`
@@ -94,6 +103,20 @@ Use these sources for context:
    - the docs link from the README opens successfully
    - provenance is visible for the published version
    - the provenance details point back to the expected GitHub workflow run
+
+   Token and package settings hardening:
+
+   - revoke the old npm automation token after the first successful trusted publish
+   - remove any old publish token secret from GitHub Actions secrets or environment secrets
+   - enable npm publishing access that requires two-factor authentication and disallows tokens
+   - keep any future read-only install token separate from the publish path
+
+   Usage signal collection:
+
+   - add one self-authored usage report from a real integration
+   - test one integration in another repo you own
+   - ask one or two early users to open a usage report when appropriate
+   - quote only reports that explicitly grant public quotation permission
 
 For local verification, `npm audit signatures` can also be used from a project that installs the package version being checked.
 


### PR DESCRIPTION
## Summary

- Clarifies the release PR template with separate publish readiness, publish plan, and post-publish checks.
- Expands RELEASING.md with trusted publishing confirmation, npm package face checks, token hardening, and initial usage-signal follow-up.

## Why

The v0.2.0 hardening pack is complete. This keeps the remaining release follow-up work explicit without adding new P0/P1 scope or changing runtime behavior.

## Checks

- npm run release:pr:check
- git diff --check

## Notes

- No public API changes.
- No runtime dependency changes.
- Follow-up design work for the next phase should happen separately from this release checklist PR.