### PR TITLE
fix: publish release tarball by relative path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
             exit 1
           fi
 
-          echo "tarball=${tarballs[0]}" >> "$GITHUB_OUTPUT"
+          echo "tarball=./${tarballs[0]#./}" >> "$GITHUB_OUTPUT"
 
       - uses: actions/upload-artifact@v7
         with:
@@ -118,7 +118,7 @@ jobs:
             exit 1
           fi
 
-          echo "tarball=${tarballs[0]}" >> "$GITHUB_OUTPUT"
+          echo "tarball=./${tarballs[0]#./}" >> "$GITHUB_OUTPUT"
 
       - name: Publish to npm
         run: npm publish "${{ steps.publish-artifact.outputs.tarball }}" --access public


### PR DESCRIPTION
## Summary

- Prefix the resolved release tarball output with `./` before passing it to upload and publish steps.
- Prevent npm from interpreting `artifacts/image-drop-input-*.tgz` as a package or git spec.

## Validation

- `actionlint .github/workflows/release.yml`
- `git diff --check`

## Context

The `v0.3.1` release workflow verified and downloaded the tarball correctly, but `npm publish "artifacts/image-drop-input-0.3.1.tgz"` was interpreted as a package spec. The publish retry should use the fixed workflow from `main` with `publish=true`.