### PR TITLE
Bump GitHub Actions to Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
     env:
       NODE_VERSION: 22
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -42,9 +42,9 @@ jobs:
     env:
       NODE_VERSION: 22
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -61,7 +61,7 @@ jobs:
       - run: npm ci
       - run: npm run pack:consumer-smoke
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: consumer-package
           path: .artifacts/image-drop-input.tgz
@@ -78,13 +78,13 @@ jobs:
           - 20.x
           - 22.x
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: consumer-package
           path: .artifacts

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,9 +22,9 @@ jobs:
       NODE_VERSION: 22
       GITHUB_PAGES: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
@@ -42,10 +42,10 @@ jobs:
       - run: npm run build:pages
 
       - name: Configure Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: examples/vite/dist
 
@@ -59,4 +59,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: https://registry.npmjs.org
@@ -63,7 +63,7 @@ jobs:
 
           echo "tarball=${tarballs[0]}" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: npm-package
           path: ${{ steps.packed-artifact.outputs.tarball }}
@@ -79,9 +79,9 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: https://registry.npmjs.org
@@ -98,7 +98,7 @@ jobs:
       - run: npm --version
       - run: npm ci
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: npm-package
           path: artifacts


### PR DESCRIPTION
## Summary

- Update official workflow actions to their Node 24 runtime majors.
- Cover CI, Pages, and Release workflows.
- Leave package code and release scripts unchanged.

## Validation

- `actionlint .github/workflows/ci.yml .github/workflows/pages.yml .github/workflows/release.yml`
- `git diff --check`
- PR CI: https://github.com/mt4110/image-drop-input/actions/runs/25206076100
- Pages workflow rehearsal: https://github.com/mt4110/image-drop-input/actions/runs/25206078922
- Release workflow rehearsal with `publish=false`: https://github.com/mt4110/image-drop-input/actions/runs/25206078931

## Rehearsal Result

- CI passed, including consumer smoke on Node 18.18.0, 20.x, and 22.x.
- Pages build passed with deploy skipped on the branch as expected.
- Release verify passed with `actions/upload-artifact@v7`; publish was skipped as expected for `publish=false`.