### PR TITLE
ci: publish release tarball by path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,4 +87,4 @@ jobs:
           path: artifacts
 
       - name: Publish to npm
-        run: npm publish artifacts/*.tgz --access public
+        run: npm publish ./artifacts/*.tgz --access public


### PR DESCRIPTION
## Summary

- Prefixes the release tarball path with `./` in the npm publish step.

## Why

The release publish job downloaded the artifact correctly, but `npm publish artifacts/*.tgz` was interpreted as a git/package spec instead of a local tarball path.

## Checks

- `npm publish ./artifacts/*.tgz --access public --dry-run`
- `git diff --check`

## Notes

- No package runtime changes.
- This unblocks publishing the verified v0.2.0 tarball.