### PR TITLE
Harden upload error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@ Notable changes for `image-drop-input` are tracked here.
 
 - Added packed-package consumer smoke checks for the supported Node install floor.
 - Added tokenless npm trusted publishing release documentation, provenance verification steps, and a security policy.
+- Added `ImageUploadError` and `isImageUploadError()` for structured upload failure handling.
 
 ### Changed
 
 - Changed the release workflow to publish through npm Trusted Publishing instead of a long-lived npm token.
 - Changed the release PR checklist to include changelog, trusted publisher, provenance, and token revocation checks.
+- Split upload session orchestration out of the main React hook internals.
 
 ### Fixed
 

--- a/consumer-fixtures/headless-cjs/index.cjs
+++ b/consumer-fixtures/headless-cjs/index.cjs
@@ -5,6 +5,8 @@ const requiredFunctions = [
   'createMultipartUploader',
   'createPresignedPutUploader',
   'createRawPutUploader',
+  'ImageUploadError',
+  'isImageUploadError',
   'validateImage'
 ];
 
@@ -12,4 +14,14 @@ for (const name of requiredFunctions) {
   if (typeof headless[name] !== 'function') {
     throw new Error(`Expected headless ${name} export.`);
   }
+}
+
+const uploadError = new headless.ImageUploadError(
+  'network_error',
+  'Upload failed due to a network error.',
+  { stage: 'request', method: 'PUT' }
+);
+
+if (!headless.isImageUploadError(uploadError)) {
+  throw new Error('Expected headless isImageUploadError to narrow ImageUploadError.');
 }

--- a/consumer-fixtures/root-types/src/index.tsx
+++ b/consumer-fixtures/root-types/src/index.tsx
@@ -1,9 +1,12 @@
 import {
   ImageDropInput,
   ImageUploadError,
+  ImageValidationError,
   isImageUploadError,
   type ImageDropInputProps,
   type ImageUploadErrorDetails,
+  type ImageUploadErrorOptions,
+  type ImageValidationErrorOptions,
   type ImageUploadValue
 } from 'image-drop-input';
 import 'image-drop-input/style.css';
@@ -23,11 +26,28 @@ const uploadErrorDetails: ImageUploadErrorDetails = {
   method: 'PUT',
   status: 413
 };
+const uploadErrorOptions: ImageUploadErrorOptions = {
+  cause: new Error('upstream rejected')
+};
 const uploadError = new ImageUploadError(
   'http_error',
   'Upload failed: 413 Payload Too Large',
-  uploadErrorDetails
+  uploadErrorDetails,
+  uploadErrorOptions
+);
+const validationErrorOptions: ImageValidationErrorOptions = {
+  cause: uploadError
+};
+const validationError = new ImageValidationError(
+  'decode_failed',
+  'Image metadata could not be read.',
+  {
+    actualBytes: 12,
+    mimeType: 'image/png'
+  },
+  validationErrorOptions
 );
 
 void node;
 void isImageUploadError(uploadError);
+void validationError;

--- a/consumer-fixtures/root-types/src/index.tsx
+++ b/consumer-fixtures/root-types/src/index.tsx
@@ -1,6 +1,9 @@
 import {
   ImageDropInput,
+  ImageUploadError,
+  isImageUploadError,
   type ImageDropInputProps,
+  type ImageUploadErrorDetails,
   type ImageUploadValue
 } from 'image-drop-input';
 import 'image-drop-input/style.css';
@@ -15,5 +18,16 @@ const props: ImageDropInputProps = {
 };
 
 const node = <ImageDropInput {...props} />;
+const uploadErrorDetails: ImageUploadErrorDetails = {
+  stage: 'request',
+  method: 'PUT',
+  status: 413
+};
+const uploadError = new ImageUploadError(
+  'http_error',
+  'Upload failed: 413 Payload Too Large',
+  uploadErrorDetails
+);
 
 void node;
+void isImageUploadError(uploadError);

--- a/consumer-fixtures/root-types/tsconfig.json
+++ b/consumer-fixtures/root-types/tsconfig.json
@@ -11,7 +11,7 @@
     "jsx": "react-jsx",
     "strict": true,
     "noEmit": true,
-    "skipLibCheck": true,
+    "skipLibCheck": false,
     "noUncheckedSideEffectImports": true,
     "verbatimModuleSyntax": true
   },

--- a/docs/uploads.md
+++ b/docs/uploads.md
@@ -152,6 +152,37 @@ Adapters may call `context.onProgress(percent)`.
 
 Successful uploads finish with `100`, even if the adapter did not emit `100` itself.
 
+## Upload errors
+
+Built-in upload helpers throw `ImageUploadError` for package-owned upload failures. The React component still reports errors through `onError(error: Error)`, so existing handlers keep working.
+
+Use `isImageUploadError()` when your product needs localized copy, retry labels, or telemetry tags without parsing English messages.
+
+```ts
+import {
+  isImageUploadError,
+  isImageValidationError
+} from 'image-drop-input';
+
+function toUserMessage(error: Error) {
+  if (isImageValidationError(error)) {
+    return `Image validation failed: ${error.code}`;
+  }
+
+  if (isImageUploadError(error)) {
+    if (error.code === 'http_error' && error.details.status === 413) {
+      return 'This image is too large to upload.';
+    }
+
+    return `Image upload failed: ${error.code}`;
+  }
+
+  return 'Could not prepare this image.';
+}
+```
+
+Upload error details include safe fields such as stage, method, status, response body, and raw response body. They do not include signed upload URLs, request headers, authorization values, or provider credentials.
+
 ## Abort signal
 
 `context.signal` is passed to built-in request helpers. Custom adapters should pass it to `fetch()` or equivalent request code so cancellation works.

--- a/meta/ADOPTION_PROOF.md
+++ b/meta/ADOPTION_PROOF.md
@@ -1,0 +1,67 @@
+# Adoption Proof Log
+
+This file tracks adoption-hardening evidence that is useful to maintainers but should stay out of the published package face.
+
+## 2026-05-01 local packed-consumer proof
+
+The packed tarball was verified with:
+
+```bash
+npm run smoke:consumer
+```
+
+Coverage:
+
+- root TypeScript consumer imports `ImageDropInput`, `ImageUploadError`, `isImageUploadError`, and public types from `image-drop-input`
+- headless CommonJS consumer requires `image-drop-input/headless`
+- headless CommonJS consumer verifies uploader exports plus `ImageUploadError` and `isImageUploadError`
+
+This is not a public usage report, but it is an external-consumer-style check against the package tarball rather than source imports.
+
+## 2026-05-01 registry and account check
+
+Checked locally:
+
+- `gh auth status` is authenticated as `mt4110`
+- `npm whoami` returns `mt4110`
+- `npm view image-drop-input@0.2.0 dist --json` returns an integrity hash, registry signature, and npm provenance attestation URL for `0.2.0`
+
+Remaining release-trust checks require the npm package settings UI and the next GitHub Actions publish run:
+
+- npm Trusted Publisher is configured for `mt4110/image-drop-input`
+- workflow filename is `release.yml`
+- environment is `npm-publish`
+- the publish job uses OIDC without `NPM_TOKEN` or `NODE_AUTH_TOKEN`
+- any old automation publish token is revoked after the trusted publish succeeds
+
+## Usage report draft
+
+Use this as the first self-authored usage report after confirming a real app or external integration.
+
+Title:
+
+```txt
+usage: packed consumer smoke with root types and headless CJS
+```
+
+Fields:
+
+```txt
+Use case: Other
+Framework or bundler: packed tarball consumer fixtures, TypeScript, CommonJS
+Integration mode: Evaluating
+Upload pattern: Not sure yet
+
+What worked well:
+The package tarball can be consumed from the root entry for React/types and from the headless CommonJS subpath. Structured upload errors are available from both root and headless entrypoints, so product code can narrow upload failures without parsing messages.
+
+Pain points, missing docs, or adoption blockers:
+This is still a maintainer-owned consumer proof, not an independent product report. The next stronger signal should come from a Next.js App Router or React Hook Form/Zod integration outside this repository.
+
+Company or project name:
+
+Website URL:
+
+Public quotation permission:
+Do not check unless a real external project name or URL is provided and quotation is appropriate.
+```

--- a/meta/README.md
+++ b/meta/README.md
@@ -3,8 +3,14 @@
 This directory keeps repository planning notes that are useful to maintainers but are not part of the package's public face.
 
 - `OSS_FOUNDATION_PLAN.md`: foundation notes for the repository and publishing posture.
+- `ADOPTION_PROOF.md`: maintainer-side adoption proof, registry checks, and usage report drafts.
 - `REPO_PLAN.md`: historical repository structure and packaging plan.
 - `ROADMAP.md`: release-direction notes and future work.
 - `design/`: future design notes that are useful to maintainers but not part of the package docs.
+
+Current design notes:
+
+- `design/P1-08-adoption-hardening.md`: v0.3 trust, maintainability, error-surface, and usage-proof plan.
+- `design/P2-07-upload-error-model.md`: structured upload error model for localization, telemetry, and retry UI.
 
 Published package contents are still controlled by `package.json.files`; this directory is intentionally excluded.

--- a/meta/ROADMAP.md
+++ b/meta/ROADMAP.md
@@ -2,6 +2,18 @@
 
 This project is strongest when it stays focused on one job: a product-safe React image input for the pre-upload image flow.
 
+## v0.3 Focus
+
+The next phase is adoption hardening, not feature expansion.
+
+- Verify tokenless npm Trusted Publishing and provenance during the next publish.
+- Keep the published package consumer floor at Node `>=18.18.0` unless packed-tarball checks prove a different requirement.
+- Keep upload session control separated from `use-image-drop-input.ts` before adding new hook behavior.
+- Maintain the structured upload error model as integration UX needs sharper failure classification.
+- Collect at least one real usage report or equivalent external integration proof.
+
+See `meta/design/P1-08-adoption-hardening.md` for the working design.
+
 ## v0.2 Focus
 
 - Keep validation and transform semantics explicit, especially source vs output byte limits.

--- a/meta/design/P1-08-adoption-hardening.md
+++ b/meta/design/P1-08-adoption-hardening.md
@@ -1,0 +1,157 @@
+# P1-08. v0.3 adoption hardening plan
+
+- Priority: **P1**
+- Depends on: **v0.2.0 public package baseline**
+- Status: **design**
+- Release target: **v0.3.x**
+- Public API break allowed: **no**
+- Runtime dependency additions allowed: **no**
+
+## Summary
+
+Move `image-drop-input` from "well-built package" to "safe package to adopt in another product."
+
+The next release should not chase broader uploader features. The work should harden trust, maintainability, integration failure handling, and adoption proof around the existing single-image pre-upload flow.
+
+## Current Scorecard
+
+The package is already in the 9-point range as a small React library:
+
+| Area | Current read |
+| --- | --- |
+| Concept | Strong single-image scope |
+| README | Clear product-safe positioning |
+| API design | Solid value model and explicit upload adapter |
+| Docs and recipes | Strong, with Next.js and form recipes present |
+| Package design | Root, `/headless`, and `/style.css` entrypoints are clear |
+| CI and release | Stronger after consumer smoke and trusted publish work |
+| Maintainability | Good, but the main hook is still heavy |
+| External trust | The main remaining gap |
+
+The 10-point path is adoption hardening, not feature expansion.
+
+## Already Addressed Locally
+
+The following items from the external review are no longer open in this repository:
+
+- `CHANGELOG.md` exists and carries release-facing notes.
+- `docs/README.md` lists the newer Next.js and React Hook Form/Zod recipes.
+- `package.json` uses the consumer install floor `node >=18.18.0`.
+- CI verifies packed consumer fixtures on Node `18.18.0`, `20.x`, and `22.x`.
+- `RELEASING.md` documents npm Trusted Publishing, provenance checks, and token removal.
+- `.github/workflows/release.yml` publishes without `NPM_TOKEN` or `NODE_AUTH_TOKEN`.
+- A usage report issue template exists.
+- Upload session orchestration is separated into `src/react/use-image-drop-input-internal/upload-session.ts`.
+- `ImageUploadError` and `isImageUploadError()` are implemented, exported, documented, and covered by tests.
+- npm registry metadata for `0.2.0` exposes a provenance attestation URL.
+
+## Goals
+
+- Keep the public package narrow: one product-safe image field, not a general uploader.
+- Make the release path independently trustworthy through OIDC, provenance, and documented verification.
+- Keep Node 18.18 as the consumer floor unless a concrete packaged artifact test proves otherwise.
+- Reduce the main hook's operational weight before adding new behavior.
+- Make upload failures easier to localize, classify, and observe without changing the `onError(error: Error)` callback shape.
+- Collect at least one real usage signal that proves an app can adopt the package outside the local example environment.
+
+## Non-goals
+
+- Add multi-image support.
+- Add a crop editor.
+- Add resumable or chunked upload orchestration.
+- Add provider SDK adapters.
+- Add a CLI generator.
+- Add UI framework skins.
+- Rewrite the component surface for a new design system.
+
+## Workstreams
+
+### 1. Release trust verification
+
+Most of the repository-side work is already in place. The remaining task is to verify the actual npm and GitHub settings during the next publish.
+
+Acceptance criteria:
+
+- npm Trusted Publisher is configured for `mt4110/image-drop-input`.
+- The configured workflow filename is `release.yml`.
+- The configured environment is `npm-publish`.
+- A rehearsal release workflow passes with publish disabled.
+- A real publish uses OIDC and succeeds without npm token environment variables.
+- npm provenance is visible for the published version and points to the expected GitHub workflow run.
+- Any old npm automation token is revoked after the first successful trusted publish.
+
+### 2. Upload session extraction
+
+`src/react/use-image-drop-input.ts` was the central gravity point. Upload orchestration now sits behind a named internal hook.
+
+Module:
+
+- `src/react/use-image-drop-input-internal/upload-session.ts`
+
+Encapsulated:
+
+- `abortControllerRef`
+- `retryableUploadRef`
+- `runId` checks that are upload-specific
+- progress clamping and final `100`
+- upload retry eligibility
+- upload cancellation behavior
+- draft cleanup after upload failure or abort
+
+Keep in the hook:
+
+- public returned shape
+- file intake handlers
+- validation and transform pipeline until a separate extraction is justified
+- controlled value sync until upload extraction proves stable
+
+Acceptance criteria:
+
+- Existing retry, cancel, abort, progress, and failed-upload tests still pass.
+- `AbortError` remains silent and does not call `onError`.
+- Failed upload preserves the last committed value.
+- Successful upload still commits `src` when present and keeps object URLs out of persisted state.
+- The hook becomes easier to scan because upload side effects sit behind a named boundary.
+
+### 3. Structured upload error model
+
+Use `meta/design/P2-07-upload-error-model.md` as the detailed record. The initial model has been implemented without changing the `onError(error: Error)` callback shape.
+
+Acceptance criteria:
+
+- Add `ImageUploadError` and `isImageUploadError()`.
+- Preserve `onError?: (error: Error) => void`.
+- Export the type and guard from both root and `/headless` entrypoints.
+- Package-owned request failures include a stable code and safe details.
+- Signed URLs, request headers, and auth material are not included in error details.
+- Documentation shows narrowing validation errors and upload errors separately.
+
+### 4. Adoption proof
+
+The project already has a usage report template. The missing layer is at least one concrete report from a real integration.
+
+Acceptance criteria:
+
+- Open one self-authored usage report from a real app or integration test repo.
+- Confirm at least one path from the docs works outside this repository, preferably Next.js App Router or React Hook Form/Zod.
+- Link the report in release notes or maintainer notes only if it is useful and the report grants public quotation permission.
+- Treat pain points from the first report as docs or compatibility fixes before adding new features.
+
+## Sequencing
+
+1. Keep release trust verification on the next release checklist.
+2. Keep upload session internals covered before adding hook behavior.
+3. Iterate structured upload errors only from concrete integration feedback.
+4. Collect usage proof and feed any concrete blockers back into docs or tests.
+
+## Definition of Done
+
+The v0.3 adoption hardening pass is done when:
+
+- packed package consumer smoke passes on Node `18.18.0`, `20.x`, and `22.x`
+- a tokenless trusted publish path has been verified end to end
+- the main hook has a smaller upload orchestration boundary
+- upload failures can be classified without parsing English messages
+- at least one real usage report or equivalent integration proof exists
+
+That is the bridge from "good package" to "safe dependency."

--- a/meta/design/P2-07-upload-error-model.md
+++ b/meta/design/P2-07-upload-error-model.md
@@ -2,14 +2,14 @@
 
 - Priority: **P2**
 - Depends on: **v0.2.0 P0/P1 hardening pack**
-- Status: **design**
+- Status: **implemented**
 - PR target size: **small to medium**
 - Public API break allowed: **no**
 - Runtime dependency additions allowed: **no**
 
 ## Summary
 
-Design a structured upload error model around `ImageUploadError` and `isImageUploadError()` without implementing it yet.
+Record the structured upload error model around `ImageUploadError` and `isImageUploadError()`.
 
 The goal is to make `onError` easier to use for localization, telemetry, and retry UI while keeping the existing public callback shape.
 
@@ -244,23 +244,30 @@ Recommended stance:
 - HTTP status / body details are covered.
 - signed URL leakage risk is explicitly handled.
 - semver risks and compatibility constraints are documented.
-- No runtime implementation is included in this design PR.
+- Runtime implementation preserves `onError?: (error: Error) => void`.
 
-## Future Implementation Checks
+## Implementation Checks
 
-When implementation starts, require:
+Covered by the implementation:
 
 - unit tests for `ImageUploadError` and `isImageUploadError()`
 - request helper tests for HTTP body/status details
-- fetch and XHR network failure tests
 - built-in uploader tests for target and response mapping wrappers
-- React hook test proving `onError` receives structured upload errors from built-in helpers
 - entrypoint tests for root and headless exports
 - docs update showing localization and telemetry narrowing
+- React hook coverage proving `onError` receives structured upload errors from built-in helpers
+
+Still useful future checks:
+
+- XHR-specific network failure coverage if a stable XMLHttpRequest mock is added.
+
+## Resolved Questions
+
+- `getTarget` failures are wrapped as `target_failed` unless they are already `ImageUploadError` or aborts.
+- `rawBody` is included by default because it is useful for debugging and does not include request URLs or headers.
+- `unknown_upload_error` stays in the public code union for custom adapter authors, but the hook does not wrap unknown custom adapter errors globally.
+- Custom adapter errors keep their identity unless the adapter opts into `ImageUploadError`.
 
 ## Open Questions
 
-- Should `target_failed` wrapping be automatic for `getTarget`, or should examples teach consumers to throw `ImageUploadError` themselves?
-- Should `rawBody` be included by default, or is parsed `body` enough for safer telemetry?
 - Should `ImageUploadErrorDetails` include a redacted request label in the future?
-- Should `unknown_upload_error` exist, or is preserving unknown custom adapter errors better?

--- a/meta/design/P2-07-upload-error-model.md
+++ b/meta/design/P2-07-upload-error-model.md
@@ -252,14 +252,11 @@ Covered by the implementation:
 
 - unit tests for `ImageUploadError` and `isImageUploadError()`
 - request helper tests for HTTP body/status details
+- fetch and XHR network failure tests
 - built-in uploader tests for target and response mapping wrappers
 - entrypoint tests for root and headless exports
 - docs update showing localization and telemetry narrowing
 - React hook coverage proving `onError` receives structured upload errors from built-in helpers
-
-Still useful future checks:
-
-- XHR-specific network failure coverage if a stable XMLHttpRequest mock is added.
 
 ## Resolved Questions
 

--- a/scripts/prepare-consumer-smoke-artifact.mjs
+++ b/scripts/prepare-consumer-smoke-artifact.mjs
@@ -5,6 +5,10 @@ import { fileURLToPath } from 'node:url';
 
 const artifactsDir = fileURLToPath(new URL('../.artifacts/', import.meta.url));
 const fixedTarballName = 'image-drop-input.tgz';
+const consumerFixtureDirs = [
+  fileURLToPath(new URL('../consumer-fixtures/root-types/', import.meta.url)),
+  fileURLToPath(new URL('../consumer-fixtures/headless-cjs/', import.meta.url))
+];
 
 rmSync(artifactsDir, {
   force: true,
@@ -39,5 +43,12 @@ const sourcePath = join(artifactsDir, tarballName);
 const targetPath = join(artifactsDir, fixedTarballName);
 
 renameSync(sourcePath, targetPath);
+
+consumerFixtureDirs.forEach((fixtureDir) => {
+  rmSync(join(fixtureDir, 'node_modules', 'image-drop-input'), {
+    force: true,
+    recursive: true
+  });
+});
 
 console.log(`Prepared ${targetPath}`);

--- a/src/core/validate-image.ts
+++ b/src/core/validate-image.ts
@@ -6,6 +6,10 @@ import type {
   ImageValidationOptions
 } from './types';
 
+export interface ImageValidationErrorOptions {
+  cause?: unknown;
+}
+
 export class ImageValidationError extends Error {
   readonly code: ImageValidationErrorCode;
   readonly details: ImageValidationErrorDetails;
@@ -14,7 +18,7 @@ export class ImageValidationError extends Error {
     code: ImageValidationErrorCode,
     message: string,
     details: ImageValidationErrorDetails = {},
-    options?: ErrorOptions
+    options?: ImageValidationErrorOptions
   ) {
     super(message, options);
     this.name = 'ImageValidationError';

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -27,6 +27,7 @@ export { ImageValidationError, isImageValidationError, validateImage } from './c
 export { createMultipartUploader } from './upload/create-multipart-uploader';
 export { createPresignedPutUploader, uploadWithSignedTarget } from './upload/create-presigned-put-uploader';
 export { createRawPutUploader } from './upload/create-raw-put-uploader';
+export { ImageUploadError, isImageUploadError } from './upload/errors';
 export { sendUploadRequest } from './upload/request';
 export type {
   CreateMultipartUploaderOptions,
@@ -40,3 +41,8 @@ export type {
   UploadResponse,
   UploadResult
 } from './upload/types';
+export type {
+  ImageUploadErrorCode,
+  ImageUploadErrorDetails,
+  ImageUploadErrorStage
+} from './upload/errors';

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -44,5 +44,7 @@ export type {
 export type {
   ImageUploadErrorCode,
   ImageUploadErrorDetails,
+  ImageUploadErrorOptions,
   ImageUploadErrorStage
 } from './upload/errors';
+export type { ImageValidationErrorOptions } from './core/validate-image';

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,3 +21,12 @@ export type {
   UploadContext,
   UploadResult
 } from './upload/types';
+export {
+  ImageUploadError,
+  isImageUploadError
+} from './upload/errors';
+export type {
+  ImageUploadErrorCode,
+  ImageUploadErrorDetails,
+  ImageUploadErrorStage
+} from './upload/errors';

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,5 +28,7 @@ export {
 export type {
   ImageUploadErrorCode,
   ImageUploadErrorDetails,
+  ImageUploadErrorOptions,
   ImageUploadErrorStage
 } from './upload/errors';
+export type { ImageValidationErrorOptions } from './core/validate-image';

--- a/src/react/use-image-drop-input-internal/upload-session.ts
+++ b/src/react/use-image-drop-input-internal/upload-session.ts
@@ -1,0 +1,229 @@
+import { useCallback, useRef, useState } from 'react';
+import { createObjectUrl } from '../../core/create-object-url';
+import type { ImageUploadValue, ManagedObjectUrl } from '../../core/types';
+import type { UploadAdapter } from '../../upload/types';
+import {
+  clampProgressPercent,
+  isAbortError
+} from './errors';
+import {
+  createPreviewValue,
+  type PreparedUpload
+} from './preview-value';
+
+export interface UseUploadSessionOptions {
+  upload?: UploadAdapter;
+  onProgress?: (percent: number) => void;
+  isCurrentRun: (runId: number) => boolean;
+  reportError: (error: unknown) => void;
+  setCommittedValue: (
+    next: ImageUploadValue | null,
+    ownedObjectUrl?: ManagedObjectUrl | null
+  ) => void;
+}
+
+export interface RetryUploadOptions {
+  disabled?: boolean;
+  clearError: () => void;
+}
+
+export interface UseUploadSessionReturn {
+  canRetryUpload: (error: Error | null) => boolean;
+  cancelActiveUpload: () => void;
+  clearRetryableUpload: () => void;
+  draftValue: ImageUploadValue | null;
+  isUploading: boolean;
+  progress: number;
+  releaseDraftObjectUrl: () => void;
+  reset: () => void;
+  retryUpload: (createRunId: () => number, options: RetryUploadOptions) => void;
+  uploadPrepared: (preparedUpload: PreparedUpload, runId: number) => Promise<void>;
+}
+
+export function useUploadSession({
+  upload,
+  onProgress,
+  isCurrentRun,
+  reportError,
+  setCommittedValue
+}: UseUploadSessionOptions): UseUploadSessionReturn {
+  const [draftValue, setDraftValue] = useState<ImageUploadValue | null>(null);
+  const [isUploading, setIsUploading] = useState(false);
+  const [progress, setProgress] = useState(0);
+  const abortControllerRef = useRef<AbortController | null>(null);
+  const draftObjectUrlRef = useRef<ManagedObjectUrl | null>(null);
+  const retryableUploadRef = useRef<PreparedUpload | null>(null);
+
+  const releaseDraftObjectUrl = useCallback(() => {
+    draftObjectUrlRef.current?.revoke();
+    draftObjectUrlRef.current = null;
+  }, []);
+
+  const clearRetryableUpload = useCallback(() => {
+    retryableUploadRef.current = null;
+  }, []);
+
+  const clearDraft = useCallback(() => {
+    setDraftValue(null);
+  }, []);
+
+  const discardDraftValue = useCallback(() => {
+    clearDraft();
+    releaseDraftObjectUrl();
+  }, [clearDraft, releaseDraftObjectUrl]);
+
+  const reset = useCallback(() => {
+    setIsUploading(false);
+    setProgress(0);
+    discardDraftValue();
+    clearRetryableUpload();
+  }, [clearRetryableUpload, discardDraftValue]);
+
+  const cancelActiveUpload = useCallback(() => {
+    abortControllerRef.current?.abort();
+    abortControllerRef.current = null;
+  }, []);
+
+  const uploadPrepared = useCallback(
+    async (preparedUpload: PreparedUpload, runId: number) => {
+      if (!upload) {
+        return;
+      }
+
+      try {
+        const objectUrl = createObjectUrl(preparedUpload.file);
+
+        if (!isCurrentRun(runId)) {
+          objectUrl.revoke();
+          return;
+        }
+
+        const previewValue = createPreviewValue(preparedUpload, objectUrl.url);
+
+        retryableUploadRef.current = preparedUpload;
+        draftObjectUrlRef.current = objectUrl;
+        setDraftValue(previewValue);
+        setIsUploading(true);
+
+        const abortController = new AbortController();
+        abortControllerRef.current = abortController;
+        let lastProgressPercent = 0;
+
+        const result = await upload(preparedUpload.file, {
+          signal: abortController.signal,
+          fileName: preparedUpload.value.fileName,
+          originalFileName: preparedUpload.originalFileName,
+          mimeType: preparedUpload.value.mimeType,
+          onProgress(percent) {
+            if (!isCurrentRun(runId)) {
+              return;
+            }
+
+            const nextPercent = clampProgressPercent(percent);
+
+            lastProgressPercent = nextPercent;
+            setProgress(nextPercent);
+            onProgress?.(nextPercent);
+          }
+        });
+
+        if (!isCurrentRun(runId)) {
+          return;
+        }
+
+        abortControllerRef.current = null;
+        setIsUploading(false);
+        setProgress(100);
+        if (lastProgressPercent < 100) {
+          onProgress?.(100);
+        }
+        clearRetryableUpload();
+
+        const nextValue: ImageUploadValue = {
+          ...preparedUpload.value,
+          key: result.key,
+          ...(result.src ? { src: result.src } : { previewSrc: previewValue.previewSrc })
+        };
+
+        clearDraft();
+
+        if (result.src && result.src !== previewValue.previewSrc) {
+          releaseDraftObjectUrl();
+          setCommittedValue(nextValue);
+          return;
+        }
+
+        const ownedDraftUrl = draftObjectUrlRef.current;
+        draftObjectUrlRef.current = null;
+        setCommittedValue(nextValue, ownedDraftUrl);
+      } catch (nextError) {
+        if (!isCurrentRun(runId)) {
+          return;
+        }
+
+        if (isAbortError(nextError)) {
+          abortControllerRef.current = null;
+          reset();
+          return;
+        }
+
+        abortControllerRef.current = null;
+        setIsUploading(false);
+        setProgress(0);
+        discardDraftValue();
+        reportError(nextError);
+      }
+    },
+    [
+      clearDraft,
+      clearRetryableUpload,
+      discardDraftValue,
+      isCurrentRun,
+      onProgress,
+      releaseDraftObjectUrl,
+      reportError,
+      reset,
+      setCommittedValue,
+      upload
+    ]
+  );
+
+  const canRetryUpload = useCallback(
+    (error: Error | null) => Boolean(upload && error && retryableUploadRef.current && !isUploading),
+    [isUploading, upload]
+  );
+
+  const retryUpload = useCallback(
+    (createRunId: () => number, { disabled, clearError }: RetryUploadOptions) => {
+      const preparedUpload = retryableUploadRef.current;
+
+      if (disabled || isUploading || !preparedUpload) {
+        return;
+      }
+
+      const runId = createRunId();
+
+      cancelActiveUpload();
+      discardDraftValue();
+      clearError();
+      setIsUploading(false);
+      setProgress(0);
+
+      void uploadPrepared(preparedUpload, runId);
+    },
+    [cancelActiveUpload, discardDraftValue, isUploading, uploadPrepared]
+  );
+
+  return {
+    canRetryUpload,
+    cancelActiveUpload,
+    clearRetryableUpload,
+    draftValue,
+    isUploading,
+    progress,
+    releaseDraftObjectUrl,
+    reset,
+    retryUpload,
+    uploadPrepared
+  };
+}

--- a/src/react/use-image-drop-input.ts
+++ b/src/react/use-image-drop-input.ts
@@ -13,7 +13,6 @@ import type {
 import { validateImage } from '../core/validate-image';
 import type { UploadAdapter } from '../upload/types';
 import {
-  clampProgressPercent,
   isAbortError,
   toError
 } from './use-image-drop-input-internal/errors';
@@ -26,6 +25,7 @@ import {
   type PreparedUpload
 } from './use-image-drop-input-internal/preview-value';
 import { normalizeTransformedFile } from './use-image-drop-input-internal/transform-result';
+import { useUploadSession } from './use-image-drop-input-internal/upload-session';
 
 export function normalizeAspectRatio(aspectRatio?: AspectRatioValue): string | number | undefined {
   if (typeof aspectRatio === 'undefined') {
@@ -107,16 +107,10 @@ export function useImageDropInput({
   value
 }: UseImageDropInputOptions): UseImageDropInputReturn {
   const [internalValue, setInternalValue] = useState<ImageUploadValue | null>(value ?? null);
-  const [draftValue, setDraftValue] = useState<ImageUploadValue | null>(null);
   const [error, setError] = useState<Error | null>(null);
   const [isDragging, setIsDragging] = useState(false);
-  const [isUploading, setIsUploading] = useState(false);
-  const [progress, setProgress] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
   const committedObjectUrlRef = useRef<ManagedObjectUrl | null>(null);
-  const draftObjectUrlRef = useRef<ManagedObjectUrl | null>(null);
-  const abortControllerRef = useRef<AbortController | null>(null);
-  const retryableUploadRef = useRef<PreparedUpload | null>(null);
   const runIdRef = useRef(0);
   const controlledValueFingerprintRef = useRef<string | undefined>(getValueFingerprint(value));
   const pendingControlledCommitRef = useRef<ImageUploadValue | null | undefined>(undefined);
@@ -134,24 +128,6 @@ export function useImageDropInput({
     committedObjectUrlRef.current?.revoke();
     committedObjectUrlRef.current = null;
   }, []);
-
-  const releaseDraftObjectUrl = useCallback(() => {
-    draftObjectUrlRef.current?.revoke();
-    draftObjectUrlRef.current = null;
-  }, []);
-
-  const clearDraft = useCallback(() => {
-    setDraftValue(null);
-  }, []);
-
-  const clearRetryableUpload = useCallback(() => {
-    retryableUploadRef.current = null;
-  }, []);
-
-  const discardDraftValue = useCallback(() => {
-    clearDraft();
-    releaseDraftObjectUrl();
-  }, [clearDraft, releaseDraftObjectUrl]);
 
   useEffect(() => {
     if (!isControlled) {
@@ -203,33 +179,46 @@ export function useImageDropInput({
     [onError]
   );
 
+  const isCurrentRun = useCallback((runId: number) => runIdRef.current === runId, []);
+
+  const {
+    canRetryUpload: canRetryUploadFromSession,
+    cancelActiveUpload,
+    clearRetryableUpload,
+    draftValue,
+    isUploading,
+    progress,
+    releaseDraftObjectUrl,
+    reset: resetUploadSession,
+    retryUpload: retryUploadFromSession,
+    uploadPrepared
+  } = useUploadSession({
+    upload,
+    onProgress,
+    isCurrentRun,
+    reportError,
+    setCommittedValue
+  });
+
   const displayValue = draftValue ?? committedValue;
 
   useEffect(() => {
     return () => {
       runIdRef.current += 1;
-      abortControllerRef.current?.abort();
+      cancelActiveUpload();
       releaseDraftObjectUrl();
       releaseCommittedObjectUrl();
     };
-  }, [releaseCommittedObjectUrl, releaseDraftObjectUrl]);
+  }, [cancelActiveUpload, releaseCommittedObjectUrl, releaseDraftObjectUrl]);
 
   const clearError = useCallback(() => {
     setError(null);
   }, []);
 
   const resetTransientState = useCallback(() => {
-    setIsUploading(false);
-    setProgress(0);
-    discardDraftValue();
+    resetUploadSession();
     clearError();
-    clearRetryableUpload();
-  }, [clearError, clearRetryableUpload, discardDraftValue]);
-
-  const cancelActiveUpload = useCallback(() => {
-    abortControllerRef.current?.abort();
-    abortControllerRef.current = null;
-  }, []);
+  }, [clearError, resetUploadSession]);
 
   useEffect(() => {
     if (!isControlled) {
@@ -263,8 +252,6 @@ export function useImageDropInput({
     resetTransientState();
   }, [cancelActiveUpload, isControlled, resetTransientState, value]);
 
-  const isCurrentRun = useCallback((runId: number) => runIdRef.current === runId, []);
-
   const cancelUpload = useCallback(() => {
     if (disabled) {
       return;
@@ -293,110 +280,6 @@ export function useImageDropInput({
     resetTransientState,
     setCommittedValue
   ]);
-
-  const uploadPrepared = useCallback(
-    async (preparedUpload: PreparedUpload, runId: number) => {
-      if (!upload) {
-        return;
-      }
-
-      try {
-        const objectUrl = createObjectUrl(preparedUpload.file);
-
-        if (!isCurrentRun(runId)) {
-          objectUrl.revoke();
-          return;
-        }
-
-        const previewValue = createPreviewValue(preparedUpload, objectUrl.url);
-
-        retryableUploadRef.current = preparedUpload;
-        draftObjectUrlRef.current = objectUrl;
-        setDraftValue(previewValue);
-        setIsUploading(true);
-
-        const abortController = new AbortController();
-        abortControllerRef.current = abortController;
-        let lastProgressPercent = 0;
-
-        const result = await upload(preparedUpload.file, {
-          signal: abortController.signal,
-          fileName: preparedUpload.value.fileName,
-          originalFileName: preparedUpload.originalFileName,
-          mimeType: preparedUpload.value.mimeType,
-          onProgress(percent) {
-            if (!isCurrentRun(runId)) {
-              return;
-            }
-
-            const nextPercent = clampProgressPercent(percent);
-
-            lastProgressPercent = nextPercent;
-            setProgress(nextPercent);
-            onProgress?.(nextPercent);
-          }
-        });
-
-        if (!isCurrentRun(runId)) {
-          return;
-        }
-
-        abortControllerRef.current = null;
-        setIsUploading(false);
-        setProgress(100);
-        if (lastProgressPercent < 100) {
-          onProgress?.(100);
-        }
-        clearRetryableUpload();
-
-        const nextValue: ImageUploadValue = {
-          ...preparedUpload.value,
-          key: result.key,
-          ...(result.src ? { src: result.src } : { previewSrc: previewValue.previewSrc }),
-        };
-
-        clearDraft();
-
-        if (result.src && result.src !== previewValue.previewSrc) {
-          releaseDraftObjectUrl();
-          setCommittedValue(nextValue);
-          return;
-        }
-
-        const ownedDraftUrl = draftObjectUrlRef.current;
-        draftObjectUrlRef.current = null;
-        setCommittedValue(nextValue, ownedDraftUrl);
-      } catch (nextError) {
-        if (!isCurrentRun(runId)) {
-          return;
-        }
-
-        if (isAbortError(nextError)) {
-          abortControllerRef.current = null;
-          resetTransientState();
-          return;
-        }
-
-        abortControllerRef.current = null;
-        setIsUploading(false);
-        setProgress(0);
-        discardDraftValue();
-        reportError(nextError);
-      }
-    },
-    [
-      clearDraft,
-      clearRetryableUpload,
-      discardDraftValue,
-      isCurrentRun,
-      onProgress,
-      releaseDraftObjectUrl,
-      reportError,
-      resetTransientState,
-      setCommittedValue,
-      upload
-    ]
-  );
 
   const handleFile = useCallback(
     async (file: File) => {
@@ -476,15 +359,11 @@ export function useImageDropInput({
         }
 
         if (isAbortError(nextError)) {
-          abortControllerRef.current = null;
           resetTransientState();
           return;
         }
 
-        abortControllerRef.current = null;
-        setIsUploading(false);
-        setProgress(0);
-        discardDraftValue();
+        resetTransientState();
         reportError(nextError);
       }
     },
@@ -629,23 +508,13 @@ export function useImageDropInput({
 
     return resolvedMessages.statusIdle;
   }, [displayValue?.fileName, error, isUploading, progress, resolvedMessages]);
-  const canRetryUpload = Boolean(upload && error && retryableUploadRef.current && !isUploading);
+  const canRetryUpload = canRetryUploadFromSession(error);
   const retryUpload = useCallback(() => {
-    const preparedUpload = retryableUploadRef.current;
-
-    if (disabled || isUploading || !preparedUpload) {
-      return;
-    }
-
-    const runId = ++runIdRef.current;
-    cancelActiveUpload();
-    discardDraftValue();
-    clearError();
-    setIsUploading(false);
-    setProgress(0);
-
-    void uploadPrepared(preparedUpload, runId);
-  }, [cancelActiveUpload, clearError, disabled, discardDraftValue, isUploading, uploadPrepared]);
+    retryUploadFromSession(() => ++runIdRef.current, {
+      disabled,
+      clearError
+    });
+  }, [clearError, disabled, retryUploadFromSession]);
   const displaySrc = resolveDisplaySrc(displayValue);
 
   return {

--- a/src/upload/create-multipart-uploader.ts
+++ b/src/upload/create-multipart-uploader.ts
@@ -1,4 +1,5 @@
 import { sendUploadRequest } from './request';
+import { ImageUploadError, isAbortError, isImageUploadError } from './errors';
 import type {
   CreateMultipartUploaderOptions,
   UploadAdapter,
@@ -68,6 +69,26 @@ export function createMultipartUploader(options: CreateMultipartUploaderOptions)
       withCredentials: options.withCredentials
     });
 
-    return (options.mapResponse ?? defaultMapResponse)(response.body, response);
+    try {
+      return (options.mapResponse ?? defaultMapResponse)(response.body, response);
+    } catch (error) {
+      if (isImageUploadError(error) || isAbortError(error)) {
+        throw error;
+      }
+
+      throw new ImageUploadError(
+        'response_mapping_failed',
+        'Upload response mapping failed.',
+        {
+          stage: 'response_mapping',
+          method: 'POST',
+          status: response.status,
+          statusText: response.statusText,
+          body: response.body,
+          rawBody: response.rawBody
+        },
+        error instanceof Error ? { cause: error } : undefined
+      );
+    }
   };
 }

--- a/src/upload/create-presigned-put-uploader.ts
+++ b/src/upload/create-presigned-put-uploader.ts
@@ -1,4 +1,5 @@
 import { sendUploadRequest } from './request';
+import { ImageUploadError, isAbortError, isImageUploadError } from './errors';
 import type {
   CreatePresignedPutUploaderOptions,
   PresignedPutTarget,
@@ -35,7 +36,22 @@ export function createPresignedPutUploader(
   options: CreatePresignedPutUploaderOptions
 ): UploadAdapter {
   return async (file, context) => {
-    const target = await options.getTarget(file, context);
+    let target: PresignedPutTarget;
+
+    try {
+      target = await options.getTarget(file, context);
+    } catch (error) {
+      if (isImageUploadError(error) || isAbortError(error)) {
+        throw error;
+      }
+
+      throw new ImageUploadError(
+        'target_failed',
+        'Upload target resolution failed.',
+        { stage: 'target' },
+        error instanceof Error ? { cause: error } : undefined
+      );
+    }
 
     return uploadWithSignedTarget(
       file,

--- a/src/upload/errors.ts
+++ b/src/upload/errors.ts
@@ -21,6 +21,10 @@ export interface ImageUploadErrorDetails {
   rawBody?: string;
 }
 
+export interface ImageUploadErrorOptions {
+  cause?: unknown;
+}
+
 export class ImageUploadError extends Error {
   readonly code: ImageUploadErrorCode;
   readonly details: ImageUploadErrorDetails;
@@ -29,7 +33,7 @@ export class ImageUploadError extends Error {
     code: ImageUploadErrorCode,
     message: string,
     details: ImageUploadErrorDetails,
-    options?: ErrorOptions
+    options?: ImageUploadErrorOptions
   ) {
     super(message, options);
     this.name = 'ImageUploadError';

--- a/src/upload/errors.ts
+++ b/src/upload/errors.ts
@@ -1,0 +1,114 @@
+export type ImageUploadErrorCode =
+  | 'target_failed'
+  | 'request_unavailable'
+  | 'network_error'
+  | 'http_error'
+  | 'response_mapping_failed'
+  | 'unknown_upload_error';
+
+export type ImageUploadErrorStage =
+  | 'target'
+  | 'request'
+  | 'response_mapping'
+  | 'adapter';
+
+export interface ImageUploadErrorDetails {
+  stage: ImageUploadErrorStage;
+  method?: 'POST' | 'PUT';
+  status?: number;
+  statusText?: string;
+  body?: unknown;
+  rawBody?: string;
+}
+
+export class ImageUploadError extends Error {
+  readonly code: ImageUploadErrorCode;
+  readonly details: ImageUploadErrorDetails;
+
+  constructor(
+    code: ImageUploadErrorCode,
+    message: string,
+    details: ImageUploadErrorDetails,
+    options?: ErrorOptions
+  ) {
+    super(message, options);
+    this.name = 'ImageUploadError';
+    this.code = code;
+    this.details = details;
+  }
+}
+
+const imageUploadErrorCodes = new Set<ImageUploadErrorCode>([
+  'target_failed',
+  'request_unavailable',
+  'network_error',
+  'http_error',
+  'response_mapping_failed',
+  'unknown_upload_error'
+]);
+
+const imageUploadErrorStages = new Set<ImageUploadErrorStage>([
+  'target',
+  'request',
+  'response_mapping',
+  'adapter'
+]);
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (!isObjectRecord(value)) {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+
+  return prototype === Object.prototype || prototype === null;
+}
+
+function isValidMethod(value: unknown): value is 'POST' | 'PUT' {
+  return value === 'POST' || value === 'PUT';
+}
+
+function hasOptionalString(details: Record<string, unknown>, key: keyof ImageUploadErrorDetails) {
+  return typeof details[key] === 'undefined' || typeof details[key] === 'string';
+}
+
+function hasOptionalNumber(details: Record<string, unknown>, key: keyof ImageUploadErrorDetails) {
+  const value = details[key];
+
+  return typeof value === 'undefined' || (typeof value === 'number' && Number.isFinite(value));
+}
+
+export function isImageUploadError(error: unknown): error is ImageUploadError {
+  if (!isObjectRecord(error)) {
+    return false;
+  }
+
+  if (
+    error.name !== 'ImageUploadError' ||
+    typeof error.message !== 'string' ||
+    typeof error.code !== 'string' ||
+    !imageUploadErrorCodes.has(error.code as ImageUploadErrorCode) ||
+    !isPlainRecord(error.details)
+  ) {
+    return false;
+  }
+
+  const details = error.details;
+
+  return (
+    typeof details.stage === 'string' &&
+    imageUploadErrorStages.has(details.stage as ImageUploadErrorStage) &&
+    (typeof details.method === 'undefined' || isValidMethod(details.method)) &&
+    hasOptionalNumber(details, 'status') &&
+    hasOptionalString(details, 'statusText') &&
+    hasOptionalString(details, 'rawBody')
+  );
+}
+
+export function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
+}

--- a/src/upload/request.ts
+++ b/src/upload/request.ts
@@ -1,4 +1,5 @@
 import type { UploadRequest, UploadRequestFn, UploadResponse } from './types';
+import { ImageUploadError, isAbortError } from './errors';
 
 function createAbortError(): Error {
   if (typeof DOMException !== 'undefined') {
@@ -8,6 +9,50 @@ function createAbortError(): Error {
   const error = new Error('The upload was aborted.');
   error.name = 'AbortError';
   return error;
+}
+
+function createNetworkError(
+  request: UploadRequest,
+  cause?: unknown,
+  response?: Pick<UploadResponse, 'status' | 'statusText'>
+): ImageUploadError {
+  return new ImageUploadError(
+    'network_error',
+    'Upload failed due to a network error.',
+    {
+      stage: 'request',
+      method: request.method,
+      ...(response
+        ? {
+            status: response.status,
+            statusText: response.statusText
+          }
+        : {})
+    },
+    cause instanceof Error ? { cause } : undefined
+  );
+}
+
+function createHttpError(
+  request: UploadRequest,
+  response: Pick<UploadResponse, 'status' | 'statusText'>,
+  body?: unknown,
+  rawBody?: string,
+  cause?: unknown
+): ImageUploadError {
+  return new ImageUploadError(
+    'http_error',
+    `Upload failed: ${response.status} ${response.statusText}`,
+    {
+      stage: 'request',
+      method: request.method,
+      status: response.status,
+      statusText: response.statusText,
+      ...(typeof body === 'undefined' ? {} : { body }),
+      ...(typeof rawBody === 'undefined' ? {} : { rawBody })
+    },
+    cause instanceof Error ? { cause } : undefined
+  );
 }
 
 function parseResponseBody(rawBody: string, headers: Headers): unknown {
@@ -50,23 +95,57 @@ function parseHeaders(rawHeaders: string): Headers {
   return headers;
 }
 
+async function readFetchResponseBody(response: Response, request: UploadRequest): Promise<string> {
+  try {
+    return await response.text();
+  } catch (error) {
+    if (isAbortError(error)) {
+      throw error;
+    }
+
+    if (!response.ok) {
+      throw createHttpError(request, response, undefined, undefined, error);
+    }
+
+    throw createNetworkError(request, error, response);
+  }
+}
+
 async function sendWithFetch(request: UploadRequest): Promise<UploadResponse> {
   if (typeof fetch !== 'function') {
-    throw new Error('fetch is unavailable in this environment.');
+    throw new ImageUploadError(
+      'request_unavailable',
+      'Upload request is unavailable in this environment.',
+      {
+        stage: 'request',
+        method: request.method
+      }
+    );
   }
 
-  const response = await fetch(request.url, {
-    method: request.method,
-    headers: request.headers,
-    body: request.body,
-    signal: request.signal,
-    credentials: request.withCredentials ? 'include' : 'same-origin'
-  });
-  const rawBody = await response.text();
+  let response: Response;
+
+  try {
+    response = await fetch(request.url, {
+      method: request.method,
+      headers: request.headers,
+      body: request.body,
+      signal: request.signal,
+      credentials: request.withCredentials ? 'include' : 'same-origin'
+    });
+  } catch (error) {
+    if (isAbortError(error)) {
+      throw error;
+    }
+
+    throw createNetworkError(request, error);
+  }
+
+  const rawBody = await readFetchResponseBody(response, request);
   const body = parseResponseBody(rawBody, response.headers);
 
   if (!response.ok) {
-    throw new Error(`Upload failed: ${response.status} ${response.statusText}`);
+    throw createHttpError(request, response, body, rawBody);
   }
 
   return {
@@ -90,15 +169,20 @@ async function sendWithXhr(request: UploadRequest): Promise<UploadResponse> {
   return new Promise<UploadResponse>((resolve, reject) => {
     const xhr = new XMLHttpRequest();
 
-    xhr.open(request.method, request.url, true);
+    try {
+      xhr.open(request.method, request.url, true);
 
-    if (request.withCredentials) {
-      xhr.withCredentials = true;
+      if (request.withCredentials) {
+        xhr.withCredentials = true;
+      }
+
+      Object.entries(request.headers ?? {}).forEach(([key, value]) => {
+        xhr.setRequestHeader(key, value);
+      });
+    } catch (error) {
+      reject(createNetworkError(request, error));
+      return;
     }
-
-    Object.entries(request.headers ?? {}).forEach(([key, value]) => {
-      xhr.setRequestHeader(key, value);
-    });
 
     const cleanup = () => {
       request.signal?.removeEventListener('abort', handleAbort);
@@ -126,7 +210,7 @@ async function sendWithXhr(request: UploadRequest): Promise<UploadResponse> {
 
     xhr.onerror = () => {
       cleanup();
-      reject(new Error('Upload failed due to a network error.'));
+      reject(createNetworkError(request));
     };
 
     xhr.onabort = () => {
@@ -142,7 +226,7 @@ async function sendWithXhr(request: UploadRequest): Promise<UploadResponse> {
       const body = parseResponseBody(rawBody, headers);
 
       if (xhr.status < 200 || xhr.status >= 300) {
-        reject(new Error(`Upload failed: ${xhr.status} ${xhr.statusText}`));
+        reject(createHttpError(request, xhr, body, rawBody));
         return;
       }
 
@@ -155,7 +239,12 @@ async function sendWithXhr(request: UploadRequest): Promise<UploadResponse> {
       });
     };
 
-    xhr.send(request.body);
+    try {
+      xhr.send(request.body);
+    } catch (error) {
+      cleanup();
+      reject(createNetworkError(request, error));
+    }
   });
 }
 

--- a/tests/entrypoints.test.ts
+++ b/tests/entrypoints.test.ts
@@ -4,9 +4,11 @@ import * as headless from '../src/headless';
 import * as root from '../src/index';
 
 describe('package entrypoints', () => {
-  it('keeps advanced utilities off the root entry', () => {
+  it('keeps advanced helper utilities off the root entry', () => {
     expect(root).toHaveProperty('ImageDropInput');
     expect(root.isImageValidationError).toBeTypeOf('function');
+    expect(root.ImageUploadError).toBeTypeOf('function');
+    expect(root.isImageUploadError).toBeTypeOf('function');
     expect(root).not.toHaveProperty('compressImage');
     expect(root).not.toHaveProperty('createPresignedPutUploader');
     expect(root).not.toHaveProperty('useImageDropInput');
@@ -18,6 +20,8 @@ describe('package entrypoints', () => {
     expect(headless.createPresignedPutUploader).toBeTypeOf('function');
     expect(headless.ImageValidationError).toBeTypeOf('function');
     expect(headless.isImageValidationError).toBeTypeOf('function');
+    expect(headless.ImageUploadError).toBeTypeOf('function');
+    expect(headless.isImageUploadError).toBeTypeOf('function');
     expect(headless.useImageDropInput).toBeTypeOf('function');
     expect(headless.validateImage).toBeTypeOf('function');
   });

--- a/tests/react/use-image-drop-input.test.tsx
+++ b/tests/react/use-image-drop-input.test.tsx
@@ -5,6 +5,8 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useImageDropInput } from '../../src/react/use-image-drop-input';
 import type { ImageUploadValue } from '../../src/core/types';
+import { ImageUploadError } from '../../src/upload/errors';
+import { createRawPutUploader } from '../../src/upload/create-raw-put-uploader';
 import type { UploadAdapter } from '../../src/upload/types';
 
 const { getImageMetadataMock } = vi.hoisted(() => ({
@@ -388,6 +390,38 @@ describe('useImageDropInput', () => {
     expect(transform).toHaveBeenCalledTimes(1);
     expect(upload.mock.calls[0]?.[0]).toBe(preparedFile);
     expect(upload.mock.calls[1]?.[0]).toBe(preparedFile);
+  });
+
+  it('passes structured errors from built-in upload helpers to onError', async () => {
+    const onError = vi.fn();
+    const uploadError = new ImageUploadError(
+      'http_error',
+      'Upload failed: 413 Payload Too Large',
+      {
+        stage: 'request',
+        method: 'PUT',
+        status: 413,
+        statusText: 'Payload Too Large'
+      }
+    );
+    const request = vi.fn(async () => {
+      throw uploadError;
+    });
+    const upload = createRawPutUploader({
+      endpoint: '/api/avatar',
+      request
+    });
+    const { result } = renderHook(() => useImageDropInput({ upload, onError }));
+
+    await act(async () => {
+      await result.current.handleInputChange(
+        createInputChange(new File(['hello'], 'avatar.png', { type: 'image/png' }))
+      );
+    });
+
+    expect(onError).toHaveBeenCalledWith(uploadError);
+    expect(result.current.error).toBe(uploadError);
+    expect(result.current.canRetryUpload).toBe(true);
   });
 
   it('normalizes object transform metadata for upload context and the final value', async () => {

--- a/tests/upload/uploaders.test.ts
+++ b/tests/upload/uploaders.test.ts
@@ -3,10 +3,13 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createMultipartUploader } from '../../src/upload/create-multipart-uploader';
 import { createPresignedPutUploader } from '../../src/upload/create-presigned-put-uploader';
 import { createRawPutUploader } from '../../src/upload/create-raw-put-uploader';
+import { ImageUploadError, isImageUploadError } from '../../src/upload/errors';
+import { sendUploadRequest } from '../../src/upload/request';
 
 describe('upload adapters', () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it('uploads to a signed target without inferring the provider', async () => {
@@ -140,5 +143,274 @@ describe('upload adapters', () => {
       etag: 'etag-789',
       response: { ok: true }
     });
+  });
+
+  it('reports built-in HTTP request failures as structured upload errors', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => new Response(
+        JSON.stringify({ error: 'too_large' }),
+        {
+          status: 413,
+          statusText: 'Payload Too Large',
+          headers: { 'Content-Type': 'application/json' }
+        }
+      ))
+    );
+
+    await expect(
+      sendUploadRequest({
+        method: 'PUT',
+        url: 'https://upload.example.com/private.png?signature=secret',
+        body: new Blob(['hello'], { type: 'image/png' })
+      })
+    ).rejects.toMatchObject({
+      name: 'ImageUploadError',
+      code: 'http_error',
+      message: 'Upload failed: 413 Payload Too Large',
+      details: {
+        stage: 'request',
+        method: 'PUT',
+        status: 413,
+        statusText: 'Payload Too Large',
+        body: { error: 'too_large' },
+        rawBody: '{"error":"too_large"}'
+      }
+    });
+  });
+
+  it('reports unavailable requests and network failures as structured upload errors', async () => {
+    vi.stubGlobal('fetch', undefined);
+
+    await expect(
+      sendUploadRequest({
+        method: 'POST',
+        url: '/api/upload',
+        body: new FormData()
+      })
+    ).rejects.toMatchObject({
+      name: 'ImageUploadError',
+      code: 'request_unavailable',
+      details: {
+        stage: 'request',
+        method: 'POST'
+      }
+    });
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new TypeError('fetch failed');
+      })
+    );
+
+    await expect(
+      sendUploadRequest({
+        method: 'PUT',
+        url: '/api/upload',
+        body: new Blob(['hello'])
+      })
+    ).rejects.toMatchObject({
+      name: 'ImageUploadError',
+      code: 'network_error',
+      details: {
+        stage: 'request',
+        method: 'PUT'
+      }
+    });
+  });
+
+  it('reports fetch response body read failures as structured upload errors', async () => {
+    const bodyFailure = new TypeError('body stream failed');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        headers: new Headers(),
+        text: vi.fn(async () => {
+          throw bodyFailure;
+        })
+      }))
+    );
+
+    await expect(
+      sendUploadRequest({
+        method: 'PUT',
+        url: '/api/upload',
+        body: new Blob(['hello'])
+      })
+    ).rejects.toMatchObject({
+      name: 'ImageUploadError',
+      code: 'network_error',
+      message: 'Upload failed due to a network error.',
+      details: {
+        stage: 'request',
+        method: 'PUT',
+        status: 200,
+        statusText: 'OK'
+      },
+      cause: bodyFailure
+    });
+
+    const errorBodyFailure = new TypeError('error body stream failed');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: false,
+        status: 413,
+        statusText: 'Payload Too Large',
+        headers: new Headers(),
+        text: vi.fn(async () => {
+          throw errorBodyFailure;
+        })
+      }))
+    );
+
+    await expect(
+      sendUploadRequest({
+        method: 'POST',
+        url: '/api/upload',
+        body: new FormData()
+      })
+    ).rejects.toMatchObject({
+      name: 'ImageUploadError',
+      code: 'http_error',
+      message: 'Upload failed: 413 Payload Too Large',
+      details: {
+        stage: 'request',
+        method: 'POST',
+        status: 413,
+        statusText: 'Payload Too Large'
+      },
+      cause: errorBodyFailure
+    });
+  });
+
+  it('reports XHR setup failures as structured upload errors', async () => {
+    const setupFailure = new Error('invalid upload request');
+
+    class ThrowingXMLHttpRequest {
+      upload = {};
+
+      open() {
+        throw setupFailure;
+      }
+    }
+
+    vi.stubGlobal('XMLHttpRequest', ThrowingXMLHttpRequest);
+
+    await expect(
+      sendUploadRequest({
+        method: 'PUT',
+        url: 'https://upload.example.com/avatar.png',
+        body: new Blob(['hello']),
+        onProgress: vi.fn()
+      })
+    ).rejects.toMatchObject({
+      name: 'ImageUploadError',
+      code: 'network_error',
+      message: 'Upload failed due to a network error.',
+      details: {
+        stage: 'request',
+        method: 'PUT'
+      },
+      cause: setupFailure
+    });
+  });
+
+  it('wraps presign and response mapping failures without hiding structured errors', async () => {
+    const targetFailure = new Error('presign denied');
+    const presignedUpload = createPresignedPutUploader({
+      getTarget: vi.fn(async () => {
+        throw targetFailure;
+      })
+    });
+
+    await expect(
+      presignedUpload(new Blob(['hello'], { type: 'image/png' }), {})
+    ).rejects.toMatchObject({
+      name: 'ImageUploadError',
+      code: 'target_failed',
+      message: 'Upload target resolution failed.',
+      details: {
+        stage: 'target'
+      },
+      cause: targetFailure
+    });
+
+    const structuredFailure = new ImageUploadError(
+      'target_failed',
+      'Custom target failure.',
+      { stage: 'target' }
+    );
+    const passthroughUpload = createPresignedPutUploader({
+      getTarget: vi.fn(async () => {
+        throw structuredFailure;
+      })
+    });
+
+    await expect(
+      passthroughUpload(new Blob(['hello'], { type: 'image/png' }), {})
+    ).rejects.toBe(structuredFailure);
+
+    const multipartUpload = createMultipartUploader({
+      endpoint: '/api/upload',
+      request: vi.fn(async () => ({
+        status: 201,
+        statusText: 'Created',
+        headers: new Headers(),
+        body: { ok: true },
+        rawBody: '{"ok":true}'
+      })),
+      mapResponse() {
+        throw new Error('bad response shape');
+      }
+    });
+
+    await expect(
+      multipartUpload(new Blob(['hello'], { type: 'image/png' }), {})
+    ).rejects.toMatchObject({
+      name: 'ImageUploadError',
+      code: 'response_mapping_failed',
+      message: 'Upload response mapping failed.',
+      details: {
+        stage: 'response_mapping',
+        method: 'POST',
+        status: 201,
+        statusText: 'Created',
+        body: { ok: true },
+        rawBody: '{"ok":true}'
+      }
+    });
+  });
+
+  it('narrows structurally valid upload errors', () => {
+    const error = new ImageUploadError(
+      'http_error',
+      'Upload failed: 500 Server Error',
+      {
+        stage: 'request',
+        method: 'PUT',
+        status: 500,
+        statusText: 'Server Error',
+        rawBody: 'nope'
+      }
+    );
+
+    expect(isImageUploadError(error)).toBe(true);
+    expect(
+      isImageUploadError({
+        name: 'ImageUploadError',
+        message: 'Upload failed.',
+        code: 'http_error',
+        details: {
+          stage: 'request',
+          method: 'DELETE',
+          status: 500
+        }
+      })
+    ).toBe(false);
   });
 });

--- a/tests/upload/uploaders.test.ts
+++ b/tests/upload/uploaders.test.ts
@@ -320,6 +320,97 @@ describe('upload adapters', () => {
     });
   });
 
+  it('reports XHR network events as structured upload errors', async () => {
+    class NetworkErrorXMLHttpRequest {
+      upload = {};
+      onabort: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      onload: (() => void) | null = null;
+
+      open() {}
+
+      setRequestHeader() {}
+
+      getAllResponseHeaders() {
+        return '';
+      }
+
+      abort() {}
+
+      send() {
+        this.onerror?.();
+      }
+    }
+
+    vi.stubGlobal('XMLHttpRequest', NetworkErrorXMLHttpRequest);
+
+    await expect(
+      sendUploadRequest({
+        method: 'PUT',
+        url: 'https://upload.example.com/avatar.png',
+        body: new Blob(['hello']),
+        onProgress: vi.fn()
+      })
+    ).rejects.toMatchObject({
+      name: 'ImageUploadError',
+      code: 'network_error',
+      message: 'Upload failed due to a network error.',
+      details: {
+        stage: 'request',
+        method: 'PUT'
+      }
+    });
+  });
+
+  it('reports XHR non-2xx load events as structured upload errors', async () => {
+    class HttpErrorXMLHttpRequest {
+      upload = {};
+      onabort: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      onload: (() => void) | null = null;
+      responseText = '{"error":"forbidden"}';
+      status = 403;
+      statusText = 'Forbidden';
+
+      open() {}
+
+      setRequestHeader() {}
+
+      getAllResponseHeaders() {
+        return 'content-type: application/json\r\n';
+      }
+
+      abort() {}
+
+      send() {
+        this.onload?.();
+      }
+    }
+
+    vi.stubGlobal('XMLHttpRequest', HttpErrorXMLHttpRequest);
+
+    await expect(
+      sendUploadRequest({
+        method: 'POST',
+        url: '/api/upload',
+        body: new FormData(),
+        onProgress: vi.fn()
+      })
+    ).rejects.toMatchObject({
+      name: 'ImageUploadError',
+      code: 'http_error',
+      message: 'Upload failed: 403 Forbidden',
+      details: {
+        stage: 'request',
+        method: 'POST',
+        status: 403,
+        statusText: 'Forbidden',
+        body: { error: 'forbidden' },
+        rawBody: '{"error":"forbidden"}'
+      }
+    });
+  });
+
   it('wraps presign and response mapping failures without hiding structured errors', async () => {
     const targetFailure = new Error('presign denied');
     const presignedUpload = createPresignedPutUploader({


### PR DESCRIPTION
## Summary

- Add structured `ImageUploadError` and `isImageUploadError()` exports from root and headless entrypoints.
- Split upload session orchestration out of the main React hook internals.
- Harden built-in upload helpers so request, target, and response mapping failures keep safe structured details.
- Add adoption-hardening notes, upload error docs, and packed consumer smoke coverage.

## Checks

- `npm run release:pr:check`
- `npm run smoke:consumer`
- `git diff --check`

## Notes

- `main` was reset to `origin/main`; this work lives on `feat/v0.3.0-adoption-hardening`.
- Push is complete; no release publish was run.