### PR TITLE
ci: fix release artifact upload path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,13 +43,13 @@ jobs:
 
       - name: Pack publish artifact
         run: |
-          mkdir -p .artifacts
-          npm pack --pack-destination .artifacts
+          mkdir -p artifacts
+          npm pack --pack-destination artifacts
 
       - uses: actions/upload-artifact@v4
         with:
           name: npm-package
-          path: .artifacts/*.tgz
+          path: artifacts/*.tgz
           if-no-files-found: error
           retention-days: 7
 
@@ -84,7 +84,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: npm-package
-          path: .artifacts
+          path: artifacts
 
       - name: Publish to npm
-        run: npm publish .artifacts/*.tgz --access public
+        run: npm publish artifacts/*.tgz --access public


### PR DESCRIPTION
## Summary

- Changes the release workflow pack directory from `.artifacts` to `artifacts`.
- Keeps the publish job download and `npm publish` path aligned with the new artifact directory.

## Why

`actions/upload-artifact@v4` excludes hidden paths by default, so the rehearsal could pack successfully but fail to upload `.artifacts/*.tgz`.

## Checks

- `npm pack --pack-destination artifacts`
- `git diff --check`

## Notes

- No package runtime changes.
- This unblocks the v0.2.0 release rehearsal and publish workflow.