### PR TITLE
Harden release artifact publishing

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -30,7 +30,9 @@
 
 - [ ] merge to `main`
 - [ ] run the `Release` workflow from `main` with `publish` off and confirm the rehearsal passed
+- [ ] confirm the rehearsal resolved exactly one package tarball artifact
 - [ ] rerun the `Release` workflow from `main` with `publish` on
+- [ ] confirm the publish run resolved exactly one package tarball before `npm publish`
 - [ ] confirm the publish job used the `npm-publish` environment
 
 ## Post-publish Checks

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,10 +46,27 @@ jobs:
           mkdir -p artifacts
           npm pack --pack-destination artifacts
 
+      - name: Resolve packed artifact
+        id: packed-artifact
+        shell: bash
+        run: |
+          mapfile -t tarballs < <(find artifacts -maxdepth 1 -type f -name '*.tgz' -print | sort)
+
+          if [ "${#tarballs[@]}" -ne 1 ]; then
+            echo "Expected exactly one npm package tarball in artifacts, found ${#tarballs[@]}." >&2
+            if [ "${#tarballs[@]}" -gt 0 ]; then
+              printf 'Found tarballs:\n' >&2
+              printf '  %s\n' "${tarballs[@]}" >&2
+            fi
+            exit 1
+          fi
+
+          echo "tarball=${tarballs[0]}" >> "$GITHUB_OUTPUT"
+
       - uses: actions/upload-artifact@v4
         with:
           name: npm-package
-          path: artifacts/*.tgz
+          path: ${{ steps.packed-artifact.outputs.tarball }}
           if-no-files-found: error
           retention-days: 7
 
@@ -86,5 +103,22 @@ jobs:
           name: npm-package
           path: artifacts
 
+      - name: Resolve publish artifact
+        id: publish-artifact
+        shell: bash
+        run: |
+          mapfile -t tarballs < <(find artifacts -maxdepth 1 -type f -name '*.tgz' -print | sort)
+
+          if [ "${#tarballs[@]}" -ne 1 ]; then
+            echo "Expected exactly one npm package tarball in artifacts, found ${#tarballs[@]}." >&2
+            if [ "${#tarballs[@]}" -gt 0 ]; then
+              printf 'Found tarballs:\n' >&2
+              printf '  %s\n' "${tarballs[@]}" >&2
+            fi
+            exit 1
+          fi
+
+          echo "tarball=${tarballs[0]}" >> "$GITHUB_OUTPUT"
+
       - name: Publish to npm
-        run: npm publish ./artifacts/*.tgz --access public
+        run: npm publish "${{ steps.publish-artifact.outputs.tarball }}" --access public

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -80,8 +80,8 @@ Use these sources for context:
 
 5. After the release PR is merged to `main`, run the GitHub `Release` workflow:
 
-   - first with `publish` turned off for a rehearsal; this runs the verification job and stores the checked package tarball as a short-lived workflow artifact
-   - then with `publish` turned on for the real publish; this enters the `npm-publish` environment and publishes that verified tarball with OIDC
+   - first with `publish` turned off for a rehearsal; this runs the verification job, confirms there is exactly one package tarball, and stores that checked tarball as a short-lived workflow artifact
+   - then with `publish` turned on for the real publish; this enters the `npm-publish` environment, confirms the downloaded artifact still contains exactly one package tarball, and publishes that resolved tarball path with OIDC
 
 6. After publishing, complete the release follow-up checklist.
 


### PR DESCRIPTION
## Summary

- Resolve the packed npm tarball explicitly after `npm pack`.
- Fail the release workflow if the artifact directory contains zero or multiple `.tgz` files.
- Publish the resolved tarball path instead of relying on a glob.
- Document the single-tarball checks in the release guide and release PR template.

## Validation

- `npm run release:pr:check`
- `actionlint .github/workflows/release.yml`
- `git diff --check`
- Release workflow rehearsal with `publish=false`: https://github.com/mt4110/image-drop-input/actions/runs/25204985568

## Rehearsal Result

The `verify` job completed successfully on `feat/release-artifact-hardening`. The new `Resolve packed artifact` step passed, and artifact upload used the resolved tarball path: `artifacts/image-drop-input-0.3.0.tgz`.

The `publish` job was skipped as expected because the rehearsal ran with `publish=false`.