### PR TITLE
feat: add persistable image value guard

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -157,6 +157,26 @@ type ImageUploadValue = {
 
 upload が失敗した場合、component は最後に commit 済みの値へ戻り、Retry では同じ prepared file を再送します。
 
+## 保存してよい値だけにする
+
+form submit の直前で `toPersistableImageValue()` を使うと、`previewSrc` を落とし、`blob:` などの一時 URL を保存 payload に混ぜる事故を防げます。
+
+```tsx
+import { toPersistableImageValue } from 'image-drop-input';
+
+async function submitProfile() {
+  const image = toPersistableImageValue(value);
+
+  await fetch('/api/profile', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ image })
+  });
+}
+```
+
+`src` または `key` のような永続参照だけを API / DB に渡してください。詳しくは [Persistable value guard](./docs/persistable-value.md) を参照してください。
+
 ## Recipes
 
 - [Next.js App Router](./docs/recipes/nextjs-app-router.md)

--- a/README.md
+++ b/README.md
@@ -149,6 +149,28 @@ failed upload           -> previous committed value remains safe
 
 Read the full state model in [docs/value-model.md](./docs/value-model.md).
 
+## Persist only durable image state
+
+Before a form payload reaches your API, strip browser-only preview fields and reject temporary image URLs:
+
+```tsx
+import { toPersistableImageValue } from 'image-drop-input';
+
+async function submitProfile() {
+  const image = toPersistableImageValue(value);
+
+  await fetch('/api/profile', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ image })
+  });
+}
+```
+
+`toPersistableImageValue()` never returns `previewSrc`, rejects `blob:` / `filesystem:` / `data:` `src` values by default, and accepts durable `src` or `key` references.
+
+Read the submit-boundary guide in [docs/persistable-value.md](./docs/persistable-value.md).
+
 ## Validation and byte limits
 
 Validation runs before and after `transform`.

--- a/consumer-fixtures/headless-cjs/index.cjs
+++ b/consumer-fixtures/headless-cjs/index.cjs
@@ -7,6 +7,11 @@ const requiredFunctions = [
   'createRawPutUploader',
   'ImageUploadError',
   'isImageUploadError',
+  'ImagePersistableValueError',
+  'toPersistableImageValue',
+  'assertPersistableImageValue',
+  'isPersistableImageValue',
+  'isTemporaryImageSrc',
   'validateImage'
 ];
 
@@ -24,4 +29,17 @@ const uploadError = new headless.ImageUploadError(
 
 if (!headless.isImageUploadError(uploadError)) {
   throw new Error('Expected headless isImageUploadError to narrow ImageUploadError.');
+}
+
+const persistableValue = headless.toPersistableImageValue({
+  src: 'https://cdn.example.com/avatar.webp',
+  previewSrc: 'blob:preview'
+});
+
+if (persistableValue.previewSrc) {
+  throw new Error('Expected previewSrc to be removed from persistable image values.');
+}
+
+if (!headless.isPersistableImageValue(persistableValue)) {
+  throw new Error('Expected headless isPersistableImageValue to accept durable image values.');
 }

--- a/consumer-fixtures/root-types/src/index.tsx
+++ b/consumer-fixtures/root-types/src/index.tsx
@@ -1,13 +1,21 @@
 import {
   ImageDropInput,
+  ImagePersistableValueError,
   ImageUploadError,
   ImageValidationError,
+  assertPersistableImageValue,
+  isPersistableImageValue,
   isImageUploadError,
+  isTemporaryImageSrc,
+  toPersistableImageValue,
   type ImageDropInputProps,
+  type ImagePersistableValueErrorDetails,
+  type ImagePersistableValueErrorOptions,
   type ImageUploadErrorDetails,
   type ImageUploadErrorOptions,
   type ImageValidationErrorOptions,
-  type ImageUploadValue
+  type ImageUploadValue,
+  type PersistableImageValue
 } from 'image-drop-input';
 import 'image-drop-input/style.css';
 
@@ -47,7 +55,28 @@ const validationError = new ImageValidationError(
   },
   validationErrorOptions
 );
+const persistableValue: PersistableImageValue | null = toPersistableImageValue({
+  src: 'https://cdn.example.com/avatar.webp',
+  previewSrc: 'blob:preview'
+});
+const persistableDetails: ImagePersistableValueErrorDetails = {
+  field: 'src',
+  srcProtocol: 'blob:'
+};
+const persistableErrorOptions: ImagePersistableValueErrorOptions = {
+  cause: validationError
+};
+const persistableError = new ImagePersistableValueError(
+  'src_is_temporary',
+  'Temporary image src cannot be persisted.',
+  persistableDetails,
+  persistableErrorOptions
+);
 
 void node;
 void isImageUploadError(uploadError);
+void isTemporaryImageSrc('blob:preview');
+void isPersistableImageValue(persistableValue);
+void assertPersistableImageValue(persistableValue);
 void validationError;
+void persistableError;

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@
 Start with:
 
 - [Value model](./value-model.md): how `src`, `previewSrc`, `key`, and metadata fit together
+- [Persistable value guard](./persistable-value.md): remove temporary preview state before submit
 - [Validation](./validation.md): source limits, output limits, dimensions, pixels, and error codes
 - [Uploads](./uploads.md): adapter contracts, signed upload boundaries, progress, typed upload errors, and aborts
 - [Transforms](./transforms.md): compression, WebP conversion, return shapes, and MIME consistency

--- a/docs/persistable-value.md
+++ b/docs/persistable-value.md
@@ -1,0 +1,125 @@
+# Persistable value guard
+
+`ImageUploadValue` can contain browser-only preview state. Product payloads should not.
+
+Use `toPersistableImageValue()` at the submit boundary to keep temporary fields out of your API request or database row.
+
+```tsx
+import { toPersistableImageValue, type ImageUploadValue } from 'image-drop-input';
+
+async function submitProfile(value: ImageUploadValue | null) {
+  const image = toPersistableImageValue(value);
+
+  await fetch('/api/profile', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ image })
+  });
+}
+```
+
+## What it keeps
+
+`toPersistableImageValue()` copies only durable image fields:
+
+```ts
+type PersistableImageValue = {
+  src?: string;
+  key?: string;
+  fileName?: string;
+  mimeType?: string;
+  size?: number;
+  width?: number;
+  height?: number;
+};
+```
+
+It never returns `previewSrc`.
+
+## What it rejects
+
+By default, the helper rejects values that cannot safely represent product state:
+
+- values with only `previewSrc`
+- `src` values using `blob:`
+- `src` values using `filesystem:`
+- `src` values using `data:`
+- values with neither `src` nor `key`
+- invalid metadata such as negative `size` or `width: 0`
+
+```tsx
+import { ImagePersistableValueError, toPersistableImageValue } from 'image-drop-input';
+
+try {
+  const image = toPersistableImageValue(value);
+  await save({ image });
+} catch (error) {
+  if (error instanceof ImagePersistableValueError) {
+    // Show product-specific copy or log error.code.
+  }
+}
+```
+
+## Runtime guards
+
+Use `isPersistableImageValue()` when you only need a boolean check.
+
+```ts
+if (!isPersistableImageValue(value)) {
+  throw new Error('Image is not ready to save.');
+}
+```
+
+Use `assertPersistableImageValue()` when a caller already owns sanitization and only needs validation. It does not remove `previewSrc`; `toPersistableImageValue()` is the safer submit helper.
+
+```ts
+assertPersistableImageValue(payload.image);
+```
+
+## React Hook Form example
+
+```tsx
+import { toPersistableImageValue, type ImageUploadValue } from 'image-drop-input';
+
+async function onSubmit(form: { name: string; image: ImageUploadValue | null }) {
+  await fetch('/api/profile', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      name: form.name,
+      image: toPersistableImageValue(form.image)
+    })
+  });
+}
+```
+
+## Next.js server payload
+
+Your route should receive a persistable image value, not a browser preview.
+
+```ts
+type ProfilePayload = {
+  name: string;
+  image: {
+    src?: string;
+    key?: string;
+    fileName?: string;
+    mimeType?: string;
+    size?: number;
+    width?: number;
+    height?: number;
+  } | null;
+};
+```
+
+Validate the payload again on the server with your own schema. This package keeps browser state out of the client payload, but the server still owns authorization, storage policy, and persistence.
+
+## Common mistakes
+
+Do not save `previewSrc`. It is usually a local `blob:` URL.
+
+Do not save a `blob:` URL in `src`.
+
+Do not infer a public image URL from a signed upload URL. Return the durable `src` or `key` from your backend.
+
+Do not treat a draft object key as final product state unless your backend contract says it is final. Draft commit and cleanup belong to the draft lifecycle layer.

--- a/docs/persistable-value.md
+++ b/docs/persistable-value.md
@@ -76,6 +76,22 @@ Use `assertPersistableImageValue()` when a caller already owns sanitization and 
 assertPersistableImageValue(payload.image);
 ```
 
+Because this assertion does not mutate the original object, it rejects values that still contain `previewSrc`. Use `toPersistableImageValue()` for raw component values.
+
+## Temporary URL escape hatches
+
+Temporary URL schemes are rejected by default. If your product intentionally persists one of these schemes, opt in explicitly:
+
+```ts
+toPersistableImageValue(value, {
+  allowDataUrl: true,
+  allowBlobUrl: true,
+  allowFilesystemUrl: true
+});
+```
+
+`allowBlobUrl` only affects `blob:` URLs. `filesystem:` requires `allowFilesystemUrl`.
+
 ## React Hook Form example
 
 ```tsx

--- a/docs/persistable-value.md
+++ b/docs/persistable-value.md
@@ -18,6 +18,8 @@ async function submitProfile(value: ImageUploadValue | null) {
 }
 ```
 
+`null` and `undefined` inputs return `null` from this submit helper so optional image fields can be normalized before serialization.
+
 ## What it keeps
 
 `toPersistableImageValue()` copies only durable image fields:
@@ -77,6 +79,8 @@ assertPersistableImageValue(payload.image);
 ```
 
 Because this assertion does not mutate the original object, it rejects values that still contain `previewSrc`. Use `toPersistableImageValue()` for raw component values.
+
+`null` is accepted by the guard helpers as an already-normalized empty image value. `undefined` is rejected by the assertion/type guard path so TypeScript narrowing cannot hide an unnormalized variable.
 
 ## Temporary URL escape hatches
 

--- a/docs/value-model.md
+++ b/docs/value-model.md
@@ -86,6 +86,8 @@ That behavior prevents a product form from accidentally treating an unuploaded l
 
 Do not save `previewSrc` to your database.
 
+Use [`toPersistableImageValue()`](./persistable-value.md) at your submit boundary to remove temporary browser-only fields before sending image state to your API.
+
 Do not infer a public URL from a signed upload URL.
 
 Do not treat `key` as a browser-renderable image URL unless your application explicitly resolves it.

--- a/src/core/persistable-image-value.ts
+++ b/src/core/persistable-image-value.ts
@@ -1,0 +1,245 @@
+import type { ImageUploadValue } from './types';
+
+export interface PersistableImageValue {
+  src?: string;
+  key?: string;
+  fileName?: string;
+  mimeType?: string;
+  size?: number;
+  width?: number;
+  height?: number;
+}
+
+export interface PersistableImageValueOptions {
+  allowEmptyReference?: boolean;
+  allowDataUrl?: boolean;
+  allowBlobUrl?: boolean;
+  stripUndefined?: boolean;
+}
+
+export type ImagePersistableValueErrorCode =
+  | 'preview_src_not_persistable'
+  | 'src_is_temporary'
+  | 'empty_reference'
+  | 'invalid_metadata';
+
+export interface ImagePersistableValueErrorDetails {
+  field?: string;
+  srcProtocol?: string;
+}
+
+export interface ImagePersistableValueErrorOptions {
+  cause?: unknown;
+}
+
+export class ImagePersistableValueError extends Error {
+  readonly code: ImagePersistableValueErrorCode;
+  readonly details: ImagePersistableValueErrorDetails;
+
+  constructor(
+    code: ImagePersistableValueErrorCode,
+    message: string,
+    details: ImagePersistableValueErrorDetails = {},
+    options?: ImagePersistableValueErrorOptions
+  ) {
+    super(message, options);
+    this.name = 'ImagePersistableValueError';
+    this.code = code;
+    this.details = details;
+  }
+}
+
+const temporarySrcSchemes = new Set(['blob', 'filesystem', 'data']);
+
+function getLowercaseScheme(src: string): string | null {
+  const match = /^([a-zA-Z][a-zA-Z0-9+.-]*):/.exec(src.trim());
+
+  return match ? match[1].toLowerCase() : null;
+}
+
+function hasReference(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isValidOptionalString(value: unknown): boolean {
+  return typeof value === 'undefined' || typeof value === 'string';
+}
+
+function isValidOptionalNonNegativeNumber(value: unknown): boolean {
+  return (
+    typeof value === 'undefined' ||
+    (typeof value === 'number' && Number.isFinite(value) && value >= 0)
+  );
+}
+
+function isValidOptionalPositiveNumber(value: unknown): boolean {
+  return (
+    typeof value === 'undefined' ||
+    (typeof value === 'number' && Number.isFinite(value) && value > 0)
+  );
+}
+
+function validateMetadata(value: PersistableImageValue): void {
+  if (!isValidOptionalString(value.src)) {
+    throw new ImagePersistableValueError('invalid_metadata', 'Image src must be a string.', {
+      field: 'src'
+    });
+  }
+
+  if (!isValidOptionalString(value.key)) {
+    throw new ImagePersistableValueError('invalid_metadata', 'Image key must be a string.', {
+      field: 'key'
+    });
+  }
+
+  if (!isValidOptionalString(value.fileName)) {
+    throw new ImagePersistableValueError(
+      'invalid_metadata',
+      'Image fileName must be a string.',
+      {
+        field: 'fileName'
+      }
+    );
+  }
+
+  if (!isValidOptionalString(value.mimeType)) {
+    throw new ImagePersistableValueError(
+      'invalid_metadata',
+      'Image mimeType must be a string.',
+      {
+        field: 'mimeType'
+      }
+    );
+  }
+
+  if (!isValidOptionalNonNegativeNumber(value.size)) {
+    throw new ImagePersistableValueError(
+      'invalid_metadata',
+      'Image size must be a finite non-negative number.',
+      {
+        field: 'size'
+      }
+    );
+  }
+
+  if (!isValidOptionalPositiveNumber(value.width)) {
+    throw new ImagePersistableValueError(
+      'invalid_metadata',
+      'Image width must be a finite positive number.',
+      {
+        field: 'width'
+      }
+    );
+  }
+
+  if (!isValidOptionalPositiveNumber(value.height)) {
+    throw new ImagePersistableValueError(
+      'invalid_metadata',
+      'Image height must be a finite positive number.',
+      {
+        field: 'height'
+      }
+    );
+  }
+}
+
+function stripUndefinedProperties(value: PersistableImageValue): PersistableImageValue {
+  return {
+    ...(typeof value.src !== 'undefined' ? { src: value.src } : {}),
+    ...(typeof value.key !== 'undefined' ? { key: value.key } : {}),
+    ...(typeof value.fileName !== 'undefined' ? { fileName: value.fileName } : {}),
+    ...(typeof value.mimeType !== 'undefined' ? { mimeType: value.mimeType } : {}),
+    ...(typeof value.size !== 'undefined' ? { size: value.size } : {}),
+    ...(typeof value.width !== 'undefined' ? { width: value.width } : {}),
+    ...(typeof value.height !== 'undefined' ? { height: value.height } : {})
+  };
+}
+
+export function isTemporaryImageSrc(src: string): boolean {
+  const scheme = getLowercaseScheme(src);
+
+  return scheme !== null && temporarySrcSchemes.has(scheme);
+}
+
+export function toPersistableImageValue(
+  value: ImageUploadValue | PersistableImageValue | null | undefined,
+  options: PersistableImageValueOptions = {}
+): PersistableImageValue | null {
+  if (value == null) {
+    return null;
+  }
+
+  const persistable: PersistableImageValue = {
+    src: value.src,
+    key: value.key,
+    fileName: value.fileName,
+    mimeType: value.mimeType,
+    size: value.size,
+    width: value.width,
+    height: value.height
+  };
+
+  if (hasReference(persistable.src)) {
+    const scheme = getLowercaseScheme(persistable.src);
+
+    if (
+      (scheme === 'blob' || scheme === 'filesystem') &&
+      options.allowBlobUrl !== true
+    ) {
+      throw new ImagePersistableValueError(
+        'src_is_temporary',
+        'Image src is a temporary browser URL and must not be persisted.',
+        { field: 'src', srcProtocol: `${scheme}:` }
+      );
+    }
+
+    if (scheme === 'data' && options.allowDataUrl !== true) {
+      throw new ImagePersistableValueError(
+        'src_is_temporary',
+        'Image src is a data URL and must not be persisted unless explicitly allowed.',
+        { field: 'src', srcProtocol: 'data:' }
+      );
+    }
+  }
+
+  if (
+    !options.allowEmptyReference &&
+    !hasReference(persistable.src) &&
+    !hasReference(persistable.key)
+  ) {
+    throw new ImagePersistableValueError(
+      'empty_reference',
+      'Persistable image values need a durable src or key.'
+    );
+  }
+
+  validateMetadata(persistable);
+
+  return options.stripUndefined === false
+    ? persistable
+    : stripUndefinedProperties(persistable);
+}
+
+export function assertPersistableImageValue(
+  value: ImageUploadValue | PersistableImageValue | null | undefined,
+  options?: PersistableImageValueOptions
+): asserts value is PersistableImageValue | null {
+  toPersistableImageValue(value, options);
+}
+
+export function isPersistableImageValue(
+  value: ImageUploadValue | PersistableImageValue | null | undefined,
+  options?: PersistableImageValueOptions
+): value is PersistableImageValue | null {
+  try {
+    toPersistableImageValue(value, options);
+
+    return true;
+  } catch (error) {
+    if (error instanceof ImagePersistableValueError) {
+      return false;
+    }
+
+    throw error;
+  }
+}

--- a/src/core/persistable-image-value.ts
+++ b/src/core/persistable-image-value.ts
@@ -52,6 +52,10 @@ export class ImagePersistableValueError extends Error {
 
 const temporarySrcSchemes = new Set(['blob', 'filesystem', 'data']);
 
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 function getLowercaseScheme(src: string): string | null {
   const match = /^([a-zA-Z][a-zA-Z0-9+.-]*):/.exec(src.trim());
 
@@ -191,14 +195,22 @@ export function toPersistableImageValue(
     return null;
   }
 
+  if (!isObjectRecord(value)) {
+    throw new ImagePersistableValueError(
+      'invalid_metadata',
+      'Persistable image value must be an object or null.'
+    );
+  }
+
+  const imageValue = value as ImageUploadValue | PersistableImageValue;
   const persistable: PersistableImageValue = {
-    src: value.src,
-    key: value.key,
-    fileName: value.fileName,
-    mimeType: value.mimeType,
-    size: value.size,
-    width: value.width,
-    height: value.height
+    src: imageValue.src,
+    key: imageValue.key,
+    fileName: imageValue.fileName,
+    mimeType: imageValue.mimeType,
+    size: imageValue.size,
+    width: imageValue.width,
+    height: imageValue.height
   };
 
   validateMetadata(persistable);

--- a/src/core/persistable-image-value.ts
+++ b/src/core/persistable-image-value.ts
@@ -14,6 +14,7 @@ export interface PersistableImageValueOptions {
   allowEmptyReference?: boolean;
   allowDataUrl?: boolean;
   allowBlobUrl?: boolean;
+  allowFilesystemUrl?: boolean;
   stripUndefined?: boolean;
 }
 
@@ -59,6 +60,27 @@ function getLowercaseScheme(src: string): string | null {
 
 function hasReference(value: unknown): value is string {
   return typeof value === 'string' && value.trim().length > 0;
+}
+
+function hasPreviewSrc(value: unknown): value is { previewSrc: unknown } {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'previewSrc' in value &&
+    typeof (value as { previewSrc?: unknown }).previewSrc !== 'undefined'
+  );
+}
+
+function assertNoPreviewSrc(value: unknown): void {
+  if (!hasPreviewSrc(value)) {
+    return;
+  }
+
+  throw new ImagePersistableValueError(
+    'preview_src_not_persistable',
+    'Image previewSrc is browser-only state and must not be persisted.',
+    { field: 'previewSrc' }
+  );
 }
 
 function isValidOptionalString(value: unknown): boolean {
@@ -179,17 +201,24 @@ export function toPersistableImageValue(
     height: value.height
   };
 
+  validateMetadata(persistable);
+
   if (hasReference(persistable.src)) {
     const scheme = getLowercaseScheme(persistable.src);
 
-    if (
-      (scheme === 'blob' || scheme === 'filesystem') &&
-      options.allowBlobUrl !== true
-    ) {
+    if (scheme === 'blob' && options.allowBlobUrl !== true) {
       throw new ImagePersistableValueError(
         'src_is_temporary',
         'Image src is a temporary browser URL and must not be persisted.',
-        { field: 'src', srcProtocol: `${scheme}:` }
+        { field: 'src', srcProtocol: 'blob:' }
+      );
+    }
+
+    if (scheme === 'filesystem' && options.allowFilesystemUrl !== true) {
+      throw new ImagePersistableValueError(
+        'src_is_temporary',
+        'Image src is a filesystem URL and must not be persisted unless explicitly allowed.',
+        { field: 'src', srcProtocol: 'filesystem:' }
       );
     }
 
@@ -213,8 +242,6 @@ export function toPersistableImageValue(
     );
   }
 
-  validateMetadata(persistable);
-
   return options.stripUndefined === false
     ? persistable
     : stripUndefinedProperties(persistable);
@@ -224,6 +251,14 @@ export function assertPersistableImageValue(
   value: ImageUploadValue | PersistableImageValue | null | undefined,
   options?: PersistableImageValueOptions
 ): asserts value is PersistableImageValue | null {
+  if (typeof value === 'undefined') {
+    throw new ImagePersistableValueError(
+      'empty_reference',
+      'Persistable image values cannot be undefined.'
+    );
+  }
+
+  assertNoPreviewSrc(value);
   toPersistableImageValue(value, options);
 }
 
@@ -231,6 +266,10 @@ export function isPersistableImageValue(
   value: ImageUploadValue | PersistableImageValue | null | undefined,
   options?: PersistableImageValueOptions
 ): value is PersistableImageValue | null {
+  if (typeof value === 'undefined' || hasPreviewSrc(value)) {
+    return false;
+  }
+
   try {
     toPersistableImageValue(value, options);
 

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -11,6 +11,20 @@ export type { UseImageDropInputOptions, UseImageDropInputReturn } from './react/
 export { compressImage } from './core/compress-image';
 export { createObjectUrl } from './core/create-object-url';
 export { getImageMetadata } from './core/get-image-metadata';
+export {
+  assertPersistableImageValue,
+  ImagePersistableValueError,
+  isPersistableImageValue,
+  isTemporaryImageSrc,
+  toPersistableImageValue
+} from './core/persistable-image-value';
+export type {
+  ImagePersistableValueErrorCode,
+  ImagePersistableValueErrorDetails,
+  ImagePersistableValueErrorOptions,
+  PersistableImageValue,
+  PersistableImageValueOptions
+} from './core/persistable-image-value';
 export type {
   AspectRatioValue,
   CompressImageOptions,

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,20 @@ export type {
   ImageValidationErrorDetails
 } from './core/types';
 export { ImageValidationError, isImageValidationError } from './core/validate-image';
+export {
+  assertPersistableImageValue,
+  ImagePersistableValueError,
+  isPersistableImageValue,
+  isTemporaryImageSrc,
+  toPersistableImageValue
+} from './core/persistable-image-value';
+export type {
+  ImagePersistableValueErrorCode,
+  ImagePersistableValueErrorDetails,
+  ImagePersistableValueErrorOptions,
+  PersistableImageValue,
+  PersistableImageValueOptions
+} from './core/persistable-image-value';
 export type {
   UploadAdapter,
   UploadContext,

--- a/tests/core/persistable-image-value.test.ts
+++ b/tests/core/persistable-image-value.test.ts
@@ -1,0 +1,191 @@
+import '../setup';
+import { describe, expect, it } from 'vitest';
+import {
+  assertPersistableImageValue,
+  ImagePersistableValueError,
+  isPersistableImageValue,
+  isTemporaryImageSrc,
+  toPersistableImageValue
+} from '../../src/core/persistable-image-value';
+
+describe('persistable image value guards', () => {
+  it('drops previewSrc from values with a durable src', () => {
+    expect(
+      toPersistableImageValue({
+        src: 'https://cdn.example.com/avatar.webp',
+        previewSrc: 'blob:local-preview',
+        fileName: 'avatar.webp',
+        mimeType: 'image/webp',
+        size: 123,
+        width: 256,
+        height: 256
+      })
+    ).toEqual({
+      src: 'https://cdn.example.com/avatar.webp',
+      fileName: 'avatar.webp',
+      mimeType: 'image/webp',
+      size: 123,
+      width: 256,
+      height: 256
+    });
+  });
+
+  it('returns null for null and undefined values', () => {
+    expect(toPersistableImageValue(null)).toBeNull();
+    expect(toPersistableImageValue(undefined)).toBeNull();
+  });
+
+  it('accepts durable src values', () => {
+    expect(toPersistableImageValue({ src: '/images/avatar.webp' })).toEqual({
+      src: '/images/avatar.webp'
+    });
+  });
+
+  it('accepts key-only values', () => {
+    expect(toPersistableImageValue({ key: 'avatars/user-1.webp' })).toEqual({
+      key: 'avatars/user-1.webp'
+    });
+  });
+
+  it('rejects previewSrc-only values', () => {
+    expect(() => toPersistableImageValue({ previewSrc: 'blob:local-preview' })).toThrow(
+      ImagePersistableValueError
+    );
+
+    expect(() => toPersistableImageValue({ previewSrc: 'blob:local-preview' })).toThrowError(
+      expect.objectContaining({
+        code: 'empty_reference'
+      })
+    );
+  });
+
+  it('rejects blob src values by default', () => {
+    expect(() => toPersistableImageValue({ src: 'blob:https://example.com/123' })).toThrowError(
+      expect.objectContaining({
+        code: 'src_is_temporary',
+        details: {
+          field: 'src',
+          srcProtocol: 'blob:'
+        }
+      })
+    );
+  });
+
+  it('rejects filesystem src values by default', () => {
+    expect(() =>
+      toPersistableImageValue({ src: 'filesystem:https://example.com/temporary/avatar.png' })
+    ).toThrowError(
+      expect.objectContaining({
+        code: 'src_is_temporary',
+        details: {
+          field: 'src',
+          srcProtocol: 'filesystem:'
+        }
+      })
+    );
+  });
+
+  it('rejects data src values by default', () => {
+    expect(() => toPersistableImageValue({ src: 'data:image/png;base64,abc' })).toThrowError(
+      expect.objectContaining({
+        code: 'src_is_temporary',
+        details: {
+          field: 'src',
+          srcProtocol: 'data:'
+        }
+      })
+    );
+  });
+
+  it('allows data URLs when explicitly requested', () => {
+    expect(
+      toPersistableImageValue(
+        { src: 'data:image/png;base64,abc' },
+        { allowDataUrl: true }
+      )
+    ).toEqual({
+      src: 'data:image/png;base64,abc'
+    });
+  });
+
+  it('allows blob URLs when explicitly requested', () => {
+    expect(
+      toPersistableImageValue(
+        { src: 'blob:https://example.com/123' },
+        { allowBlobUrl: true }
+      )
+    ).toEqual({
+      src: 'blob:https://example.com/123'
+    });
+  });
+
+  it('rejects negative size metadata', () => {
+    expect(() => toPersistableImageValue({ key: 'avatars/user-1.webp', size: -1 })).toThrowError(
+      expect.objectContaining({
+        code: 'invalid_metadata',
+        details: {
+          field: 'size'
+        }
+      })
+    );
+  });
+
+  it('rejects zero width metadata', () => {
+    expect(() => toPersistableImageValue({ key: 'avatars/user-1.webp', width: 0 })).toThrowError(
+      expect.objectContaining({
+        code: 'invalid_metadata',
+        details: {
+          field: 'width'
+        }
+      })
+    );
+  });
+
+  it('strips undefined properties by default', () => {
+    expect(
+      toPersistableImageValue({
+        src: 'https://cdn.example.com/avatar.webp',
+        key: undefined,
+        fileName: undefined
+      })
+    ).toEqual({
+      src: 'https://cdn.example.com/avatar.webp'
+    });
+  });
+
+  it('keeps undefined properties when stripUndefined is false', () => {
+    const value = toPersistableImageValue(
+      {
+        src: 'https://cdn.example.com/avatar.webp',
+        key: undefined,
+        fileName: undefined
+      },
+      { stripUndefined: false }
+    );
+
+    expect(value).toHaveProperty('src', 'https://cdn.example.com/avatar.webp');
+    expect(value).toHaveProperty('key', undefined);
+    expect(value).toHaveProperty('fileName', undefined);
+  });
+
+  it('returns false for invalid persistable values', () => {
+    expect(isPersistableImageValue({ src: 'blob:local-preview' })).toBe(false);
+    expect(isPersistableImageValue({ key: 'avatars/user-1.webp' })).toBe(true);
+  });
+
+  it('throws a typed error from assertPersistableImageValue', () => {
+    expect(() => assertPersistableImageValue({ src: 'data:image/png;base64,abc' })).toThrow(
+      ImagePersistableValueError
+    );
+  });
+
+  it('identifies temporary image sources without requiring URL parsing', () => {
+    expect(isTemporaryImageSrc('blob:https://example.com/123')).toBe(true);
+    expect(isTemporaryImageSrc('filesystem:https://example.com/temporary/avatar.png')).toBe(true);
+    expect(isTemporaryImageSrc('data:image/png;base64,abc')).toBe(true);
+    expect(isTemporaryImageSrc('https://cdn.example.com/avatar.webp')).toBe(false);
+    expect(isTemporaryImageSrc('/images/avatar.webp')).toBe(false);
+    expect(isTemporaryImageSrc('//cdn.example.com/avatar.webp')).toBe(false);
+    expect(isTemporaryImageSrc('')).toBe(false);
+  });
+});

--- a/tests/core/persistable-image-value.test.ts
+++ b/tests/core/persistable-image-value.test.ts
@@ -35,6 +35,11 @@ describe('persistable image value guards', () => {
     expect(toPersistableImageValue(undefined)).toBeNull();
   });
 
+  it('treats null as an already-normalized empty persistable value', () => {
+    expect(isPersistableImageValue(null)).toBe(true);
+    expect(() => assertPersistableImageValue(null)).not.toThrow();
+  });
+
   it('accepts durable src values', () => {
     expect(toPersistableImageValue({ src: '/images/avatar.webp' })).toEqual({
       src: '/images/avatar.webp'

--- a/tests/core/persistable-image-value.test.ts
+++ b/tests/core/persistable-image-value.test.ts
@@ -40,6 +40,38 @@ describe('persistable image value guards', () => {
     expect(() => assertPersistableImageValue(null)).not.toThrow();
   });
 
+  it('rejects non-object runtime values even when empty references are allowed', () => {
+    expect(() =>
+      toPersistableImageValue(0 as never, { allowEmptyReference: true })
+    ).toThrowError(
+      expect.objectContaining({
+        code: 'invalid_metadata'
+      })
+    );
+    expect(() =>
+      toPersistableImageValue(false as never, { allowEmptyReference: true })
+    ).toThrowError(
+      expect.objectContaining({
+        code: 'invalid_metadata'
+      })
+    );
+    expect(() =>
+      toPersistableImageValue('avatar' as never, { allowEmptyReference: true })
+    ).toThrowError(
+      expect.objectContaining({
+        code: 'invalid_metadata'
+      })
+    );
+    expect(() =>
+      toPersistableImageValue([] as never, { allowEmptyReference: true })
+    ).toThrowError(
+      expect.objectContaining({
+        code: 'invalid_metadata'
+      })
+    );
+    expect(isPersistableImageValue(0 as never, { allowEmptyReference: true })).toBe(false);
+  });
+
   it('accepts durable src values', () => {
     expect(toPersistableImageValue({ src: '/images/avatar.webp' })).toEqual({
       src: '/images/avatar.webp'

--- a/tests/core/persistable-image-value.test.ts
+++ b/tests/core/persistable-image-value.test.ts
@@ -119,6 +119,34 @@ describe('persistable image value guards', () => {
     });
   });
 
+  it('does not allow filesystem URLs through the blob URL option', () => {
+    expect(() =>
+      toPersistableImageValue(
+        { src: 'filesystem:https://example.com/temporary/avatar.png' },
+        { allowBlobUrl: true }
+      )
+    ).toThrowError(
+      expect.objectContaining({
+        code: 'src_is_temporary',
+        details: {
+          field: 'src',
+          srcProtocol: 'filesystem:'
+        }
+      })
+    );
+  });
+
+  it('allows filesystem URLs only when explicitly requested', () => {
+    expect(
+      toPersistableImageValue(
+        { src: 'filesystem:https://example.com/temporary/avatar.png' },
+        { allowFilesystemUrl: true }
+      )
+    ).toEqual({
+      src: 'filesystem:https://example.com/temporary/avatar.png'
+    });
+  });
+
   it('rejects negative size metadata', () => {
     expect(() => toPersistableImageValue({ key: 'avatars/user-1.webp', size: -1 })).toThrowError(
       expect.objectContaining({
@@ -170,12 +198,43 @@ describe('persistable image value guards', () => {
 
   it('returns false for invalid persistable values', () => {
     expect(isPersistableImageValue({ src: 'blob:local-preview' })).toBe(false);
+    expect(isPersistableImageValue(undefined)).toBe(false);
+    expect(
+      isPersistableImageValue({
+        src: 'https://cdn.example.com/avatar.webp',
+        previewSrc: 'blob:local-preview'
+      })
+    ).toBe(false);
     expect(isPersistableImageValue({ key: 'avatars/user-1.webp' })).toBe(true);
   });
 
   it('throws a typed error from assertPersistableImageValue', () => {
     expect(() => assertPersistableImageValue({ src: 'data:image/png;base64,abc' })).toThrow(
       ImagePersistableValueError
+    );
+  });
+
+  it('rejects undefined from assertPersistableImageValue before narrowing', () => {
+    expect(() => assertPersistableImageValue(undefined)).toThrowError(
+      expect.objectContaining({
+        code: 'empty_reference'
+      })
+    );
+  });
+
+  it('rejects previewSrc from assertPersistableImageValue because it does not sanitize', () => {
+    expect(() =>
+      assertPersistableImageValue({
+        src: 'https://cdn.example.com/avatar.webp',
+        previewSrc: 'blob:local-preview'
+      })
+    ).toThrowError(
+      expect.objectContaining({
+        code: 'preview_src_not_persistable',
+        details: {
+          field: 'previewSrc'
+        }
+      })
     );
   });
 

--- a/tests/entrypoints.test.ts
+++ b/tests/entrypoints.test.ts
@@ -9,6 +9,11 @@ describe('package entrypoints', () => {
     expect(root.isImageValidationError).toBeTypeOf('function');
     expect(root.ImageUploadError).toBeTypeOf('function');
     expect(root.isImageUploadError).toBeTypeOf('function');
+    expect(root.ImagePersistableValueError).toBeTypeOf('function');
+    expect(root.toPersistableImageValue).toBeTypeOf('function');
+    expect(root.assertPersistableImageValue).toBeTypeOf('function');
+    expect(root.isPersistableImageValue).toBeTypeOf('function');
+    expect(root.isTemporaryImageSrc).toBeTypeOf('function');
     expect(root).not.toHaveProperty('compressImage');
     expect(root).not.toHaveProperty('createPresignedPutUploader');
     expect(root).not.toHaveProperty('useImageDropInput');
@@ -22,6 +27,11 @@ describe('package entrypoints', () => {
     expect(headless.isImageValidationError).toBeTypeOf('function');
     expect(headless.ImageUploadError).toBeTypeOf('function');
     expect(headless.isImageUploadError).toBeTypeOf('function');
+    expect(headless.ImagePersistableValueError).toBeTypeOf('function');
+    expect(headless.toPersistableImageValue).toBeTypeOf('function');
+    expect(headless.assertPersistableImageValue).toBeTypeOf('function');
+    expect(headless.isPersistableImageValue).toBeTypeOf('function');
+    expect(headless.isTemporaryImageSrc).toBeTypeOf('function');
     expect(headless.useImageDropInput).toBeTypeOf('function');
     expect(headless.validateImage).toBeTypeOf('function');
   });


### PR DESCRIPTION
## Summary

Adds a persistable image value guard for the submit boundary:

- adds `PersistableImageValue` and `ImagePersistableValueError`
- adds `toPersistableImageValue()`, `assertPersistableImageValue()`, `isPersistableImageValue()`, and `isTemporaryImageSrc()`
- exports the new helpers from both root and headless entrypoints
- documents how to keep `previewSrc` and temporary URLs out of API/database payloads
- extends unit, entrypoint, root type, and headless CJS smoke coverage

## Why

The package is moving toward a product-safe single image field, not a generic uploader. This change gives users an explicit runtime boundary between browser-only preview state and durable product image state.

## Validation

- `npm run verify`
- `npm run smoke:consumer`
- `npm run publish:check`