### PR TITLE
Document typed upload error handling

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -325,6 +325,32 @@ function toMessage(error: Error) {
 
 code は `invalid_type`, `file_too_large`, `image_too_small`, `image_too_large`, `too_many_pixels`, `decode_failed` です。英語 message を parse せずに翻訳できます。
 
+## Upload error
+
+組み込み upload helper の失敗は `ImageUploadError` として扱えます。`code` と `details` を見ることで、toast、retry copy、telemetry を `error.message` に依存せずに組めます。
+
+```ts
+import { isImageUploadError } from 'image-drop-input';
+
+function toUploadMessage(error: Error) {
+  if (!isImageUploadError(error)) {
+    return '画像を準備できませんでした。';
+  }
+
+  if (error.code === 'http_error' && error.details.status === 413) {
+    return 'アップロード先の上限を超えています。';
+  }
+
+  if (error.code === 'network_error') {
+    return '通信が切れました。もう一度お試しください。';
+  }
+
+  return '画像をアップロードできませんでした。';
+}
+```
+
+`details.stage`, `details.method`, `details.status` は telemetry に使えます。実際の再送は default UI の Retry、または headless の `canRetryUpload` / `retryUpload()` を使ってください。
+
 ## Headless usage
 
 UI を自前で組みたい場合は `useImageDropInput()` を使います。

--- a/README.md
+++ b/README.md
@@ -225,6 +225,47 @@ type PresignedPutTarget = {
 
 See [docs/uploads.md](./docs/uploads.md) for presigned PUT, multipart POST, raw PUT, custom adapters, progress, and abort behavior.
 
+## Upload error handling
+
+Built-in upload helpers throw `ImageUploadError` with stable `code` and `details` fields. Use `isImageUploadError()` for product copy, retry labels, and telemetry instead of parsing English messages.
+
+```tsx
+import { ImageDropInput, isImageUploadError } from 'image-drop-input';
+
+function toUploadMessage(error: Error) {
+  if (!isImageUploadError(error)) {
+    return 'Could not prepare this image.';
+  }
+
+  if (error.code === 'http_error' && error.details.status === 413) {
+    return 'This image is too large for the upload endpoint.';
+  }
+
+  if (error.code === 'network_error') {
+    return 'The network dropped the upload. Please try again.';
+  }
+
+  return 'Image upload failed. Please try again.';
+}
+
+<ImageDropInput
+  value={value}
+  onChange={setValue}
+  upload={upload}
+  onError={(error) => {
+    if (isImageUploadError(error)) {
+      reportUploadFailure({
+        code: error.code,
+        stage: error.details.stage,
+        status: error.details.status
+      });
+    }
+  }}
+/>;
+```
+
+The default UI can retry failed uploads without rerunning `transform`. Headless UIs get the same flow through `canRetryUpload` and `retryUpload()`.
+
 ## Transform recipes
 
 Use `transform` when you want to resize, compress, or convert the image before preview and upload.
@@ -285,14 +326,15 @@ Read the checklist in [docs/accessibility.md](./docs/accessibility.md).
 
 | Import | Exports |
 | --- | --- |
-| `image-drop-input` | `ImageDropInput`, UI props and render types, `ImageUploadValue`, upload types, validation error helpers |
-| `image-drop-input/headless` | `useImageDropInput`, `compressImage`, `validateImage`, metadata helpers, upload factories |
+| `image-drop-input` | `ImageDropInput`, UI props and render types, `ImageUploadValue`, upload types, validation and upload error helpers |
+| `image-drop-input/headless` | `useImageDropInput`, `compressImage`, `validateImage`, metadata helpers, upload factories, upload error helpers |
 | `image-drop-input/style.css` | default component styles |
 
 ```ts
 import {
   ImageDropInput,
   ImageValidationError,
+  isImageUploadError,
   isImageValidationError,
   type ImageDropInputProps,
   type ImageUploadValue,

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ Start with:
 
 - [Value model](./value-model.md): how `src`, `previewSrc`, `key`, and metadata fit together
 - [Validation](./validation.md): source limits, output limits, dimensions, pixels, and error codes
-- [Uploads](./uploads.md): adapter contracts, signed upload boundaries, progress, and aborts
+- [Uploads](./uploads.md): adapter contracts, signed upload boundaries, progress, typed upload errors, and aborts
 - [Transforms](./transforms.md): compression, WebP conversion, return shapes, and MIME consistency
 - [Accessibility](./accessibility.md): keyboard, paste, status, dialog, and headless responsibilities
 

--- a/docs/uploads.md
+++ b/docs/uploads.md
@@ -214,7 +214,7 @@ function toUploadFailureEvent(error: Error) {
 }
 ```
 
-Upload error details include fields such as stage, method, status, response body, and raw response body. They do not include signed upload URLs, request headers, authorization values, or provider credentials. Treat `body` and `rawBody` as diagnostics, not end-user copy, because they come from your upload endpoint.
+Upload error details include helper-generated fields such as stage, method, and status, and may also include response body data such as `body` and `rawBody`. The helper-generated fields do not include signed upload URLs, request headers, authorization values, or provider credentials. Treat `body`, `rawBody`, and any attached `cause` as potentially sensitive diagnostics, not end-user copy, because they may include whatever your upload endpoint or underlying error returns and should not be logged indiscriminately.
 
 ## Abort signal
 

--- a/docs/uploads.md
+++ b/docs/uploads.md
@@ -156,7 +156,7 @@ Successful uploads finish with `100`, even if the adapter did not emit `100` its
 
 Built-in upload helpers throw `ImageUploadError` for package-owned upload failures. The React component still reports errors through `onError(error: Error)`, so existing handlers keep working.
 
-Use `isImageUploadError()` when your product needs localized copy, retry labels, or telemetry tags without parsing English messages.
+Use `isImageUploadError()` when your product needs localized copy, retry labels, or telemetry tags without parsing English messages. Use the component or hook retry action for the actual retry; use the typed error shape to decide how that retry should be presented.
 
 ```ts
 import {
@@ -179,9 +179,42 @@ function toUserMessage(error: Error) {
 
   return 'Could not prepare this image.';
 }
+
+function shouldEmphasizeRetry(error: Error) {
+  if (!isImageUploadError(error)) {
+    return false;
+  }
+
+  if (error.code === 'network_error' || error.code === 'request_unavailable') {
+    return true;
+  }
+
+  return (
+    error.code === 'http_error' &&
+    typeof error.details.status === 'number' &&
+    (error.details.status === 408 ||
+      error.details.status === 409 ||
+      error.details.status === 425 ||
+      error.details.status === 429 ||
+      (error.details.status >= 500 && error.details.status < 600))
+  );
+}
+
+function toUploadFailureEvent(error: Error) {
+  if (!isImageUploadError(error)) {
+    return null;
+  }
+
+  return {
+    code: error.code,
+    stage: error.details.stage,
+    method: error.details.method,
+    status: error.details.status
+  };
+}
 ```
 
-Upload error details include safe fields such as stage, method, status, response body, and raw response body. They do not include signed upload URLs, request headers, authorization values, or provider credentials.
+Upload error details include fields such as stage, method, status, response body, and raw response body. They do not include signed upload URLs, request headers, authorization values, or provider credentials. Treat `body` and `rawBody` as diagnostics, not end-user copy, because they come from your upload endpoint.
 
 ## Abort signal
 

--- a/tests/react/use-image-drop-input.test.tsx
+++ b/tests/react/use-image-drop-input.test.tsx
@@ -5,7 +5,7 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useImageDropInput } from '../../src/react/use-image-drop-input';
 import type { ImageUploadValue } from '../../src/core/types';
-import { ImageUploadError } from '../../src/upload/errors';
+import { ImageUploadError, isImageUploadError } from '../../src/upload/errors';
 import { createRawPutUploader } from '../../src/upload/create-raw-put-uploader';
 import type { UploadAdapter } from '../../src/upload/types';
 
@@ -393,7 +393,16 @@ describe('useImageDropInput', () => {
   });
 
   it('passes structured errors from built-in upload helpers to onError', async () => {
-    const onError = vi.fn();
+    const telemetry = vi.fn();
+    const onError = vi.fn((error: Error) => {
+      if (isImageUploadError(error)) {
+        telemetry({
+          code: error.code,
+          stage: error.details.stage,
+          status: error.details.status
+        });
+      }
+    });
     const uploadError = new ImageUploadError(
       'http_error',
       'Upload failed: 413 Payload Too Large',
@@ -420,6 +429,11 @@ describe('useImageDropInput', () => {
     });
 
     expect(onError).toHaveBeenCalledWith(uploadError);
+    expect(telemetry).toHaveBeenCalledWith({
+      code: 'http_error',
+      stage: 'request',
+      status: 413
+    });
     expect(result.current.error).toBe(uploadError);
     expect(result.current.canRetryUpload).toBe(true);
   });

--- a/tests/upload/uploaders.test.ts
+++ b/tests/upload/uploaders.test.ts
@@ -494,6 +494,19 @@ describe('upload adapters', () => {
     expect(
       isImageUploadError({
         name: 'ImageUploadError',
+        message: 'Upload failed due to a network error.',
+        code: 'network_error',
+        details: {
+          stage: 'request',
+          method: 'POST',
+          body: { error: 'temporary_unavailable' },
+          rawBody: '{"error":"temporary_unavailable"}'
+        }
+      })
+    ).toBe(true);
+    expect(
+      isImageUploadError({
+        name: 'ImageUploadError',
         message: 'Upload failed.',
         code: 'http_error',
         details: {


### PR DESCRIPTION
## Summary

- Add README guidance for `isImageUploadError()` so upload failures can drive product copy and telemetry without parsing messages.
- Expand upload docs with retry-presentation and telemetry examples based on `code`, `stage`, `method`, and `status`.
- Mirror the upload error guidance in the Japanese README and docs index.
- Add tests that exercise typed upload-error telemetry handling from the hook and structural narrowing for upload errors.

## Validation

- `npm test -- tests/upload/uploaders.test.ts tests/react/use-image-drop-input.test.tsx`
- `npm run typecheck`
- `npm run release:pr:check`