### PR TITLE
feat: add byte-budget image preparation helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,24 +183,31 @@ Validation runs before and after `transform`.
 
 ```tsx
 import { ImageDropInput } from 'image-drop-input';
-import { compressImage } from 'image-drop-input/headless';
+import { prepareImageToBudget } from 'image-drop-input/headless';
 
 <ImageDropInput
   inputMaxBytes={20 * 1024 * 1024}
-  outputMaxBytes={5 * 1024 * 1024}
-  transform={(file) =>
-    compressImage(file, {
+  outputMaxBytes={500_000}
+  transform={async (file) => {
+    const prepared = await prepareImageToBudget(file, {
+      outputMaxBytes: 500_000,
+      outputType: 'image/webp',
       maxWidth: 1600,
-      maxHeight: 1600,
-      quality: 0.86
-    })
-  }
+      maxHeight: 1600
+    });
+
+    return {
+      file: prepared.file,
+      fileName: prepared.fileName,
+      mimeType: prepared.mimeType
+    };
+  }}
 />
 ```
 
 Dimension and pixel-budget validation also runs after `transform`, so `onChange` receives metadata for the prepared file.
 
-Read the details in [docs/validation.md](./docs/validation.md).
+Read the details in [docs/validation.md](./docs/validation.md) and the deterministic byte-budget guide in [docs/byte-budget.md](./docs/byte-budget.md).
 
 ## Upload recipes
 
@@ -349,7 +356,7 @@ Read the checklist in [docs/accessibility.md](./docs/accessibility.md).
 | Import | Exports |
 | --- | --- |
 | `image-drop-input` | `ImageDropInput`, UI props and render types, `ImageUploadValue`, upload types, validation and upload error helpers |
-| `image-drop-input/headless` | `useImageDropInput`, `compressImage`, `validateImage`, metadata helpers, upload factories, upload error helpers |
+| `image-drop-input/headless` | `useImageDropInput`, `compressImage`, `prepareImageToBudget`, `validateImage`, metadata helpers, upload factories, upload error helpers |
 | `image-drop-input/style.css` | default component styles |
 
 ```ts
@@ -370,6 +377,7 @@ import {
   createMultipartUploader,
   createPresignedPutUploader,
   createRawPutUploader,
+  prepareImageToBudget,
   useImageDropInput,
   validateImage,
   type UseImageDropInputReturn

--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ Read the checklist in [docs/accessibility.md](./docs/accessibility.md).
 | Import | Exports |
 | --- | --- |
 | `image-drop-input` | `ImageDropInput`, UI props and render types, `ImageUploadValue`, upload types, validation and upload error helpers |
-| `image-drop-input/headless` | `useImageDropInput`, `compressImage`, `prepareImageToBudget`, `validateImage`, metadata helpers, upload factories, upload error helpers |
+| `image-drop-input/headless` | `useImageDropInput`, `compressImage`, `prepareImageToBudget`, `validateImage`, metadata helpers, upload factories, budget/validation/upload error helpers |
 | `image-drop-input/style.css` | default component styles |
 
 ```ts
@@ -373,10 +373,12 @@ import {
 
 ```ts
 import {
+  ImageBudgetError,
   compressImage,
   createMultipartUploader,
   createPresignedPutUploader,
   createRawPutUploader,
+  isImageBudgetError,
   prepareImageToBudget,
   useImageDropInput,
   validateImage,

--- a/consumer-fixtures/headless-cjs/index.cjs
+++ b/consumer-fixtures/headless-cjs/index.cjs
@@ -4,6 +4,7 @@ const requiredFunctions = [
   'compressImage',
   'prepareImageToBudget',
   'ImageBudgetError',
+  'isImageBudgetError',
   'createMultipartUploader',
   'createPresignedPutUploader',
   'createRawPutUploader',
@@ -40,6 +41,10 @@ if (!headless.isImageUploadError(uploadError)) {
 
 if (budgetError.name !== 'ImageBudgetError' || budgetError.code !== 'budget_unreachable') {
   throw new Error('Expected headless ImageBudgetError to expose stable error fields.');
+}
+
+if (!headless.isImageBudgetError(budgetError)) {
+  throw new Error('Expected headless isImageBudgetError to narrow ImageBudgetError.');
 }
 
 const persistableValue = headless.toPersistableImageValue({

--- a/consumer-fixtures/headless-cjs/index.cjs
+++ b/consumer-fixtures/headless-cjs/index.cjs
@@ -2,6 +2,8 @@ const headless = require('image-drop-input/headless');
 
 const requiredFunctions = [
   'compressImage',
+  'prepareImageToBudget',
+  'ImageBudgetError',
   'createMultipartUploader',
   'createPresignedPutUploader',
   'createRawPutUploader',
@@ -26,9 +28,18 @@ const uploadError = new headless.ImageUploadError(
   'Upload failed due to a network error.',
   { stage: 'request', method: 'PUT' }
 );
+const budgetError = new headless.ImageBudgetError(
+  'budget_unreachable',
+  'Unable to prepare an image within the byte budget.',
+  { outputMaxBytes: 1, attempts: [] }
+);
 
 if (!headless.isImageUploadError(uploadError)) {
   throw new Error('Expected headless isImageUploadError to narrow ImageUploadError.');
+}
+
+if (budgetError.name !== 'ImageBudgetError' || budgetError.code !== 'budget_unreachable') {
+  throw new Error('Expected headless ImageBudgetError to expose stable error fields.');
 }
 
 const persistableValue = headless.toPersistableImageValue({

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ Start with:
 - [Value model](./value-model.md): how `src`, `previewSrc`, `key`, and metadata fit together
 - [Persistable value guard](./persistable-value.md): remove temporary preview state before submit
 - [Validation](./validation.md): source limits, output limits, dimensions, pixels, and error codes
+- [Byte budget solver](./byte-budget.md): prepare images to fit an output byte budget
 - [Uploads](./uploads.md): adapter contracts, signed upload boundaries, progress, typed upload errors, and aborts
 - [Transforms](./transforms.md): compression, WebP conversion, return shapes, and MIME consistency
 - [Accessibility](./accessibility.md): keyboard, paste, status, dialog, and headless responsibilities

--- a/docs/byte-budget.md
+++ b/docs/byte-budget.md
@@ -78,7 +78,7 @@ If `fileName` is provided, the helper uses it as-is. Otherwise it derives an ext
 
 ## Errors
 
-`prepareImageToBudget()` throws `ImageBudgetError` with a stable `code`:
+`prepareImageToBudget()` throws `ImageBudgetError` with a stable `code`. Use `isImageBudgetError()` when product copy, retry labels, or telemetry need stable narrowing without relying on `instanceof`.
 
 | Code | Meaning |
 | --- | --- |

--- a/docs/byte-budget.md
+++ b/docs/byte-budget.md
@@ -1,0 +1,95 @@
+# Byte Budget Solver
+
+`outputMaxBytes` is still the final validation guard. Use `prepareImageToBudget()` when you want the browser transform step to actively produce an image at or below the same byte budget.
+
+```tsx
+import { ImageDropInput } from 'image-drop-input';
+import { prepareImageToBudget } from 'image-drop-input/headless';
+
+<ImageDropInput
+  inputMaxBytes={20 * 1024 * 1024}
+  outputMaxBytes={500_000}
+  transform={async (file) => {
+    const prepared = await prepareImageToBudget(file, {
+      outputMaxBytes: 500_000,
+      outputType: 'image/webp',
+      maxWidth: 1600,
+      maxHeight: 1600
+    });
+
+    return {
+      file: prepared.file,
+      fileName: prepared.fileName,
+      mimeType: prepared.mimeType
+    };
+  }}
+/>
+```
+
+Keep `outputMaxBytes` on `ImageDropInput`. The helper targets the budget, then the component validates the prepared file before preview or upload.
+
+## What it does
+
+For JPEG and WebP output, the helper tries quality search first, then deterministic resize steps if quality alone cannot reach the budget.
+
+For PNG output, browser canvas quality settings are not reliable, so the helper uses resize-only attempts.
+
+The helper does not upscale. If the source image or the fitted `maxWidth` / `maxHeight` dimensions cannot satisfy `minWidth` / `minHeight`, it throws `budget_unreachable` before encoding.
+
+The result describes the prepared output, not the source image:
+
+```ts
+const prepared = await prepareImageToBudget(file, {
+  outputMaxBytes: 500_000,
+  outputType: 'image/webp'
+});
+
+prepared.size <= 500_000;
+prepared.fileName;        // derived extension matches output MIME
+prepared.mimeType;        // image/webp
+prepared.width;           // prepared width
+prepared.height;          // prepared height
+prepared.attempts;        // deterministic encode history
+prepared.strategy;        // source-within-budget, quality-search, resize, ...
+```
+
+## Policy
+
+```ts
+type ImageBudgetPolicy = {
+  outputMaxBytes: number;
+  outputType?: 'image/jpeg' | 'image/png' | 'image/webp';
+  maxWidth?: number;
+  maxHeight?: number;
+  minWidth?: number;
+  minHeight?: number;
+  initialQuality?: number;      // default: 0.86
+  minQuality?: number;          // default: 0.6
+  maxEncodeAttempts?: number;   // default: 12
+  qualitySearch?: 'binary';
+  resizeStepRatio?: number;     // default: 0.85
+  fileName?: string;
+};
+```
+
+If `outputType` is omitted, supported source types are preserved. Unsupported source types default to WebP output.
+
+If `fileName` is provided, the helper uses it as-is. Otherwise it derives an extension from the output MIME type.
+
+## Errors
+
+`prepareImageToBudget()` throws `ImageBudgetError` with a stable `code`:
+
+| Code | Meaning |
+| --- | --- |
+| `invalid_policy` | budget, quality, attempt, or dimension options are invalid |
+| `decode_failed` | browser image decoding failed |
+| `encode_failed` | canvas encoding failed |
+| `unsupported_output_type` | requested output type is not supported or the browser cannot encode it |
+| `budget_unreachable` | all bounded attempts failed to fit the byte budget |
+
+`budget_unreachable` includes the attempted encodes in `error.details.attempts`, which is useful for logs and tuning product defaults.
+
+## Browser boundary
+
+The solver uses browser image decoding and canvas encoding. Do not run it in a Server Component, route handler, or Node image pipeline. Keep server work focused on presign, auth, persistence, and storage policy.

--- a/docs/transforms.md
+++ b/docs/transforms.md
@@ -33,6 +33,8 @@ import { compressImage } from 'image-drop-input/headless';
 />
 ```
 
+When you need the prepared image to fit a byte budget instead of guessing a quality value, use [`prepareImageToBudget()`](./byte-budget.md).
+
 ## WebP conversion
 
 When changing the output format, keep the file name and MIME metadata consistent.

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -22,6 +22,8 @@ Use `outputMaxBytes` when product storage, upload, or API limits apply to the pr
 
 `maxBytes` applies to both stages when the stage-specific prop is not set.
 
+When you want the transform step to actively create an image under the same limit, use [`prepareImageToBudget()`](./byte-budget.md) and keep `outputMaxBytes` as the final guard.
+
 ## MIME and extension rules
 
 `accept` uses normal file input accept syntax:

--- a/src/core/canvas-image.ts
+++ b/src/core/canvas-image.ts
@@ -1,0 +1,56 @@
+export interface ImageCanvas {
+  context: OffscreenCanvasRenderingContext2D | CanvasRenderingContext2D;
+  toBlob: (type: string, quality?: number) => Promise<Blob>;
+}
+
+export function createImageCanvas(width: number, height: number): ImageCanvas {
+  if (typeof OffscreenCanvas !== 'undefined') {
+    const canvas = new OffscreenCanvas(width, height);
+    const context = canvas.getContext('2d');
+
+    if (!context) {
+      throw new Error('2D canvas is unavailable in this environment.');
+    }
+
+    return {
+      context,
+      toBlob(type, quality) {
+        return canvas.convertToBlob({ type, quality });
+      }
+    };
+  }
+
+  if (typeof document === 'undefined') {
+    throw new Error('Canvas-based image transforms are unavailable in this environment.');
+  }
+
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+
+  const context = canvas.getContext('2d');
+
+  if (!context) {
+    throw new Error('2D canvas is unavailable in this environment.');
+  }
+
+  return {
+    context,
+    toBlob(type, quality) {
+      return new Promise<Blob>((resolve, reject) => {
+        canvas.toBlob(
+          (blob) => {
+            if (blob) {
+              resolve(blob);
+              return;
+            }
+
+            reject(new Error('Unable to encode the transformed image.'));
+          },
+          type,
+          quality
+        );
+      });
+    }
+  };
+}

--- a/src/core/compress-image.ts
+++ b/src/core/compress-image.ts
@@ -1,3 +1,4 @@
+import { createImageCanvas } from './canvas-image';
 import { decodeImage } from './decode-image';
 import type { CompressImageOptions } from './types';
 
@@ -15,62 +16,6 @@ function pickOutputType(sourceType: string, requestedType: CompressImageOptions[
   }
 
   return 'image/jpeg';
-}
-
-
-function createCanvas(width: number, height: number): {
-  context: OffscreenCanvasRenderingContext2D | CanvasRenderingContext2D;
-  toBlob: (type: string, quality?: number) => Promise<Blob>;
-} {
-  if (typeof OffscreenCanvas !== 'undefined') {
-    const canvas = new OffscreenCanvas(width, height);
-    const context = canvas.getContext('2d');
-
-    if (!context) {
-      throw new Error('2D canvas is unavailable in this environment.');
-    }
-
-    return {
-      context,
-      toBlob(type, quality) {
-        return canvas.convertToBlob({ type, quality });
-      }
-    };
-  }
-
-  if (typeof document === 'undefined') {
-    throw new Error('Canvas-based image transforms are unavailable in this environment.');
-  }
-
-  const canvas = document.createElement('canvas');
-  canvas.width = width;
-  canvas.height = height;
-
-  const context = canvas.getContext('2d');
-
-  if (!context) {
-    throw new Error('2D canvas is unavailable in this environment.');
-  }
-
-  return {
-    context,
-    toBlob(type, quality) {
-      return new Promise<Blob>((resolve, reject) => {
-        canvas.toBlob(
-          (blob) => {
-            if (blob) {
-              resolve(blob);
-              return;
-            }
-
-            reject(new Error('Unable to encode the transformed image.'));
-          },
-          type,
-          quality
-        );
-      });
-    }
-  };
 }
 
 export async function compressImage(source: Blob, options: CompressImageOptions = {}): Promise<Blob> {
@@ -94,7 +39,7 @@ export async function compressImage(source: Blob, options: CompressImageOptions 
       return source;
     }
 
-    const { context, toBlob } = createCanvas(width, height);
+    const { context, toBlob } = createImageCanvas(width, height);
 
     context.drawImage(decodedImage.drawSource, 0, 0, width, height);
     const blob = await toBlob(outputType, quality);

--- a/src/core/prepare-image-to-budget.ts
+++ b/src/core/prepare-image-to-budget.ts
@@ -86,6 +86,14 @@ export class ImageBudgetError extends Error {
   }
 }
 
+const imageBudgetErrorCodeList = [
+  'invalid_policy',
+  'decode_failed',
+  'encode_failed',
+  'unsupported_output_type',
+  'budget_unreachable'
+] as const satisfies readonly ImageBudgetErrorCode[];
+
 type ImageBudgetOutputType = NonNullable<ImageBudgetPolicy['outputType']>;
 
 interface ResolvedImageBudgetPolicy {
@@ -113,7 +121,15 @@ interface EncodedImageCandidate {
 }
 
 const supportedOutputTypes = ['image/jpeg', 'image/png', 'image/webp'] as const;
+const imageBudgetStrategyList = [
+  'source-within-budget',
+  'resize',
+  'quality-search',
+  'resize-and-quality-search'
+] as const satisfies readonly ImageBudgetStrategy[];
 const supportedOutputTypeSet = new Set<string>(supportedOutputTypes);
+const imageBudgetErrorCodes = new Set<ImageBudgetErrorCode>(imageBudgetErrorCodeList);
+const imageBudgetStrategies = new Set<ImageBudgetStrategy>(imageBudgetStrategyList);
 
 const defaultInitialQuality = 0.86;
 const defaultMinQuality = 0.6;
@@ -127,6 +143,10 @@ function isSupportedOutputType(value: string): value is ImageBudgetOutputType {
 
 function isFiniteNumber(value: unknown): value is number {
   return typeof value === 'number' && Number.isFinite(value);
+}
+
+function isIntegerAtLeast(value: unknown, minimum: number): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= minimum;
 }
 
 function isObjectRecord(value: unknown): value is Record<string, unknown> {
@@ -191,18 +211,80 @@ function fileNameMatchesImageMimeType(fileName: string, mimeType: string): boole
   }
 }
 
-function resolveOriginalFileName(file: Blob, outputType: string, policyFileName?: string): string {
+function hasOptionalFiniteNumber(
+  details: Record<string, unknown>,
+  key: keyof ImageBudgetErrorDetails
+): boolean {
+  const value = details[key];
+
+  return typeof value === 'undefined' || (typeof value === 'number' && Number.isFinite(value));
+}
+
+function isImageBudgetAttempt(value: unknown): value is ImageBudgetAttempt {
+  if (!isObjectRecord(value)) {
+    return false;
+  }
+
+  return (
+    isIntegerAtLeast(value.attempt, 1) &&
+    isIntegerAtLeast(value.width, 1) &&
+    isIntegerAtLeast(value.height, 1) &&
+    typeof value.mimeType === 'string' &&
+    isSupportedOutputType(value.mimeType) &&
+    isIntegerAtLeast(value.size, 0) &&
+    typeof value.withinBudget === 'boolean' &&
+    typeof value.strategy === 'string' &&
+    imageBudgetStrategies.has(value.strategy as ImageBudgetStrategy) &&
+    (typeof value.quality === 'undefined' ||
+      (typeof value.quality === 'number' &&
+        Number.isFinite(value.quality) &&
+        value.quality > 0 &&
+        value.quality <= 1))
+  );
+}
+
+function hasOptionalAttempts(details: Record<string, unknown>): boolean {
+  const attempts = details.attempts;
+
+  return (
+    typeof attempts === 'undefined' ||
+    (Array.isArray(attempts) && attempts.every(isImageBudgetAttempt))
+  );
+}
+
+export function isImageBudgetError(error: unknown): error is ImageBudgetError {
+  if (!isObjectRecord(error)) {
+    return false;
+  }
+
+  if (
+    error.name !== 'ImageBudgetError' ||
+    typeof error.message !== 'string' ||
+    typeof error.code !== 'string' ||
+    !imageBudgetErrorCodes.has(error.code as ImageBudgetErrorCode) ||
+    !isObjectRecord(error.details)
+  ) {
+    return false;
+  }
+
+  return (
+    hasOptionalFiniteNumber(error.details, 'outputMaxBytes') &&
+    hasOptionalFiniteNumber(error.details, 'minWidth') &&
+    hasOptionalFiniteNumber(error.details, 'minHeight') &&
+    hasOptionalAttempts(error.details)
+  );
+}
+
+function resolveOriginalFileName(file: Blob, sourceType: string): string {
   const fileName = getImageFileName(file);
 
   if (fileName) {
     return fileName;
   }
 
-  if (typeof policyFileName === 'string') {
-    return policyFileName;
-  }
+  const extension = getImageExtension(sourceType);
 
-  return `image${getImageExtension(outputType)}`;
+  return extension ? `image${extension}` : 'image';
 }
 
 function resolveOutputFileName(
@@ -236,7 +318,7 @@ function createInvalidPolicyError(
   });
 }
 
-function validatePositiveOptionalDimension(
+function validateMaxDimension(
   value: number | undefined,
   fieldName: string,
   policy: ImageBudgetPolicy
@@ -245,8 +327,11 @@ function validatePositiveOptionalDimension(
     return;
   }
 
-  if (!isFiniteNumber(value) || value <= 0) {
-    throw createInvalidPolicyError(`${fieldName} must be a finite positive number.`, policy);
+  if (!isFiniteNumber(value) || value < 1) {
+    throw createInvalidPolicyError(
+      `${fieldName} must be a finite number greater than or equal to 1.`,
+      policy
+    );
   }
 }
 
@@ -277,9 +362,11 @@ function resolvePolicy(file: Blob, policy: ImageBudgetPolicy): ResolvedImageBudg
   const requestedOutputType = toMimeType(policy.outputType);
 
   if (hasRequestedOutputType && !isSupportedOutputType(requestedOutputType)) {
+    const unsupportedOutputType = requestedOutputType || '(empty)';
+
     throw new ImageBudgetError(
       'unsupported_output_type',
-      `Unsupported image output type: ${requestedOutputType}.`,
+      `Unsupported image output type: ${unsupportedOutputType}.`,
       { outputMaxBytes: policy.outputMaxBytes }
     );
   }
@@ -321,8 +408,8 @@ function resolvePolicy(file: Blob, policy: ImageBudgetPolicy): ResolvedImageBudg
     throw createInvalidPolicyError('resizeStepRatio must be greater than 0 and less than 1.', policy);
   }
 
-  validatePositiveOptionalDimension(policy.maxWidth, 'maxWidth', policy);
-  validatePositiveOptionalDimension(policy.maxHeight, 'maxHeight', policy);
+  validateMaxDimension(policy.maxWidth, 'maxWidth', policy);
+  validateMaxDimension(policy.maxHeight, 'maxHeight', policy);
   validateNonNegativeOptionalDimension(policy.minWidth, 'minWidth', policy);
   validateNonNegativeOptionalDimension(policy.minHeight, 'minHeight', policy);
 
@@ -365,10 +452,16 @@ function fitWithinMaxDimensions(
   const maxWidth = policy.maxWidth ?? originalWidth;
   const maxHeight = policy.maxHeight ?? originalHeight;
   const scale = Math.min(1, maxWidth / originalWidth, maxHeight / originalHeight);
+  const width = Math.max(1, Math.round(originalWidth * scale));
+  const height = Math.max(1, Math.round(originalHeight * scale));
 
   return {
-    width: Math.max(1, Math.round(originalWidth * scale)),
-    height: Math.max(1, Math.round(originalHeight * scale))
+    width: typeof policy.maxWidth === 'number'
+      ? Math.min(width, Math.floor(policy.maxWidth))
+      : width,
+    height: typeof policy.maxHeight === 'number'
+      ? Math.min(height, Math.floor(policy.maxHeight))
+      : height
   };
 }
 
@@ -673,7 +766,7 @@ export async function prepareImageToBudget(
 
   const resolvedPolicy = resolvePolicy(file, policy);
   const sourceType = toMimeType(file.type);
-  const originalFileName = resolveOriginalFileName(file, resolvedPolicy.outputType, policy.fileName);
+  const originalFileName = resolveOriginalFileName(file, sourceType);
   let decodedImage: DecodedImage;
 
   try {

--- a/src/core/prepare-image-to-budget.ts
+++ b/src/core/prepare-image-to-budget.ts
@@ -1,0 +1,806 @@
+import { createImageCanvas } from './canvas-image';
+import { decodeImage, type DecodedImage } from './decode-image';
+
+export type ImageBudgetStrategy =
+  | 'source-within-budget'
+  | 'resize'
+  | 'quality-search'
+  | 'resize-and-quality-search';
+
+export interface ImageBudgetPolicy {
+  outputMaxBytes: number;
+  outputType?: 'image/jpeg' | 'image/png' | 'image/webp';
+  maxWidth?: number;
+  maxHeight?: number;
+  minWidth?: number;
+  minHeight?: number;
+  initialQuality?: number;
+  minQuality?: number;
+  maxEncodeAttempts?: number;
+  qualitySearch?: 'binary';
+  resizeStepRatio?: number;
+  fileName?: string;
+}
+
+export interface ImageBudgetAttempt {
+  attempt: number;
+  width: number;
+  height: number;
+  quality?: number;
+  mimeType: string;
+  size: number;
+  withinBudget: boolean;
+  strategy: ImageBudgetStrategy;
+}
+
+export interface PreparedImageToBudgetResult {
+  file: Blob;
+  fileName: string;
+  mimeType: string;
+  size: number;
+  width: number;
+  height: number;
+  originalFileName: string;
+  originalMimeType?: string;
+  originalSize: number;
+  originalWidth: number;
+  originalHeight: number;
+  outputMaxBytes: number;
+  compressionRatio: number;
+  attempts: ImageBudgetAttempt[];
+  strategy: ImageBudgetStrategy;
+}
+
+export type ImageBudgetErrorCode =
+  | 'invalid_policy'
+  | 'decode_failed'
+  | 'encode_failed'
+  | 'unsupported_output_type'
+  | 'budget_unreachable';
+
+export interface ImageBudgetErrorDetails {
+  outputMaxBytes?: number;
+  minWidth?: number;
+  minHeight?: number;
+  attempts?: ImageBudgetAttempt[];
+}
+
+export interface ImageBudgetErrorOptions {
+  cause?: unknown;
+}
+
+export class ImageBudgetError extends Error {
+  readonly code: ImageBudgetErrorCode;
+  readonly details: ImageBudgetErrorDetails;
+
+  constructor(
+    code: ImageBudgetErrorCode,
+    message: string,
+    details: ImageBudgetErrorDetails = {},
+    options?: ImageBudgetErrorOptions
+  ) {
+    super(message, options);
+    this.name = 'ImageBudgetError';
+    this.code = code;
+    this.details = details;
+  }
+}
+
+type ImageBudgetOutputType = NonNullable<ImageBudgetPolicy['outputType']>;
+
+interface ResolvedImageBudgetPolicy {
+  outputMaxBytes: number;
+  outputType: ImageBudgetOutputType;
+  maxWidth?: number;
+  maxHeight?: number;
+  minWidth?: number;
+  minHeight?: number;
+  initialQuality: number;
+  minQuality: number;
+  maxEncodeAttempts: number;
+  qualitySearch: 'binary';
+  resizeStepRatio: number;
+}
+
+interface ImageDimensions {
+  width: number;
+  height: number;
+}
+
+interface EncodedImageCandidate {
+  blob: Blob;
+  attempt: ImageBudgetAttempt;
+}
+
+const supportedOutputTypes = ['image/jpeg', 'image/png', 'image/webp'] as const;
+const supportedOutputTypeSet = new Set<string>(supportedOutputTypes);
+
+const defaultInitialQuality = 0.86;
+const defaultMinQuality = 0.6;
+const defaultMaxEncodeAttempts = 12;
+const defaultResizeStepRatio = 0.85;
+const qualitySearchEpsilon = 0.001;
+
+function isSupportedOutputType(value: string): value is ImageBudgetOutputType {
+  return supportedOutputTypeSet.has(value);
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function toMimeType(value: unknown): string {
+  return typeof value === 'string' ? value.trim().toLowerCase() : '';
+}
+
+function getImageFileName(file: Blob): string | undefined {
+  if (typeof File !== 'undefined' && file instanceof File && file.name) {
+    return file.name;
+  }
+
+  const name = (file as Blob & { name?: unknown }).name;
+
+  return typeof name === 'string' && name.length > 0 ? name : undefined;
+}
+
+function getImageExtension(mimeType: string): string {
+  switch (mimeType) {
+    case 'image/jpeg':
+      return '.jpg';
+    case 'image/png':
+      return '.png';
+    case 'image/webp':
+      return '.webp';
+    default:
+      return '';
+  }
+}
+
+function replaceImageFileExtension(fileName: string, mimeType: string): string {
+  const extension = getImageExtension(mimeType);
+
+  if (!extension) {
+    return fileName;
+  }
+
+  if (/\.(?:png|jpe?g|webp)$/i.test(fileName)) {
+    return fileName.replace(/\.(?:png|jpe?g|webp)$/i, extension);
+  }
+
+  if (/\.[^./\\]+$/.test(fileName)) {
+    return fileName.replace(/\.[^./\\]+$/, extension);
+  }
+
+  return `${fileName}${extension}`;
+}
+
+function fileNameMatchesImageMimeType(fileName: string, mimeType: string): boolean {
+  switch (mimeType) {
+    case 'image/jpeg':
+      return /\.(?:jpg|jpeg)$/i.test(fileName);
+    case 'image/png':
+      return /\.png$/i.test(fileName);
+    case 'image/webp':
+      return /\.webp$/i.test(fileName);
+    default:
+      return false;
+  }
+}
+
+function resolveOriginalFileName(file: Blob, outputType: string, policyFileName?: string): string {
+  const fileName = getImageFileName(file);
+
+  if (fileName) {
+    return fileName;
+  }
+
+  if (typeof policyFileName === 'string') {
+    return policyFileName;
+  }
+
+  return `image${getImageExtension(outputType)}`;
+}
+
+function resolveOutputFileName(
+  file: Blob,
+  outputType: string,
+  policyFileName?: string
+): string {
+  if (typeof policyFileName === 'string') {
+    return policyFileName;
+  }
+
+  const fileName = getImageFileName(file);
+
+  if (!fileName) {
+    return `image${getImageExtension(outputType)}`;
+  }
+
+  return fileNameMatchesImageMimeType(fileName, outputType)
+    ? fileName
+    : replaceImageFileExtension(fileName, outputType);
+}
+
+function createInvalidPolicyError(
+  message: string,
+  policy: Partial<ImageBudgetPolicy>
+): ImageBudgetError {
+  return new ImageBudgetError('invalid_policy', message, {
+    outputMaxBytes: policy.outputMaxBytes,
+    minWidth: policy.minWidth,
+    minHeight: policy.minHeight
+  });
+}
+
+function validatePositiveOptionalDimension(
+  value: number | undefined,
+  fieldName: string,
+  policy: ImageBudgetPolicy
+): void {
+  if (typeof value === 'undefined') {
+    return;
+  }
+
+  if (!isFiniteNumber(value) || value <= 0) {
+    throw createInvalidPolicyError(`${fieldName} must be a finite positive number.`, policy);
+  }
+}
+
+function validateNonNegativeOptionalDimension(
+  value: number | undefined,
+  fieldName: string,
+  policy: ImageBudgetPolicy
+): void {
+  if (typeof value === 'undefined') {
+    return;
+  }
+
+  if (!isFiniteNumber(value) || value < 0) {
+    throw createInvalidPolicyError(`${fieldName} must be a finite non-negative number.`, policy);
+  }
+}
+
+function resolvePolicy(file: Blob, policy: ImageBudgetPolicy): ResolvedImageBudgetPolicy {
+  if (!Number.isInteger(policy.outputMaxBytes) || policy.outputMaxBytes <= 0) {
+    throw createInvalidPolicyError('outputMaxBytes must be a finite positive integer.', policy);
+  }
+
+  if (typeof policy.outputType !== 'undefined' && typeof policy.outputType !== 'string') {
+    throw createInvalidPolicyError('outputType must be a supported image MIME type.', policy);
+  }
+
+  const hasRequestedOutputType = typeof policy.outputType !== 'undefined';
+  const requestedOutputType = toMimeType(policy.outputType);
+
+  if (hasRequestedOutputType && !isSupportedOutputType(requestedOutputType)) {
+    throw new ImageBudgetError(
+      'unsupported_output_type',
+      `Unsupported image output type: ${requestedOutputType}.`,
+      { outputMaxBytes: policy.outputMaxBytes }
+    );
+  }
+
+  const sourceType = toMimeType(file.type);
+  const outputType: ImageBudgetOutputType = requestedOutputType
+    ? (requestedOutputType as ImageBudgetOutputType)
+    : isSupportedOutputType(sourceType)
+      ? sourceType
+      : 'image/webp';
+
+  const initialQuality = policy.initialQuality ?? defaultInitialQuality;
+  const minQuality = policy.minQuality ?? defaultMinQuality;
+  const maxEncodeAttempts = policy.maxEncodeAttempts ?? defaultMaxEncodeAttempts;
+  const qualitySearch = policy.qualitySearch ?? 'binary';
+  const resizeStepRatio = policy.resizeStepRatio ?? defaultResizeStepRatio;
+
+  if (!isFiniteNumber(initialQuality) || initialQuality <= 0 || initialQuality > 1) {
+    throw createInvalidPolicyError('initialQuality must be in the range (0, 1].', policy);
+  }
+
+  if (!isFiniteNumber(minQuality) || minQuality <= 0 || minQuality > 1) {
+    throw createInvalidPolicyError('minQuality must be in the range (0, 1].', policy);
+  }
+
+  if (minQuality > initialQuality) {
+    throw createInvalidPolicyError('minQuality must not be greater than initialQuality.', policy);
+  }
+
+  if (!Number.isInteger(maxEncodeAttempts) || maxEncodeAttempts < 1) {
+    throw createInvalidPolicyError('maxEncodeAttempts must be a positive integer.', policy);
+  }
+
+  if (qualitySearch !== 'binary') {
+    throw createInvalidPolicyError('qualitySearch must be "binary".', policy);
+  }
+
+  if (!isFiniteNumber(resizeStepRatio) || resizeStepRatio <= 0 || resizeStepRatio >= 1) {
+    throw createInvalidPolicyError('resizeStepRatio must be greater than 0 and less than 1.', policy);
+  }
+
+  validatePositiveOptionalDimension(policy.maxWidth, 'maxWidth', policy);
+  validatePositiveOptionalDimension(policy.maxHeight, 'maxHeight', policy);
+  validateNonNegativeOptionalDimension(policy.minWidth, 'minWidth', policy);
+  validateNonNegativeOptionalDimension(policy.minHeight, 'minHeight', policy);
+
+  if (
+    typeof policy.maxWidth === 'number' &&
+    typeof policy.minWidth === 'number' &&
+    policy.maxWidth < policy.minWidth
+  ) {
+    throw createInvalidPolicyError('maxWidth must not be smaller than minWidth.', policy);
+  }
+
+  if (
+    typeof policy.maxHeight === 'number' &&
+    typeof policy.minHeight === 'number' &&
+    policy.maxHeight < policy.minHeight
+  ) {
+    throw createInvalidPolicyError('maxHeight must not be smaller than minHeight.', policy);
+  }
+
+  return {
+    outputMaxBytes: policy.outputMaxBytes,
+    outputType,
+    maxWidth: policy.maxWidth,
+    maxHeight: policy.maxHeight,
+    minWidth: policy.minWidth,
+    minHeight: policy.minHeight,
+    initialQuality,
+    minQuality,
+    maxEncodeAttempts,
+    qualitySearch,
+    resizeStepRatio
+  };
+}
+
+function fitWithinMaxDimensions(
+  originalWidth: number,
+  originalHeight: number,
+  policy: ResolvedImageBudgetPolicy
+): ImageDimensions {
+  const maxWidth = policy.maxWidth ?? originalWidth;
+  const maxHeight = policy.maxHeight ?? originalHeight;
+  const scale = Math.min(1, maxWidth / originalWidth, maxHeight / originalHeight);
+
+  return {
+    width: Math.max(1, Math.round(originalWidth * scale)),
+    height: Math.max(1, Math.round(originalHeight * scale))
+  };
+}
+
+function fitsMaxDimensions(width: number, height: number, policy: ResolvedImageBudgetPolicy): boolean {
+  return (
+    (typeof policy.maxWidth === 'undefined' || width <= policy.maxWidth) &&
+    (typeof policy.maxHeight === 'undefined' || height <= policy.maxHeight)
+  );
+}
+
+function fitsMinimumDimensions(
+  width: number,
+  height: number,
+  policy: ResolvedImageBudgetPolicy
+): boolean {
+  return (
+    (typeof policy.minWidth === 'undefined' || width >= policy.minWidth) &&
+    (typeof policy.minHeight === 'undefined' || height >= policy.minHeight)
+  );
+}
+
+function getMinimumDimensions(policy: ResolvedImageBudgetPolicy): ImageDimensions {
+  return {
+    width: Math.max(1, Math.ceil(policy.minWidth ?? 1)),
+    height: Math.max(1, Math.ceil(policy.minHeight ?? 1))
+  };
+}
+
+function getNextResizeDimensions(
+  current: ImageDimensions,
+  policy: ResolvedImageBudgetPolicy
+): ImageDimensions | null {
+  const minimum = getMinimumDimensions(policy);
+
+  if (current.width <= minimum.width && current.height <= minimum.height) {
+    return null;
+  }
+
+  let scale = policy.resizeStepRatio;
+
+  if (Math.round(current.width * scale) < minimum.width) {
+    scale = Math.max(scale, minimum.width / current.width);
+  }
+
+  if (Math.round(current.height * scale) < minimum.height) {
+    scale = Math.max(scale, minimum.height / current.height);
+  }
+
+  if (scale >= 1) {
+    return null;
+  }
+
+  let width = Math.max(minimum.width, Math.round(current.width * scale));
+  let height = Math.max(minimum.height, Math.round(current.height * scale));
+
+  if (width === current.width && height === current.height) {
+    const widthScale = current.width > minimum.width ? (current.width - 1) / current.width : 1;
+    const heightScale = current.height > minimum.height ? (current.height - 1) / current.height : 1;
+    const progressScale = Math.min(widthScale, heightScale);
+
+    if (progressScale >= 1) {
+      return null;
+    }
+
+    width = Math.max(minimum.width, Math.round(current.width * progressScale));
+    height = Math.max(minimum.height, Math.round(current.height * progressScale));
+  }
+
+  if (width === current.width && height === current.height) {
+    return null;
+  }
+
+  return { width, height };
+}
+
+function getAttemptStrategy(
+  dimensions: ImageDimensions,
+  originalDimensions: ImageDimensions,
+  outputType: ImageBudgetOutputType
+): ImageBudgetStrategy {
+  if (outputType === 'image/png') {
+    return 'resize';
+  }
+
+  return dimensions.width === originalDimensions.width && dimensions.height === originalDimensions.height
+    ? 'quality-search'
+    : 'resize-and-quality-search';
+}
+
+function roundQuality(value: number): number {
+  return Number(value.toFixed(4));
+}
+
+function getCompressionRatio(size: number, originalSize: number): number {
+  return size / originalSize;
+}
+
+async function encodeImageAttempt(
+  decodedImage: DecodedImage,
+  dimensions: ImageDimensions,
+  outputType: ImageBudgetOutputType,
+  quality: number | undefined,
+  policy: ResolvedImageBudgetPolicy,
+  attempts: ImageBudgetAttempt[],
+  strategy: ImageBudgetStrategy
+): Promise<EncodedImageCandidate> {
+  let blob: Blob;
+
+  try {
+    const { context, toBlob } = createImageCanvas(dimensions.width, dimensions.height);
+
+    context.drawImage(decodedImage.drawSource, 0, 0, dimensions.width, dimensions.height);
+    blob = await toBlob(outputType, quality);
+  } catch (error) {
+    throw new ImageBudgetError(
+      'encode_failed',
+      'Unable to encode the prepared image.',
+      {
+        outputMaxBytes: policy.outputMaxBytes,
+        minWidth: policy.minWidth,
+        minHeight: policy.minHeight,
+        attempts: attempts.slice()
+      },
+      { cause: error }
+    );
+  }
+
+  if (blob.type !== outputType) {
+    throw new ImageBudgetError(
+      'unsupported_output_type',
+      `This browser cannot encode ${outputType}.`,
+      {
+        outputMaxBytes: policy.outputMaxBytes,
+        minWidth: policy.minWidth,
+        minHeight: policy.minHeight,
+        attempts: attempts.slice()
+      }
+    );
+  }
+
+  const attempt: ImageBudgetAttempt = {
+    attempt: attempts.length + 1,
+    width: dimensions.width,
+    height: dimensions.height,
+    ...(typeof quality === 'number' ? { quality } : {}),
+    mimeType: outputType,
+    size: blob.size,
+    withinBudget: blob.size <= policy.outputMaxBytes,
+    strategy
+  };
+
+  attempts.push(attempt);
+
+  return { blob, attempt };
+}
+
+async function solvePngBudget(
+  decodedImage: DecodedImage,
+  initialDimensions: ImageDimensions,
+  originalDimensions: ImageDimensions,
+  policy: ResolvedImageBudgetPolicy,
+  attempts: ImageBudgetAttempt[]
+): Promise<EncodedImageCandidate | null> {
+  let dimensions = initialDimensions;
+
+  while (attempts.length < policy.maxEncodeAttempts) {
+    const candidate = await encodeImageAttempt(
+      decodedImage,
+      dimensions,
+      policy.outputType,
+      undefined,
+      policy,
+      attempts,
+      getAttemptStrategy(dimensions, originalDimensions, policy.outputType)
+    );
+
+    if (candidate.attempt.withinBudget) {
+      return candidate;
+    }
+
+    const nextDimensions = getNextResizeDimensions(dimensions, policy);
+
+    if (!nextDimensions) {
+      break;
+    }
+
+    dimensions = nextDimensions;
+  }
+
+  return null;
+}
+
+async function solveLossyBudget(
+  decodedImage: DecodedImage,
+  initialDimensions: ImageDimensions,
+  originalDimensions: ImageDimensions,
+  policy: ResolvedImageBudgetPolicy,
+  attempts: ImageBudgetAttempt[]
+): Promise<EncodedImageCandidate | null> {
+  let dimensions = initialDimensions;
+
+  while (attempts.length < policy.maxEncodeAttempts) {
+    const strategy = getAttemptStrategy(dimensions, originalDimensions, policy.outputType);
+    const initialCandidate = await encodeImageAttempt(
+      decodedImage,
+      dimensions,
+      policy.outputType,
+      policy.initialQuality,
+      policy,
+      attempts,
+      strategy
+    );
+
+    if (initialCandidate.attempt.withinBudget) {
+      return initialCandidate;
+    }
+
+    if (attempts.length >= policy.maxEncodeAttempts) {
+      break;
+    }
+
+    if (policy.minQuality < policy.initialQuality) {
+      const minCandidate = await encodeImageAttempt(
+        decodedImage,
+        dimensions,
+        policy.outputType,
+        policy.minQuality,
+        policy,
+        attempts,
+        strategy
+      );
+
+      if (minCandidate.attempt.withinBudget) {
+        let bestCandidate = minCandidate;
+        let lowQuality = policy.minQuality;
+        let highQuality = policy.initialQuality;
+
+        while (attempts.length < policy.maxEncodeAttempts && highQuality - lowQuality > qualitySearchEpsilon) {
+          const quality = roundQuality((lowQuality + highQuality) / 2);
+
+          if (quality <= lowQuality || quality >= highQuality) {
+            break;
+          }
+
+          const candidate = await encodeImageAttempt(
+            decodedImage,
+            dimensions,
+            policy.outputType,
+            quality,
+            policy,
+            attempts,
+            strategy
+          );
+
+          if (candidate.attempt.withinBudget) {
+            bestCandidate = candidate;
+            lowQuality = quality;
+          } else {
+            highQuality = quality;
+          }
+        }
+
+        return bestCandidate;
+      }
+    }
+
+    const nextDimensions = getNextResizeDimensions(dimensions, policy);
+
+    if (!nextDimensions) {
+      break;
+    }
+
+    dimensions = nextDimensions;
+  }
+
+  return null;
+}
+
+function createBudgetUnreachableError(
+  policy: ResolvedImageBudgetPolicy,
+  attempts: ImageBudgetAttempt[]
+): ImageBudgetError {
+  return new ImageBudgetError(
+    'budget_unreachable',
+    'Unable to prepare an image within the byte budget and dimension limits.',
+    {
+      outputMaxBytes: policy.outputMaxBytes,
+      minWidth: policy.minWidth,
+      minHeight: policy.minHeight,
+      attempts: attempts.slice()
+    }
+  );
+}
+
+export async function prepareImageToBudget(
+  file: File | Blob,
+  policy: ImageBudgetPolicy
+): Promise<PreparedImageToBudgetResult> {
+  if (!isObjectRecord(policy)) {
+    throw createInvalidPolicyError('Image budget policy must be an object.', {});
+  }
+
+  const resolvedPolicy = resolvePolicy(file, policy);
+  const sourceType = toMimeType(file.type);
+  const originalFileName = resolveOriginalFileName(file, resolvedPolicy.outputType, policy.fileName);
+  let decodedImage: DecodedImage;
+
+  try {
+    decodedImage = await decodeImage(file);
+  } catch (error) {
+    throw new ImageBudgetError(
+      'decode_failed',
+      'Unable to read image dimensions.',
+      {
+        outputMaxBytes: resolvedPolicy.outputMaxBytes,
+        minWidth: resolvedPolicy.minWidth,
+        minHeight: resolvedPolicy.minHeight
+      },
+      { cause: error }
+    );
+  }
+
+  try {
+    if (
+      !Number.isFinite(decodedImage.width) ||
+      !Number.isFinite(decodedImage.height) ||
+      decodedImage.width <= 0 ||
+      decodedImage.height <= 0
+    ) {
+      throw new ImageBudgetError(
+        'decode_failed',
+        'Unable to read valid image dimensions.',
+        {
+          outputMaxBytes: resolvedPolicy.outputMaxBytes,
+          minWidth: resolvedPolicy.minWidth,
+          minHeight: resolvedPolicy.minHeight
+        }
+      );
+    }
+
+    const originalDimensions = {
+      width: decodedImage.width,
+      height: decodedImage.height
+    };
+    const initialDimensions = fitWithinMaxDimensions(
+      decodedImage.width,
+      decodedImage.height,
+      resolvedPolicy
+    );
+    const outputFileName = resolveOutputFileName(
+      file,
+      resolvedPolicy.outputType,
+      policy.fileName
+    );
+
+    if (
+      !fitsMinimumDimensions(initialDimensions.width, initialDimensions.height, resolvedPolicy)
+    ) {
+      throw createBudgetUnreachableError(resolvedPolicy, []);
+    }
+
+    const sourceFitsBudget = file.size <= resolvedPolicy.outputMaxBytes;
+    const sourceFitsMaxDimensions = fitsMaxDimensions(
+      decodedImage.width,
+      decodedImage.height,
+      resolvedPolicy
+    );
+
+    if (
+      sourceFitsBudget &&
+      sourceType === resolvedPolicy.outputType &&
+      sourceFitsMaxDimensions
+    ) {
+      return {
+        file,
+        fileName: outputFileName,
+        mimeType: resolvedPolicy.outputType,
+        size: file.size,
+        width: decodedImage.width,
+        height: decodedImage.height,
+        originalFileName,
+        ...(file.type ? { originalMimeType: file.type } : {}),
+        originalSize: file.size,
+        originalWidth: decodedImage.width,
+        originalHeight: decodedImage.height,
+        outputMaxBytes: resolvedPolicy.outputMaxBytes,
+        compressionRatio: getCompressionRatio(file.size, file.size),
+        attempts: [],
+        strategy: 'source-within-budget'
+      };
+    }
+
+    const attempts: ImageBudgetAttempt[] = [];
+    const candidate =
+      resolvedPolicy.outputType === 'image/png'
+        ? await solvePngBudget(
+            decodedImage,
+            initialDimensions,
+            originalDimensions,
+            resolvedPolicy,
+            attempts
+          )
+        : await solveLossyBudget(
+            decodedImage,
+            initialDimensions,
+            originalDimensions,
+            resolvedPolicy,
+            attempts
+          );
+
+    if (!candidate) {
+      throw createBudgetUnreachableError(resolvedPolicy, attempts);
+    }
+
+    return {
+      file: candidate.blob,
+      fileName: outputFileName,
+      mimeType: resolvedPolicy.outputType,
+      size: candidate.blob.size,
+      width: candidate.attempt.width,
+      height: candidate.attempt.height,
+      originalFileName,
+      ...(file.type ? { originalMimeType: file.type } : {}),
+      originalSize: file.size,
+      originalWidth: decodedImage.width,
+      originalHeight: decodedImage.height,
+      outputMaxBytes: resolvedPolicy.outputMaxBytes,
+      compressionRatio: getCompressionRatio(candidate.blob.size, file.size),
+      attempts,
+      strategy: candidate.attempt.strategy
+    };
+  } finally {
+    decodedImage.cleanup();
+  }
+}

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -11,7 +11,11 @@ export type { UseImageDropInputOptions, UseImageDropInputReturn } from './react/
 export { compressImage } from './core/compress-image';
 export { createObjectUrl } from './core/create-object-url';
 export { getImageMetadata } from './core/get-image-metadata';
-export { ImageBudgetError, prepareImageToBudget } from './core/prepare-image-to-budget';
+export {
+  ImageBudgetError,
+  isImageBudgetError,
+  prepareImageToBudget
+} from './core/prepare-image-to-budget';
 export type {
   ImageBudgetAttempt,
   ImageBudgetErrorCode,

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -11,6 +11,16 @@ export type { UseImageDropInputOptions, UseImageDropInputReturn } from './react/
 export { compressImage } from './core/compress-image';
 export { createObjectUrl } from './core/create-object-url';
 export { getImageMetadata } from './core/get-image-metadata';
+export { ImageBudgetError, prepareImageToBudget } from './core/prepare-image-to-budget';
+export type {
+  ImageBudgetAttempt,
+  ImageBudgetErrorCode,
+  ImageBudgetErrorDetails,
+  ImageBudgetErrorOptions,
+  ImageBudgetPolicy,
+  ImageBudgetStrategy,
+  PreparedImageToBudgetResult
+} from './core/prepare-image-to-budget';
 export {
   assertPersistableImageValue,
   ImagePersistableValueError,

--- a/tests/core/prepare-image-to-budget.test.ts
+++ b/tests/core/prepare-image-to-budget.test.ts
@@ -2,6 +2,7 @@ import '../setup';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   ImageBudgetError,
+  isImageBudgetError,
   prepareImageToBudget,
   type ImageBudgetAttempt
 } from '../../src/core/prepare-image-to-budget';
@@ -164,6 +165,20 @@ describe('prepareImageToBudget', () => {
     expect(close).toHaveBeenCalledTimes(1);
   });
 
+  it('keeps nameless Blob originalFileName independent from policy fileName', async () => {
+    const source = new Blob([new Uint8Array(600_000)], { type: 'image/jpeg' });
+    const result = await prepareImageToBudget(source, {
+      outputMaxBytes: 300_000,
+      outputType: 'image/webp',
+      fileName: 'prepared-avatar.webp'
+    });
+
+    expect(result.fileName).toBe('prepared-avatar.webp');
+    expect(result.mimeType).toBe('image/webp');
+    expect(result.originalFileName).toBe('image.jpg');
+    expect(result.originalMimeType).toBe('image/jpeg');
+  });
+
   it('searches quality deterministically when the first lossy encode is too large', async () => {
     const source = new File([new Uint8Array(800_000)], 'cover.jpg', { type: 'image/jpeg' });
     const policy = {
@@ -234,6 +249,22 @@ describe('prepareImageToBudget', () => {
     expect(result.strategy).toBe('resize');
     expect(result.attempts.every((attempt) => typeof attempt.quality === 'undefined')).toBe(true);
     expect(result.attempts.every((attempt) => attempt.strategy === 'resize')).toBe(true);
+  });
+
+  it('clamps rounded max dimensions so the prepared image does not exceed policy max', async () => {
+    decodedWidth = 201;
+    decodedHeight = 100;
+
+    const source = new File([new Uint8Array(500_000)], 'wide.jpg', { type: 'image/jpeg' });
+    const result = await prepareImageToBudget(source, {
+      outputMaxBytes: 250_000,
+      outputType: 'image/jpeg',
+      maxWidth: 100.6
+    });
+
+    expect(result.width).toBe(100);
+    expect(result.width).toBeLessThanOrEqual(100.6);
+    expect(drawImage).toHaveBeenCalledWith(expect.anything(), 0, 0, 100, 50);
   });
 
   it('does not return or encode an image when the minimum dimensions are unreachable', async () => {
@@ -318,6 +349,7 @@ describe('prepareImageToBudget', () => {
       });
     } catch (error) {
       expect(error).toBeInstanceOf(ImageBudgetError);
+      expect(isImageBudgetError(error)).toBe(true);
       expect((error as ImageBudgetError).details.attempts).toHaveLength(3);
       expect(
         (error as ImageBudgetError).details.attempts?.every((attempt: ImageBudgetAttempt) => {
@@ -333,6 +365,15 @@ describe('prepareImageToBudget', () => {
     await expect(
       prepareImageToBudget(source, {
         outputMaxBytes: 100.5
+      })
+    ).rejects.toMatchObject({
+      name: 'ImageBudgetError',
+      code: 'invalid_policy'
+    });
+    await expect(
+      prepareImageToBudget(source, {
+        outputMaxBytes: 100,
+        maxWidth: 0.5
       })
     ).rejects.toMatchObject({
       name: 'ImageBudgetError',
@@ -379,7 +420,8 @@ describe('prepareImageToBudget', () => {
       })
     ).rejects.toMatchObject({
       name: 'ImageBudgetError',
-      code: 'unsupported_output_type'
+      code: 'unsupported_output_type',
+      message: 'Unsupported image output type: (empty).'
     });
     expect(globalThis.createImageBitmap).not.toHaveBeenCalled();
   });
@@ -460,5 +502,38 @@ describe('prepareImageToBudget', () => {
       code: 'decode_failed'
     });
     expect(drawImage).not.toHaveBeenCalled();
+  });
+
+  it('narrows ImageBudgetError-like values without relying on instanceof', () => {
+    expect(
+      isImageBudgetError({
+        name: 'ImageBudgetError',
+        message: 'Unable to prepare image.',
+        code: 'budget_unreachable',
+        details: {
+          outputMaxBytes: 100,
+          attempts: [
+            {
+              attempt: 1,
+              width: 640,
+              height: 480,
+              quality: 0.6,
+              mimeType: 'image/webp',
+              size: 120,
+              withinBudget: false,
+              strategy: 'quality-search'
+            }
+          ]
+        }
+      })
+    ).toBe(true);
+    expect(
+      isImageBudgetError({
+        name: 'ImageBudgetError',
+        message: 'Unknown code.',
+        code: 'unknown',
+        details: {}
+      })
+    ).toBe(false);
   });
 });

--- a/tests/core/prepare-image-to-budget.test.ts
+++ b/tests/core/prepare-image-to-budget.test.ts
@@ -1,0 +1,464 @@
+import '../setup';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  ImageBudgetError,
+  prepareImageToBudget,
+  type ImageBudgetAttempt
+} from '../../src/core/prepare-image-to-budget';
+
+describe('prepareImageToBudget', () => {
+  const originalCreateImageBitmap = globalThis.createImageBitmap;
+  const originalOffscreenCanvas = globalThis.OffscreenCanvas;
+  const originalImage = globalThis.Image;
+
+  let decodedWidth = 1000;
+  let decodedHeight = 800;
+  let close: ReturnType<typeof vi.fn>;
+
+  const drawImage = vi.fn();
+
+  class MockOffscreenCanvas {
+    constructor(
+      public width: number,
+      public height: number
+    ) {}
+
+    getContext(contextId: string) {
+      if (contextId !== '2d') {
+        return null;
+      }
+
+      return {
+        drawImage
+      } as unknown as OffscreenCanvasRenderingContext2D;
+    }
+
+    convertToBlob(options?: ImageEncodeOptions) {
+      const type = options?.type ?? 'image/png';
+      const quality = options?.quality ?? 1;
+      const typeFactor = type === 'image/png' ? 0.64 : type === 'image/webp' ? 0.24 : 0.35;
+      const qualityFactor = type === 'image/png' ? 1 : Math.max(0.2, quality);
+      const size = Math.max(16, Math.ceil(this.width * this.height * typeFactor * qualityFactor));
+
+      return Promise.resolve(new Blob([new Uint8Array(size)], { type }));
+    }
+  }
+
+  beforeEach(() => {
+    decodedWidth = 1000;
+    decodedHeight = 800;
+    close = vi.fn();
+    drawImage.mockReset();
+
+    Object.defineProperty(globalThis, 'createImageBitmap', {
+      configurable: true,
+      value: vi.fn(async () => ({
+        width: decodedWidth,
+        height: decodedHeight,
+        close
+      }))
+    });
+    Object.defineProperty(globalThis, 'OffscreenCanvas', {
+      configurable: true,
+      value: MockOffscreenCanvas
+    });
+  });
+
+  afterEach(() => {
+    if (originalCreateImageBitmap) {
+      Object.defineProperty(globalThis, 'createImageBitmap', {
+        configurable: true,
+        value: originalCreateImageBitmap
+      });
+    } else {
+      Reflect.deleteProperty(globalThis, 'createImageBitmap');
+    }
+
+    if (originalOffscreenCanvas) {
+      Object.defineProperty(globalThis, 'OffscreenCanvas', {
+        configurable: true,
+        value: originalOffscreenCanvas
+      });
+    } else {
+      Reflect.deleteProperty(globalThis, 'OffscreenCanvas');
+    }
+
+    if (typeof originalImage !== 'undefined') {
+      Object.defineProperty(globalThis, 'Image', {
+        configurable: true,
+        value: originalImage
+      });
+    } else {
+      Reflect.deleteProperty(globalThis, 'Image');
+    }
+  });
+
+  it('returns the source when it already satisfies the byte and dimension budget', async () => {
+    decodedWidth = 640;
+    decodedHeight = 480;
+
+    const source = new File(['small'], 'avatar.webp', { type: 'image/webp' });
+    const result = await prepareImageToBudget(source, {
+      outputMaxBytes: 100,
+      maxWidth: 800,
+      maxHeight: 800
+    });
+
+    expect(result.file).toBe(source);
+    expect(result.fileName).toBe('avatar.webp');
+    expect(result.mimeType).toBe('image/webp');
+    expect(result.size).toBe(source.size);
+    expect(result.width).toBe(640);
+    expect(result.height).toBe(480);
+    expect(result.originalFileName).toBe('avatar.webp');
+    expect(result.originalMimeType).toBe('image/webp');
+    expect(result.compressionRatio).toBe(1);
+    expect(result.attempts).toEqual([]);
+    expect(result.strategy).toBe('source-within-budget');
+    expect(drawImage).not.toHaveBeenCalled();
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('normalizes the output file extension when the source name and MIME type disagree', async () => {
+    decodedWidth = 640;
+    decodedHeight = 480;
+
+    const source = new File(['small'], 'avatar.png', { type: 'image/jpeg' });
+    const result = await prepareImageToBudget(source, {
+      outputMaxBytes: 100
+    });
+
+    expect(result.file).toBe(source);
+    expect(result.fileName).toBe('avatar.jpg');
+    expect(result.mimeType).toBe('image/jpeg');
+    expect(result.strategy).toBe('source-within-budget');
+  });
+
+  it('converts to WebP and reports matching output metadata', async () => {
+    const source = new File([new Uint8Array(600_000)], 'avatar.jpg', { type: 'image/jpeg' });
+    const result = await prepareImageToBudget(source, {
+      outputMaxBytes: 300_000,
+      outputType: 'image/webp',
+      maxWidth: 800,
+      maxHeight: 800
+    });
+
+    expect(result.file).toBeInstanceOf(Blob);
+    expect(result.file).not.toBe(source);
+    expect(result.fileName).toBe('avatar.webp');
+    expect(result.mimeType).toBe('image/webp');
+    expect(result.file.type).toBe('image/webp');
+    expect(result.size).toBeLessThanOrEqual(300_000);
+    expect(result.width).toBe(800);
+    expect(result.height).toBe(640);
+    expect(result.strategy).toBe('resize-and-quality-search');
+    expect(result.attempts[0]).toMatchObject({
+      attempt: 1,
+      width: 800,
+      height: 640,
+      quality: 0.86,
+      mimeType: 'image/webp',
+      withinBudget: true,
+      strategy: 'resize-and-quality-search'
+    });
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('searches quality deterministically when the first lossy encode is too large', async () => {
+    const source = new File([new Uint8Array(800_000)], 'cover.jpg', { type: 'image/jpeg' });
+    const policy = {
+      outputMaxBytes: 210_000,
+      outputType: 'image/jpeg' as const,
+      initialQuality: 0.9,
+      minQuality: 0.4,
+      maxEncodeAttempts: 7
+    };
+
+    const first = await prepareImageToBudget(source, policy);
+    const second = await prepareImageToBudget(source, policy);
+
+    expect(first.size).toBeLessThanOrEqual(policy.outputMaxBytes);
+    expect(first.size).toBe(second.size);
+    expect(first.strategy).toBe(second.strategy);
+    expect(first.strategy).toBe('quality-search');
+    expect(first.attempts.map(({ height, width, quality, size, withinBudget }) => ({
+      height,
+      width,
+      quality,
+      size,
+      withinBudget
+    }))).toEqual(
+      second.attempts.map(({ height, width, quality, size, withinBudget }) => ({
+        height,
+        width,
+        quality,
+        size,
+        withinBudget
+      }))
+    );
+    expect(first.attempts.length).toBeGreaterThan(2);
+    expect(first.attempts[0]).toMatchObject({ quality: 0.9, withinBudget: false });
+    expect(first.attempts[1]).toMatchObject({ quality: 0.4, withinBudget: true });
+  });
+
+  it('resizes when minimum lossy quality cannot reach the budget', async () => {
+    const source = new File([new Uint8Array(900_000)], 'cover.jpg', { type: 'image/jpeg' });
+    const result = await prepareImageToBudget(source, {
+      outputMaxBytes: 100_000,
+      outputType: 'image/jpeg',
+      initialQuality: 0.9,
+      minQuality: 0.4,
+      maxEncodeAttempts: 8,
+      resizeStepRatio: 0.5
+    });
+
+    expect(result.size).toBeLessThanOrEqual(100_000);
+    expect(result.strategy).toBe('resize-and-quality-search');
+    expect(result.width).toBeLessThan(1000);
+    expect(result.height).toBeLessThan(800);
+    expect(result.attempts.some((attempt) => attempt.width < 1000)).toBe(true);
+  });
+
+  it('uses resize-only attempts for PNG output', async () => {
+    const source = new File([new Uint8Array(900_000)], 'icon.jpg', { type: 'image/jpeg' });
+    const result = await prepareImageToBudget(source, {
+      outputMaxBytes: 130_000,
+      outputType: 'image/png',
+      maxEncodeAttempts: 5,
+      resizeStepRatio: 0.5
+    });
+
+    expect(result.fileName).toBe('icon.png');
+    expect(result.mimeType).toBe('image/png');
+    expect(result.size).toBeLessThanOrEqual(130_000);
+    expect(result.strategy).toBe('resize');
+    expect(result.attempts.every((attempt) => typeof attempt.quality === 'undefined')).toBe(true);
+    expect(result.attempts.every((attempt) => attempt.strategy === 'resize')).toBe(true);
+  });
+
+  it('does not return or encode an image when the minimum dimensions are unreachable', async () => {
+    decodedWidth = 300;
+    decodedHeight = 200;
+
+    const source = new File(['small'], 'avatar.webp', { type: 'image/webp' });
+
+    await expect(
+      prepareImageToBudget(source, {
+        outputMaxBytes: 100,
+        minWidth: 400
+      })
+    ).rejects.toMatchObject({
+      name: 'ImageBudgetError',
+      code: 'budget_unreachable',
+      details: {
+        attempts: []
+      }
+    });
+
+    expect(drawImage).not.toHaveBeenCalled();
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects max constraints that force the fitted image below minimum dimensions', async () => {
+    decodedWidth = 1000;
+    decodedHeight = 100;
+
+    const source = new File([new Uint8Array(500_000)], 'wide.jpg', { type: 'image/jpeg' });
+
+    await expect(
+      prepareImageToBudget(source, {
+        outputMaxBytes: 250_000,
+        maxWidth: 200,
+        minHeight: 80
+      })
+    ).rejects.toMatchObject({
+      name: 'ImageBudgetError',
+      code: 'budget_unreachable',
+      details: {
+        minHeight: 80,
+        attempts: []
+      }
+    });
+
+    expect(drawImage).not.toHaveBeenCalled();
+  });
+
+  it('throws budget_unreachable with bounded attempts when the budget cannot be reached', async () => {
+    const source = new File([new Uint8Array(900_000)], 'cover.jpg', { type: 'image/jpeg' });
+
+    await expect(
+      prepareImageToBudget(source, {
+        outputMaxBytes: 20,
+        outputType: 'image/jpeg',
+        initialQuality: 0.9,
+        minQuality: 0.4,
+        maxEncodeAttempts: 3,
+        minWidth: 900,
+        minHeight: 700
+      })
+    ).rejects.toMatchObject({
+      name: 'ImageBudgetError',
+      code: 'budget_unreachable',
+      details: {
+        outputMaxBytes: 20,
+        minWidth: 900,
+        minHeight: 700
+      }
+    });
+
+    try {
+      await prepareImageToBudget(source, {
+        outputMaxBytes: 20,
+        outputType: 'image/jpeg',
+        initialQuality: 0.9,
+        minQuality: 0.4,
+        maxEncodeAttempts: 3,
+        minWidth: 900,
+        minHeight: 700
+      });
+    } catch (error) {
+      expect(error).toBeInstanceOf(ImageBudgetError);
+      expect((error as ImageBudgetError).details.attempts).toHaveLength(3);
+      expect(
+        (error as ImageBudgetError).details.attempts?.every((attempt: ImageBudgetAttempt) => {
+          return attempt.width >= 900 && attempt.height >= 700;
+        })
+      ).toBe(true);
+    }
+  });
+
+  it('rejects invalid policies before decoding', async () => {
+    const source = new File(['small'], 'avatar.webp', { type: 'image/webp' });
+
+    await expect(
+      prepareImageToBudget(source, {
+        outputMaxBytes: 100.5
+      })
+    ).rejects.toMatchObject({
+      name: 'ImageBudgetError',
+      code: 'invalid_policy'
+    });
+    expect(globalThis.createImageBitmap).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed runtime policy values before decoding', async () => {
+    const source = new File(['small'], 'avatar.webp', { type: 'image/webp' });
+
+    await expect(prepareImageToBudget(source, null as never)).rejects.toMatchObject({
+      name: 'ImageBudgetError',
+      code: 'invalid_policy'
+    });
+    await expect(
+      prepareImageToBudget(source, {
+        outputMaxBytes: 100,
+        outputType: 42 as never
+      })
+    ).rejects.toMatchObject({
+      name: 'ImageBudgetError',
+      code: 'invalid_policy'
+    });
+    expect(globalThis.createImageBitmap).not.toHaveBeenCalled();
+  });
+
+  it('rejects unsupported output MIME types', async () => {
+    const source = new File(['small'], 'avatar.jpg', { type: 'image/jpeg' });
+
+    await expect(
+      prepareImageToBudget(source, {
+        outputMaxBytes: 100,
+        outputType: 'image/avif' as 'image/webp'
+      })
+    ).rejects.toMatchObject({
+      name: 'ImageBudgetError',
+      code: 'unsupported_output_type'
+    });
+    await expect(
+      prepareImageToBudget(source, {
+        outputMaxBytes: 100,
+        outputType: '' as 'image/webp'
+      })
+    ).rejects.toMatchObject({
+      name: 'ImageBudgetError',
+      code: 'unsupported_output_type'
+    });
+    expect(globalThis.createImageBitmap).not.toHaveBeenCalled();
+  });
+
+  it('rejects browser encoder fallbacks that return a different MIME type', async () => {
+    class FallbackOffscreenCanvas extends MockOffscreenCanvas {
+      convertToBlob() {
+        return Promise.resolve(new Blob(['fallback'], { type: 'image/png' }));
+      }
+    }
+
+    Object.defineProperty(globalThis, 'OffscreenCanvas', {
+      configurable: true,
+      value: FallbackOffscreenCanvas
+    });
+
+    const source = new File([new Uint8Array(500_000)], 'avatar.jpg', { type: 'image/jpeg' });
+
+    await expect(
+      prepareImageToBudget(source, {
+        outputMaxBytes: 250_000,
+        outputType: 'image/webp'
+      })
+    ).rejects.toMatchObject({
+      name: 'ImageBudgetError',
+      code: 'unsupported_output_type'
+    });
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('wraps canvas encoding failures in ImageBudgetError', async () => {
+    class RejectingOffscreenCanvas extends MockOffscreenCanvas {
+      convertToBlob() {
+        return Promise.reject(new Error('encoder unavailable'));
+      }
+    }
+
+    Object.defineProperty(globalThis, 'OffscreenCanvas', {
+      configurable: true,
+      value: RejectingOffscreenCanvas
+    });
+
+    const source = new File([new Uint8Array(500_000)], 'avatar.jpg', { type: 'image/jpeg' });
+
+    await expect(
+      prepareImageToBudget(source, {
+        outputMaxBytes: 250_000,
+        outputType: 'image/webp'
+      })
+    ).rejects.toMatchObject({
+      name: 'ImageBudgetError',
+      code: 'encode_failed',
+      details: {
+        attempts: []
+      }
+    });
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('wraps image decoding failures in ImageBudgetError', async () => {
+    Object.defineProperty(globalThis, 'createImageBitmap', {
+      configurable: true,
+      value: vi.fn(async () => {
+        throw new Error('not an image');
+      })
+    });
+    Reflect.deleteProperty(globalThis, 'Image');
+
+    const source = new File(['not an image'], 'avatar.jpg', { type: 'image/jpeg' });
+
+    await expect(
+      prepareImageToBudget(source, {
+        outputMaxBytes: 250_000,
+        outputType: 'image/webp'
+      })
+    ).rejects.toMatchObject({
+      name: 'ImageBudgetError',
+      code: 'decode_failed'
+    });
+    expect(drawImage).not.toHaveBeenCalled();
+  });
+});

--- a/tests/entrypoints.test.ts
+++ b/tests/entrypoints.test.ts
@@ -15,6 +15,8 @@ describe('package entrypoints', () => {
     expect(root.isPersistableImageValue).toBeTypeOf('function');
     expect(root.isTemporaryImageSrc).toBeTypeOf('function');
     expect(root).not.toHaveProperty('compressImage');
+    expect(root).not.toHaveProperty('ImageBudgetError');
+    expect(root).not.toHaveProperty('prepareImageToBudget');
     expect(root).not.toHaveProperty('createPresignedPutUploader');
     expect(root).not.toHaveProperty('useImageDropInput');
     expect(root).not.toHaveProperty('validateImage');
@@ -22,6 +24,8 @@ describe('package entrypoints', () => {
 
   it('keeps advanced utilities available from the headless entry', () => {
     expect(headless.compressImage).toBeTypeOf('function');
+    expect(headless.prepareImageToBudget).toBeTypeOf('function');
+    expect(headless.ImageBudgetError).toBeTypeOf('function');
     expect(headless.createPresignedPutUploader).toBeTypeOf('function');
     expect(headless.ImageValidationError).toBeTypeOf('function');
     expect(headless.isImageValidationError).toBeTypeOf('function');

--- a/tests/entrypoints.test.ts
+++ b/tests/entrypoints.test.ts
@@ -16,6 +16,7 @@ describe('package entrypoints', () => {
     expect(root.isTemporaryImageSrc).toBeTypeOf('function');
     expect(root).not.toHaveProperty('compressImage');
     expect(root).not.toHaveProperty('ImageBudgetError');
+    expect(root).not.toHaveProperty('isImageBudgetError');
     expect(root).not.toHaveProperty('prepareImageToBudget');
     expect(root).not.toHaveProperty('createPresignedPutUploader');
     expect(root).not.toHaveProperty('useImageDropInput');
@@ -26,6 +27,7 @@ describe('package entrypoints', () => {
     expect(headless.compressImage).toBeTypeOf('function');
     expect(headless.prepareImageToBudget).toBeTypeOf('function');
     expect(headless.ImageBudgetError).toBeTypeOf('function');
+    expect(headless.isImageBudgetError).toBeTypeOf('function');
     expect(headless.createPresignedPutUploader).toBeTypeOf('function');
     expect(headless.ImageValidationError).toBeTypeOf('function');
     expect(headless.isImageValidationError).toBeTypeOf('function');


### PR DESCRIPTION
## Summary

- Add `prepareImageToBudget()` and typed byte-budget policy/result/error APIs under `image-drop-input/headless`.
- Reuse shared browser canvas encoding helpers with the existing compression path.
- Add deterministic tests for quality search, resize fallback, PNG resize-only behavior, unreachable budgets, malformed policies, encoder fallbacks, and decode/encode errors.
- Document the byte-budget transform flow and update the README transform snippet.

## Why

`outputMaxBytes` remains the final validation guard, but callers also need a deterministic browser helper that prepares an image to fit that budget instead of guessing a single quality value.

## Validation

- `npm run verify`
- `npm run smoke:consumer`
- `npm run publish:check`
- `npm pack --dry-run`