### PR TITLE
release: 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Notable changes for `image-drop-input` are tracked here.
 
-## Unreleased
+## 0.3.0 - 2026-05-01
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "image-drop-input",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "image-drop-input",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "workspaces": [
         "examples/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "image-drop-input",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Product-safe React image input for preview, validation, compression, paste, and signed uploads.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

- release version: `0.3.0`
- dist-tag: `latest`
- scope: adoption hardening release; no tag or npm publish in this PR

## Highlights

- Ships structured `ImageUploadError` / `isImageUploadError()` for upload failure classification without parsing messages.
- Keeps upload session orchestration behind the internal `useUploadSession` boundary.
- Locks the release path around npm Trusted Publishing, provenance checks, and packed consumer smoke coverage.
- Keeps the published consumer floor at Node `>=18.18.0`.

## Checks

- [x] `package.json` and `package-lock.json` carry the intended version
- [x] `CHANGELOG.md` includes the release-facing notes
- [x] release-facing notes are included in the PR body
- [x] `npm run release:pr:check`
- [x] packed package contains the English canonical `README.md`, docs, license, dist files, and no local-only files
- [x] `npm run smoke:consumer`
- [ ] demo still looks right in the consumer you care about

## Publish Readiness

- [ ] npm Trusted Publisher is configured for `mt4110/image-drop-input`, workflow filename `release.yml`, and environment `npm-publish`
- [x] the release workflow uses OIDC for publish and does not depend on `NPM_TOKEN` or `NODE_AUTH_TOKEN`

## Publish Plan

- [ ] merge to `main`
- [ ] create signed `v0.3.0` tag on the merged `main` commit
- [ ] run the `Release` workflow from `main` with `publish` off and confirm the rehearsal passed
- [ ] rerun the `Release` workflow from `main` with `publish` on
- [ ] confirm the publish job used the `npm-publish` environment

## Post-publish Checks

- [ ] npm package page version matches `package.json` on `main`
- [ ] npm package page README starts with the English canonical `README.md`
- [ ] npm install snippet is `npm install image-drop-input react`
- [ ] npm homepage link opens the GitHub Pages demo
- [ ] npm repository link opens `mt4110/image-drop-input`
- [ ] npm bugs link opens the GitHub issue tracker
- [ ] docs link from the npm README opens successfully
- [ ] npm provenance is visible for the published version
- [ ] npm provenance details point back to the expected GitHub workflow run
- [ ] if this is the first trusted publish, the old npm automation token is revoked and removed from GitHub Actions secrets or environment secrets
- [ ] if this is the first trusted publish, npm publishing access requires 2FA and disallows tokens
- [ ] initial usage report follow-up is linked in Notes or explicitly queued

## Notes

- breaking changes: none expected
- follow-up work: merge, signed tag, trusted publish rehearsal, trusted publish, provenance verification, and one real usage report or equivalent external integration proof
