### PR TITLE
release: 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 Notable changes for `image-drop-input` are tracked here.
 
+## 0.3.1 - 2026-05-01
+
+### Changed
+
+- Documented typed upload error handling patterns for product copy, retry presentation, and telemetry.
+- Updated GitHub Actions workflows to official Node 24 runtime action majors.
+
+### Fixed
+
+- Hardened the release workflow so npm publish artifacts are resolved as exactly one tarball before upload and publish.
+
 ## 0.3.0 - 2026-05-01
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "image-drop-input",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "image-drop-input",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "workspaces": [
         "examples/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "image-drop-input",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Product-safe React image input for preview, validation, compression, paste, and signed uploads.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

- release version: 0.3.1
- dist-tag: latest
- scope: patch release for release workflow hardening, typed upload error docs, and GitHub Actions runtime maintenance

## Highlights

- Release publishing now verifies exactly one npm tarball before artifact upload and publish.
- Upload error docs now show how to use `isImageUploadError()` for product copy, retry presentation, and telemetry.
- GitHub Actions workflows now use official Node 24 runtime action majors.

## Checks

- [x] `package.json` and `package-lock.json` carry the intended version
- [x] `CHANGELOG.md` includes the release-facing notes
- [x] release-facing notes are included in the PR body
- [x] `npm run release:pr:check`
- [x] packed package contains the English canonical `README.md`, docs, license, dist files, and no local-only files

## Publish Readiness

- [x] npm Trusted Publisher is configured for `mt4110/image-drop-input`, workflow filename `release.yml`, and environment `npm-publish`
- [x] the release workflow uses OIDC for publish and does not depend on `NPM_TOKEN` or `NODE_AUTH_TOKEN`

## Publish Plan

- [ ] merge to `main`
- [ ] run the `Release` workflow from `main` with `publish` off and confirm the rehearsal passed
- [ ] confirm the rehearsal resolved exactly one package tarball artifact
- [ ] create GitHub release `v0.3.1`
- [ ] confirm the release-triggered publish job used the `npm-publish` environment

## Post-publish Checks

- [ ] npm package page version matches `package.json` on `main`
- [ ] npm package page README starts with the English canonical `README.md`
- [ ] npm install snippet is `npm install image-drop-input react`
- [ ] npm homepage link opens the GitHub Pages demo
- [ ] npm repository link opens `mt4110/image-drop-input`
- [ ] npm bugs link opens the GitHub issue tracker
- [ ] npm provenance is visible for the published version

## Notes

- breaking changes: none
- follow-up work: continue collecting real usage reports