### PR TITLE
feat: add draft image lifecycle hook

### DIFF
--- a/consumer-fixtures/headless-cjs/index.cjs
+++ b/consumer-fixtures/headless-cjs/index.cjs
@@ -15,6 +15,9 @@ const requiredFunctions = [
   'assertPersistableImageValue',
   'isPersistableImageValue',
   'isTemporaryImageSrc',
+  'ImageDraftLifecycleError',
+  'isImageDraftLifecycleError',
+  'useImageDraftLifecycle',
   'validateImage'
 ];
 
@@ -34,6 +37,11 @@ const budgetError = new headless.ImageBudgetError(
   'Unable to prepare an image within the byte budget.',
   { outputMaxBytes: 1, attempts: [] }
 );
+const lifecycleError = new headless.ImageDraftLifecycleError(
+  'missing_draft_key',
+  'Draft uploads must return draftKey or key.',
+  { phase: 'uploading-draft' }
+);
 
 if (!headless.isImageUploadError(uploadError)) {
   throw new Error('Expected headless isImageUploadError to narrow ImageUploadError.');
@@ -45,6 +53,10 @@ if (budgetError.name !== 'ImageBudgetError' || budgetError.code !== 'budget_unre
 
 if (!headless.isImageBudgetError(budgetError)) {
   throw new Error('Expected headless isImageBudgetError to narrow ImageBudgetError.');
+}
+
+if (!headless.isImageDraftLifecycleError(lifecycleError)) {
+  throw new Error('Expected headless isImageDraftLifecycleError to narrow ImageDraftLifecycleError.');
 }
 
 const persistableValue = headless.toPersistableImageValue({

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ Start with:
 - [Persistable value guard](./persistable-value.md): remove temporary preview state before submit
 - [Validation](./validation.md): source limits, output limits, dimensions, pixels, and error codes
 - [Byte budget solver](./byte-budget.md): prepare images to fit an output byte budget
+- [Draft lifecycle](./draft-lifecycle.md): upload drafts, commit on form save, discard on cancel, and cleanup previous images
 - [Uploads](./uploads.md): adapter contracts, signed upload boundaries, progress, typed upload errors, and aborts
 - [Transforms](./transforms.md): compression, WebP conversion, return shapes, and MIME consistency
 - [Accessibility](./accessibility.md): keyboard, paste, status, dialog, and headless responsibilities
@@ -21,6 +22,7 @@ Recipes:
 - [Presigned PUT](./recipes/presigned-put.md)
 - [Next.js App Router](./recipes/nextjs-app-router.md)
 - [Next.js presign route](./recipes/nextjs-presign-route.md)
+- [Next.js draft lifecycle](./recipes/nextjs-draft-lifecycle.md)
 - [React Hook Form and Zod](./recipes/react-hook-form-zod.md)
 - [Multipart POST](./recipes/multipart-post.md)
 - [Raw PUT](./recipes/raw-put.md)

--- a/docs/draft-lifecycle.md
+++ b/docs/draft-lifecycle.md
@@ -1,0 +1,179 @@
+# Draft lifecycle
+
+`useImageDraftLifecycle()` is an optional headless hook for product forms that upload an image before the form itself is saved.
+
+It keeps this boundary explicit:
+
+```txt
+upload draft succeeded != product record saved
+```
+
+Use it when replacing an existing image would otherwise create orphan draft objects or delete the previous image too early.
+
+## Flow
+
+```txt
+committed image A
+  -> user selects image B
+  -> upload B as a draft object
+  -> keep A as the authoritative committed value
+  -> form submit commits B
+  -> cleanup A only after B is committed
+```
+
+Cancel/reset does the opposite:
+
+```txt
+committed image A
+  -> user selects image B
+  -> upload B as a draft object
+  -> discard B
+  -> keep A
+```
+
+The package does not include an object-storage SDK. Your app owns signed URLs, auth, object keys, draft TTLs, transactions, and cleanup policy.
+
+## Hook
+
+```tsx
+import { ImageDropInput } from 'image-drop-input';
+import { useImageDraftLifecycle } from 'image-drop-input/headless';
+
+const image = useImageDraftLifecycle({
+  committedValue: profile.image,
+  onCommittedValueChange: setProfileImage,
+  uploadDraft,
+  commitDraft,
+  discardDraft,
+  cleanupPrevious,
+  autoDiscard: {
+    onReplace: true,
+    onReset: true,
+    onUnmount: true
+  },
+  onError(error) {
+    reportImageError(error);
+  }
+});
+
+<ImageDropInput
+  value={image.valueForInput}
+  onChange={() => {
+    // The lifecycle owns draft state. Persist only after image.commit().
+  }}
+  upload={image.uploadForInput}
+/>;
+```
+
+`valueForInput` is display state for the input. Do not save it directly as your form payload.
+
+## Draft upload result
+
+`uploadDraft` receives the prepared `Blob` and the normal upload context. It must return either `draftKey` or `key`.
+
+```ts
+type ImageDraftUploadResult = {
+  draftKey?: string;
+  key?: string;
+  src?: string;
+  previewSrc?: string;
+  expiresAt?: string;
+};
+```
+
+`src` is optional. If the draft object is not publicly renderable, the hook keeps a local `previewSrc` for display. The package never infers a public URL from a signed upload URL.
+
+## Backend contracts
+
+Draft upload creates a temporary object:
+
+```ts
+type DraftUploadResponse = {
+  uploadUrl: string;
+  headers?: Record<string, string>;
+  draftKey: string;
+  expiresAt: string;
+};
+```
+
+Commit validates ownership and promotes the draft into durable product state:
+
+```ts
+type CommitImageDraftRequest = {
+  draft: ImageDraftDescriptor;
+  previous: PersistableImageValue | null;
+};
+```
+
+Discard deletes a temporary draft when the user cancels, replaces it, resets the form, or unmounts:
+
+```ts
+type DiscardImageDraftRequest = {
+  draft: ImageDraftDescriptor;
+  reason: 'replace' | 'reset' | 'unmount' | 'manual';
+};
+```
+
+Previous cleanup runs only after commit success:
+
+```ts
+type CleanupPreviousImageRequest = {
+  previous: PersistableImageValue;
+  next: PersistableImageValue;
+};
+```
+
+Make cleanup idempotent. A cleanup failure must not rollback the new committed image.
+
+## Recommended server transaction
+
+For serious product forms, commit the image draft and save the form in the same server transaction whenever possible.
+
+```txt
+POST /api/profile
+  fields
+  image draft reference
+
+server transaction:
+  validate user can use draft
+  move/copy draft to final object
+  update profile row with final image value
+  enqueue previous cleanup
+  return final image value
+```
+
+The simpler client sequence is:
+
+```ts
+const committedImage = await image.commit();
+await saveProfile({ ...fields, image: committedImage });
+```
+
+That is easier to wire, but it can split consistency if `image.commit()` succeeds and `saveProfile()` fails. Prefer a product submit endpoint for user-facing records where image and fields must change together.
+
+## Failure matrix
+
+| Case | Expected behavior |
+|---|---|
+| Draft upload succeeds | `draft` is stored, `phase` becomes `draft-ready` |
+| Draft upload has no `draftKey` or `key` | `ImageDraftLifecycleError` with `missing_draft_key` |
+| Commit succeeds | committed value changes, draft clears |
+| Commit fails | previous committed value remains, draft stays retryable/discardable |
+| Cleanup previous fails | new committed value remains, error is reported |
+| Discard succeeds | draft clears, committed value remains |
+| Discard fails | draft remains so the user can retry or leave it to TTL cleanup |
+| Replace draft | old draft is discarded when `autoDiscard.onReplace` is enabled |
+| Unmount | draft discard is best-effort when `autoDiscard.onUnmount` is enabled |
+| Double commit | the in-flight commit is reused; backend commit is not duplicated |
+
+## Security notes
+
+Draft objects should be short-lived and scoped to the authenticated user/session.
+
+If your backend returns a draft authorization token, treat it as sensitive:
+
+- send it only to commit/discard endpoints that need it
+- do not write it to browser logs, analytics, or error messages
+- keep it short-lived and single-purpose
+
+Client discard is best-effort. Browser tabs close, networks fail, and unmount handlers do not always finish. Server-side TTL cleanup is required.

--- a/docs/draft-lifecycle.md
+++ b/docs/draft-lifecycle.md
@@ -114,6 +114,8 @@ type DiscardImageDraftRequest = {
 };
 ```
 
+`discardDraft` is optional because some products rely on short draft TTLs only. If it is omitted, `discard()` and `autoDiscard` still clear the local draft state, but no backend delete request is sent. Provide `discardDraft` when your backend can safely delete draft objects before their TTL expires.
+
 Previous cleanup runs only after commit success:
 
 ```ts

--- a/docs/recipes/nextjs-draft-lifecycle.md
+++ b/docs/recipes/nextjs-draft-lifecycle.md
@@ -1,0 +1,408 @@
+# Recipe: Next.js draft lifecycle
+
+Use this pattern when a profile, product, or CMS form needs image replacement to stay consistent with the saved record.
+
+The client uploads a draft object first. The profile submit route then commits that draft and updates the profile in one server-owned operation.
+
+## Client component
+
+```tsx
+'use client';
+
+import { useRef, useState } from 'react';
+import { ImageDropInput } from 'image-drop-input';
+import {
+  useImageDraftLifecycle,
+  type CommitImageDraftRequest,
+  type DiscardImageDraftRequest,
+  type PersistableImageValue,
+  type UploadContext
+} from 'image-drop-input/headless';
+
+type ProfileForm = {
+  displayName: string;
+  image: PersistableImageValue | null;
+};
+
+type ImageDraftPayload = {
+  draftKey: string;
+  previous: PersistableImageValue | null;
+};
+
+export function ProfileEditor({ initialProfile }: { initialProfile: ProfileForm }) {
+  const [fields, setFields] = useState(initialProfile);
+  const latestFields = useRef(fields);
+  latestFields.current = fields;
+
+  const image = useImageDraftLifecycle({
+    committedValue: fields.image,
+    onCommittedValueChange(next) {
+      setFields((current) => ({ ...current, image: next }));
+    },
+    uploadDraft,
+    async commitDraft(request) {
+      const body = await submitProfile(toImageDraftPayload(request));
+      return body.image;
+    },
+    discardDraft,
+    autoDiscard: {
+      onReplace: true,
+      onReset: true,
+      onUnmount: true
+    }
+  });
+
+  async function submitProfile(imageDraft?: ImageDraftPayload) {
+    const response = await fetch('/api/profile', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        displayName: latestFields.current.displayName,
+        ...(imageDraft ? { imageDraft } : {})
+      })
+    });
+
+    if (!response.ok) {
+      throw new Error('Profile save failed.');
+    }
+
+    return (await response.json()) as { image: PersistableImageValue };
+  }
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+
+    if (image.hasDraft) {
+      await image.commit();
+      return;
+    }
+
+    const body = await submitProfile();
+    setFields((current) => ({ ...current, image: body.image }));
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input
+        value={fields.displayName}
+        onChange={(event) => {
+          setFields((current) => ({
+            ...current,
+            displayName: event.target.value
+          }));
+        }}
+      />
+
+      <ImageDropInput
+        value={image.valueForInput}
+        onChange={() => {
+          // The lifecycle tracks draft state. The profile API returns the durable value.
+        }}
+        upload={image.uploadForInput}
+        accept="image/png,image/jpeg,image/webp"
+        outputMaxBytes={5 * 1024 * 1024}
+        disabled={image.phase === 'committing'}
+      />
+
+      <button
+        type="submit"
+        disabled={image.phase === 'uploading-draft' || image.phase === 'committing'}
+      >
+        Save
+      </button>
+    </form>
+  );
+}
+
+async function uploadDraft(file: Blob, context: UploadContext) {
+  const presign = await fetch('/api/images/drafts/presign', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      fileName: context.fileName,
+      mimeType: context.mimeType ?? file.type,
+      size: file.size
+    }),
+    signal: context.signal
+  });
+
+  if (!presign.ok) {
+    throw new Error('Could not create draft upload target.');
+  }
+
+  const target = (await presign.json()) as {
+    uploadUrl: string;
+    headers?: Record<string, string>;
+    draftKey: string;
+    expiresAt: string;
+  };
+
+  const upload = await fetch(target.uploadUrl, {
+    method: 'PUT',
+    headers: target.headers,
+    body: file,
+    signal: context.signal
+  });
+
+  if (!upload.ok) {
+    throw new Error('Draft upload failed.');
+  }
+
+  return {
+    draftKey: target.draftKey,
+    expiresAt: target.expiresAt,
+    fileName: context.fileName,
+    mimeType: context.mimeType ?? file.type,
+    size: file.size
+  };
+}
+
+function toImageDraftPayload(request: CommitImageDraftRequest): ImageDraftPayload {
+  return {
+    draftKey: request.draft.draftKey,
+    previous: request.previous
+  };
+}
+
+async function discardDraft(request: DiscardImageDraftRequest) {
+  const response = await fetch('/api/images/drafts/discard', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      draftKey: request.draft.draftKey,
+      reason: request.reason
+    }),
+    keepalive: request.reason === 'unmount'
+  });
+
+  if (!response.ok) {
+    throw new Error('Draft discard failed.');
+  }
+}
+```
+
+## `/api/images/drafts/presign`
+
+```ts
+// app/api/images/drafts/presign/route.ts
+import { NextResponse, type NextRequest } from 'next/server';
+
+type PresignDraftRequest = {
+  fileName?: string;
+  mimeType: string;
+  size: number;
+};
+
+type PresignDraftResponse = {
+  uploadUrl: string;
+  headers?: Record<string, string>;
+  draftKey: string;
+  expiresAt: string;
+};
+
+const allowedMimeTypes = new Set(['image/jpeg', 'image/png', 'image/webp']);
+const maxUploadBytes = 5 * 1024 * 1024;
+
+export const runtime = 'nodejs';
+
+export async function POST(request: NextRequest) {
+  const user = await requireUser(request);
+  const body = (await request.json()) as Partial<PresignDraftRequest>;
+
+  if (
+    !body.mimeType ||
+    !allowedMimeTypes.has(body.mimeType) ||
+    typeof body.size !== 'number' ||
+    body.size <= 0 ||
+    body.size > maxUploadBytes
+  ) {
+    return NextResponse.json({ error: 'Invalid draft upload request.' }, { status: 400 });
+  }
+
+  const draft = await createDraftUploadTarget({
+    userId: user.id,
+    mimeType: body.mimeType,
+    size: body.size
+  });
+
+  return NextResponse.json({
+    uploadUrl: draft.uploadUrl,
+    headers: draft.headers,
+    draftKey: draft.draftKey,
+    expiresAt: draft.expiresAt
+  } satisfies PresignDraftResponse);
+}
+
+async function requireUser(_request: NextRequest) {
+  return { id: 'user_123' };
+}
+
+async function createDraftUploadTarget(_input: {
+  userId: string;
+  mimeType: string;
+  size: number;
+}) {
+  // Replace with your storage service or internal upload service.
+  // Store draft ownership, MIME type, size, and expiry server-side.
+  throw new Error('Connect this route to your storage layer.');
+}
+```
+
+## `/api/profile` submit with image draft
+
+```ts
+// app/api/profile/route.ts
+import { NextResponse, type NextRequest } from 'next/server';
+
+type PersistableImageValue = {
+  src?: string;
+  key?: string;
+  fileName?: string;
+  mimeType?: string;
+  size?: number;
+  width?: number;
+  height?: number;
+};
+
+type ProfileSubmitRequest = {
+  displayName: string;
+  imageDraft?: {
+    draftKey: string;
+    previous: PersistableImageValue | null;
+  };
+};
+
+export const runtime = 'nodejs';
+
+export async function POST(request: NextRequest) {
+  const user = await requireUser(request);
+  const body = (await request.json()) as ProfileSubmitRequest;
+
+  const result = await runTransaction(async () => {
+    const currentProfile = await getProfileForUpdate(user.id);
+    const nextImage = body.imageDraft
+      ? await commitProfileImageDraft({
+          userId: user.id,
+          draftKey: body.imageDraft.draftKey,
+          previous: currentProfile.image
+        })
+      : currentProfile.image;
+
+    const profile = await updateProfile({
+      userId: user.id,
+      displayName: body.displayName,
+      image: nextImage
+    });
+
+    if (currentProfile.image && nextImage && !sameImageReference(currentProfile.image, nextImage)) {
+      await enqueuePreviousImageCleanup({
+        previous: currentProfile.image,
+        next: nextImage
+      });
+    }
+
+    return profile;
+  });
+
+  return NextResponse.json({
+    image: result.image
+  });
+}
+
+async function requireUser(_request: NextRequest) {
+  return { id: 'user_123' };
+}
+
+async function runTransaction<T>(callback: () => Promise<T>) {
+  // Replace with your database transaction helper.
+  return callback();
+}
+
+async function getProfileForUpdate(_userId: string) {
+  return {
+    image: null as PersistableImageValue | null
+  };
+}
+
+async function commitProfileImageDraft(_input: {
+  userId: string;
+  draftKey: string;
+  previous: PersistableImageValue | null;
+}) {
+  // Validate owner, expiry, MIME type, object existence, and product permissions.
+  // Move/copy the draft object to a final key and return the durable image value.
+  throw new Error('Connect this route to your image commit service.');
+}
+
+async function updateProfile(_input: {
+  userId: string;
+  displayName: string;
+  image: PersistableImageValue | null;
+}) {
+  throw new Error('Connect this route to your database.');
+}
+
+async function enqueuePreviousImageCleanup(_input: {
+  previous: PersistableImageValue;
+  next: PersistableImageValue;
+}) {
+  // Prefer a queue or idempotent background job.
+}
+
+function sameImageReference(previous: PersistableImageValue, next: PersistableImageValue) {
+  if (previous.key && next.key) {
+    return previous.key === next.key;
+  }
+
+  if (previous.src && next.src) {
+    return previous.src === next.src;
+  }
+
+  return previous.key === next.key && previous.src === next.src;
+}
+```
+
+## Best-effort discard route
+
+```ts
+// app/api/images/drafts/discard/route.ts
+import { NextResponse, type NextRequest } from 'next/server';
+
+export async function POST(request: NextRequest) {
+  const user = await requireUser(request);
+  const body = (await request.json()) as {
+    draftKey?: string;
+    reason?: 'replace' | 'reset' | 'unmount' | 'manual';
+  };
+
+  if (!body.draftKey) {
+    return NextResponse.json({ error: 'Missing draft key.' }, { status: 400 });
+  }
+
+  await discardImageDraft({
+    userId: user.id,
+    draftKey: body.draftKey,
+    reason: body.reason ?? 'manual'
+  });
+
+  return NextResponse.json({ ok: true });
+}
+
+async function requireUser(_request: NextRequest) {
+  return { id: 'user_123' };
+}
+
+async function discardImageDraft(_input: {
+  userId: string;
+  draftKey: string;
+  reason: 'replace' | 'reset' | 'unmount' | 'manual';
+}) {
+  // Delete only drafts owned by this user and still in draft storage.
+}
+```
+
+## TTL reminder
+
+Client discard is a convenience, not a guarantee. Add a server-side lifecycle rule or scheduled cleanup that removes expired draft objects and draft metadata. A good default is a short expiry, such as 15 to 60 minutes, depending on how long your form can reasonably stay open.
+
+Never delete the previous committed image before the new image has been committed with the product record.

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -8,6 +8,26 @@ export type {
 export { resolveImageDropInputMessages } from './react/customization';
 export { normalizeAspectRatio, resolveDisplaySrc, useImageDropInput } from './react/use-image-drop-input';
 export type { UseImageDropInputOptions, UseImageDropInputReturn } from './react/use-image-drop-input';
+export {
+  ImageDraftLifecycleError,
+  isImageDraftLifecycleError,
+  useImageDraftLifecycle
+} from './react/use-image-draft-lifecycle';
+export type {
+  CleanupPreviousImageRequest,
+  CommitImageDraftRequest,
+  DiscardImageDraftRequest,
+  DraftUploadAdapterResult,
+  ImageDraftDescriptor,
+  ImageDraftLifecycleErrorCode,
+  ImageDraftLifecycleErrorDetails,
+  ImageDraftLifecycleErrorOptions,
+  ImageDraftLifecyclePhase,
+  ImageDraftUploadAdapter,
+  ImageDraftUploadResult,
+  UseImageDraftLifecycleOptions,
+  UseImageDraftLifecycleReturn
+} from './react/use-image-draft-lifecycle';
 export { compressImage } from './core/compress-image';
 export { createObjectUrl } from './core/create-object-url';
 export { getImageMetadata } from './core/get-image-metadata';

--- a/src/react/use-image-draft-lifecycle.ts
+++ b/src/react/use-image-draft-lifecycle.ts
@@ -172,6 +172,10 @@ function isOptionalString(value: unknown): value is string | undefined {
   return typeof value === 'undefined' || typeof value === 'string';
 }
 
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
+}
+
 export function isImageDraftLifecycleError(
   error: unknown
 ): error is ImageDraftLifecycleError {
@@ -330,6 +334,9 @@ export function useImageDraftLifecycle(
   const uploadRunIdRef = useRef(0);
   const draftPreviewObjectUrlRef = useRef<ManagedObjectUrl | null>(null);
   const commitPromiseRef = useRef<Promise<PersistableImageValue | null> | null>(null);
+  const staleUploadDiscardReasonsRef = useRef(
+    new Map<number, DiscardImageDraftRequest['reason']>()
+  );
 
   const [phase, setPhaseState] = useState<ImageDraftLifecyclePhase>('idle');
   const phaseRef = useRef<ImageDraftLifecyclePhase>('idle');
@@ -433,7 +440,11 @@ export function useImageDraftLifecycle(
       const currentDraft = draftRef.current;
       releaseDraftPreviewObjectUrl();
 
-      if (currentDraft && optionsRef.current.autoDiscard?.onUnmount) {
+      if (
+        currentDraft &&
+        phaseRef.current !== 'committing' &&
+        optionsRef.current.autoDiscard?.onUnmount
+      ) {
         void discardDescriptorBestEffort(currentDraft, 'unmount', false);
       }
     };
@@ -471,10 +482,22 @@ export function useImageDraftLifecycle(
       const result = await optionsRef.current.uploadDraft(file, context);
 
       if (runId !== uploadRunIdRef.current) {
-        if (optionsRef.current.autoDiscard?.onReplace) {
+        const staleDiscardReason =
+          staleUploadDiscardReasonsRef.current.get(runId) ??
+          (optionsRef.current.autoDiscard?.onReplace ? 'replace' : null);
+        const unmountDiscardReason = optionsRef.current.autoDiscard?.onUnmount
+          ? 'unmount'
+          : null;
+        const discardReason = !isMountedRef.current
+          ? unmountDiscardReason
+          : staleDiscardReason;
+
+        staleUploadDiscardReasonsRef.current.delete(runId);
+
+        if (discardReason) {
           try {
             const staleDraft = createDraftDescriptor(result, file, context);
-            void discardDescriptorBestEffort(staleDraft, 'replace', false);
+            void discardDescriptorBestEffort(staleDraft, discardReason, false);
           } catch {
             // If a stale upload cannot be identified, there is nothing useful to discard.
           }
@@ -515,6 +538,12 @@ export function useImageDraftLifecycle(
       return result;
     } catch (nextError) {
       if (runId !== uploadRunIdRef.current || !isMountedRef.current) {
+        throw nextError;
+      }
+
+      if (isAbortError(nextError)) {
+        clearError();
+        setPhase(draftRef.current ? 'draft-ready' : 'idle');
         throw nextError;
       }
 
@@ -719,6 +748,12 @@ export function useImageDraftLifecycle(
     if (phaseRef.current === 'discarding') {
       reportError(createDiscardInProgressError());
       return;
+    }
+
+    const activeUploadRunId = uploadRunIdRef.current;
+
+    if (phaseRef.current === 'uploading-draft' && optionsRef.current.autoDiscard?.onReset) {
+      staleUploadDiscardReasonsRef.current.set(activeUploadRunId, 'reset');
     }
 
     uploadRunIdRef.current += 1;

--- a/src/react/use-image-draft-lifecycle.ts
+++ b/src/react/use-image-draft-lifecycle.ts
@@ -538,6 +538,7 @@ export function useImageDraftLifecycle(
       return result;
     } catch (nextError) {
       if (runId !== uploadRunIdRef.current || !isMountedRef.current) {
+        staleUploadDiscardReasonsRef.current.delete(runId);
         throw nextError;
       }
 

--- a/src/react/use-image-draft-lifecycle.ts
+++ b/src/react/use-image-draft-lifecycle.ts
@@ -1,0 +1,773 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createObjectUrl } from '../core/create-object-url';
+import {
+  toPersistableImageValue,
+  type PersistableImageValue
+} from '../core/persistable-image-value';
+import type { ImageUploadValue, ManagedObjectUrl } from '../core/types';
+import type { UploadAdapter, UploadContext, UploadResult } from '../upload/types';
+
+export interface ImageDraftDescriptor {
+  draftKey: string;
+  draftToken?: string;
+  previewSrc?: string;
+  src?: string;
+  key?: string;
+  fileName?: string;
+  mimeType?: string;
+  size?: number;
+  width?: number;
+  height?: number;
+  expiresAt?: string;
+}
+
+export type ImageDraftLifecyclePhase =
+  | 'idle'
+  | 'uploading-draft'
+  | 'draft-ready'
+  | 'committing'
+  | 'committed'
+  | 'discarding'
+  | 'discarded'
+  | 'failed';
+
+export type ImageDraftLifecycleErrorCode =
+  | 'missing_draft_key'
+  | 'draft_upload_in_progress'
+  | 'commit_in_progress'
+  | 'discard_in_progress'
+  | 'commit_failed'
+  | 'discard_failed'
+  | 'cleanup_previous_failed';
+
+export interface ImageDraftLifecycleErrorDetails {
+  phase?: ImageDraftLifecyclePhase;
+  reason?: DiscardImageDraftRequest['reason'];
+  draftKey?: string;
+}
+
+export interface ImageDraftLifecycleErrorOptions {
+  cause?: unknown;
+}
+
+export class ImageDraftLifecycleError extends Error {
+  readonly code: ImageDraftLifecycleErrorCode;
+  readonly details: ImageDraftLifecycleErrorDetails;
+
+  constructor(
+    code: ImageDraftLifecycleErrorCode,
+    message: string,
+    details: ImageDraftLifecycleErrorDetails = {},
+    options?: ImageDraftLifecycleErrorOptions
+  ) {
+    super(message, options);
+    this.name = 'ImageDraftLifecycleError';
+    this.code = code;
+    this.details = details;
+  }
+}
+
+export type ImageDraftUploadResult = UploadResult & {
+  draftKey?: string;
+  draftToken?: string;
+  previewSrc?: string;
+  expiresAt?: string;
+  fileName?: string;
+  mimeType?: string;
+  size?: number;
+  width?: number;
+  height?: number;
+};
+
+export type DraftUploadAdapterResult = ImageDraftUploadResult;
+
+export type ImageDraftUploadAdapter = (
+  file: Blob,
+  context: UploadContext
+) => Promise<ImageDraftUploadResult>;
+
+export interface CommitImageDraftRequest {
+  draft: ImageDraftDescriptor;
+  previous: PersistableImageValue | null;
+}
+
+export interface DiscardImageDraftRequest {
+  draft: ImageDraftDescriptor;
+  reason: 'replace' | 'reset' | 'unmount' | 'manual';
+}
+
+export interface CleanupPreviousImageRequest {
+  previous: PersistableImageValue;
+  next: PersistableImageValue;
+}
+
+export interface UseImageDraftLifecycleOptions {
+  committedValue: PersistableImageValue | null;
+  onCommittedValueChange?: (next: PersistableImageValue | null) => void;
+  uploadDraft: ImageDraftUploadAdapter;
+  commitDraft: (request: CommitImageDraftRequest) => Promise<PersistableImageValue>;
+  discardDraft?: (request: DiscardImageDraftRequest) => Promise<void>;
+  cleanupPrevious?: (request: CleanupPreviousImageRequest) => Promise<void>;
+  autoDiscard?: {
+    onReplace?: boolean;
+    onReset?: boolean;
+    onUnmount?: boolean;
+  };
+  onError?: (error: Error) => void;
+}
+
+export interface UseImageDraftLifecycleReturn {
+  valueForInput: ImageUploadValue | null;
+  uploadForInput: UploadAdapter;
+  phase: ImageDraftLifecyclePhase;
+  draft: ImageDraftDescriptor | null;
+  previous: PersistableImageValue | null;
+  committedValue: PersistableImageValue | null;
+  error: Error | null;
+  clearError: () => void;
+  commit: () => Promise<PersistableImageValue | null>;
+  discard: (reason?: DiscardImageDraftRequest['reason']) => Promise<void>;
+  resetToCommitted: () => void;
+  hasDraft: boolean;
+  canCommit: boolean;
+  canDiscard: boolean;
+}
+
+const imageDraftLifecycleErrorCodes = new Set<ImageDraftLifecycleErrorCode>([
+  'missing_draft_key',
+  'draft_upload_in_progress',
+  'commit_in_progress',
+  'discard_in_progress',
+  'commit_failed',
+  'discard_failed',
+  'cleanup_previous_failed'
+]);
+
+const imageDraftLifecyclePhases = new Set<ImageDraftLifecyclePhase>([
+  'idle',
+  'uploading-draft',
+  'draft-ready',
+  'committing',
+  'committed',
+  'discarding',
+  'discarded',
+  'failed'
+]);
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (!isObjectRecord(value)) {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+
+  return prototype === Object.prototype || prototype === null;
+}
+
+function isOptionalString(value: unknown): value is string | undefined {
+  return typeof value === 'undefined' || typeof value === 'string';
+}
+
+export function isImageDraftLifecycleError(
+  error: unknown
+): error is ImageDraftLifecycleError {
+  if (!isObjectRecord(error)) {
+    return false;
+  }
+
+  if (
+    error.name !== 'ImageDraftLifecycleError' ||
+    typeof error.message !== 'string' ||
+    typeof error.code !== 'string' ||
+    !imageDraftLifecycleErrorCodes.has(error.code as ImageDraftLifecycleErrorCode) ||
+    !isPlainRecord(error.details)
+  ) {
+    return false;
+  }
+
+  const details = error.details;
+
+  return (
+    (typeof details.phase === 'undefined' ||
+      imageDraftLifecyclePhases.has(details.phase as ImageDraftLifecyclePhase)) &&
+    (typeof details.reason === 'undefined' ||
+      details.reason === 'replace' ||
+      details.reason === 'reset' ||
+      details.reason === 'unmount' ||
+      details.reason === 'manual') &&
+    isOptionalString(details.draftKey)
+  );
+}
+
+function toError(error: unknown): Error {
+  if (error instanceof Error) {
+    return error;
+  }
+
+  return new Error(typeof error === 'string' ? error : 'Unknown image draft lifecycle error.');
+}
+
+function hasText(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function validOptionalNonNegativeNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+    ? value
+    : undefined;
+}
+
+function validOptionalPositiveNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? value
+    : undefined;
+}
+
+function cleanImageDraftDescriptor(value: ImageDraftDescriptor): ImageDraftDescriptor {
+  return {
+    draftKey: value.draftKey,
+    ...(typeof value.draftToken !== 'undefined' ? { draftToken: value.draftToken } : {}),
+    ...(typeof value.previewSrc !== 'undefined' ? { previewSrc: value.previewSrc } : {}),
+    ...(typeof value.src !== 'undefined' ? { src: value.src } : {}),
+    ...(typeof value.key !== 'undefined' ? { key: value.key } : {}),
+    ...(typeof value.fileName !== 'undefined' ? { fileName: value.fileName } : {}),
+    ...(typeof value.mimeType !== 'undefined' ? { mimeType: value.mimeType } : {}),
+    ...(typeof value.size !== 'undefined' ? { size: value.size } : {}),
+    ...(typeof value.width !== 'undefined' ? { width: value.width } : {}),
+    ...(typeof value.height !== 'undefined' ? { height: value.height } : {}),
+    ...(typeof value.expiresAt !== 'undefined' ? { expiresAt: value.expiresAt } : {})
+  };
+}
+
+function createDraftDescriptor(
+  result: ImageDraftUploadResult,
+  file: Blob,
+  context: UploadContext,
+  previewSrc?: string
+): ImageDraftDescriptor {
+  const draftKey = result.draftKey ?? result.key;
+
+  if (!hasText(draftKey)) {
+    throw new ImageDraftLifecycleError(
+      'missing_draft_key',
+      'Draft uploads must return draftKey or key.',
+      { phase: 'uploading-draft' }
+    );
+  }
+
+  return cleanImageDraftDescriptor({
+    draftKey,
+    draftToken: hasText(result.draftToken) ? result.draftToken : undefined,
+    previewSrc,
+    src: hasText(result.src) ? result.src : undefined,
+    key: hasText(result.key) ? result.key : undefined,
+    fileName: hasText(result.fileName) ? result.fileName : context.fileName,
+    mimeType: hasText(result.mimeType)
+      ? result.mimeType
+      : context.mimeType || file.type || undefined,
+    size: validOptionalNonNegativeNumber(result.size) ?? file.size,
+    width: validOptionalPositiveNumber(result.width),
+    height: validOptionalPositiveNumber(result.height),
+    expiresAt: hasText(result.expiresAt) ? result.expiresAt : undefined
+  });
+}
+
+function draftToInputValue(draft: ImageDraftDescriptor): ImageUploadValue {
+  return {
+    ...(typeof draft.src !== 'undefined' ? { src: draft.src } : {}),
+    ...(typeof draft.previewSrc !== 'undefined' ? { previewSrc: draft.previewSrc } : {}),
+    key: draft.key ?? draft.draftKey,
+    ...(typeof draft.fileName !== 'undefined' ? { fileName: draft.fileName } : {}),
+    ...(typeof draft.mimeType !== 'undefined' ? { mimeType: draft.mimeType } : {}),
+    ...(typeof draft.size !== 'undefined' ? { size: draft.size } : {}),
+    ...(typeof draft.width !== 'undefined' ? { width: draft.width } : {}),
+    ...(typeof draft.height !== 'undefined' ? { height: draft.height } : {})
+  };
+}
+
+function sameImageReference(
+  previous: PersistableImageValue,
+  next: PersistableImageValue
+): boolean {
+  if (previous.key && next.key) {
+    return previous.key === next.key;
+  }
+
+  if (previous.src && next.src) {
+    return previous.src === next.src;
+  }
+
+  return previous.key === next.key && previous.src === next.src;
+}
+
+function createCommitInProgressError(): ImageDraftLifecycleError {
+  return new ImageDraftLifecycleError(
+    'commit_in_progress',
+    'Cannot change an image draft while commit is in progress.',
+    { phase: 'committing' }
+  );
+}
+
+function createDiscardInProgressError(): ImageDraftLifecycleError {
+  return new ImageDraftLifecycleError(
+    'discard_in_progress',
+    'Cannot change an image draft while discard is in progress.',
+    { phase: 'discarding' }
+  );
+}
+
+export function useImageDraftLifecycle(
+  options: UseImageDraftLifecycleOptions
+): UseImageDraftLifecycleReturn {
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  const isMountedRef = useRef(true);
+  const uploadRunIdRef = useRef(0);
+  const draftPreviewObjectUrlRef = useRef<ManagedObjectUrl | null>(null);
+  const commitPromiseRef = useRef<Promise<PersistableImageValue | null> | null>(null);
+
+  const [phase, setPhaseState] = useState<ImageDraftLifecyclePhase>('idle');
+  const phaseRef = useRef<ImageDraftLifecyclePhase>('idle');
+  const [draft, setDraftState] = useState<ImageDraftDescriptor | null>(null);
+  const draftRef = useRef<ImageDraftDescriptor | null>(null);
+  const [committedValue, setCommittedValueState] = useState<PersistableImageValue | null>(
+    options.committedValue
+  );
+  const committedValueRef = useRef<PersistableImageValue | null>(options.committedValue);
+  const [error, setErrorState] = useState<Error | null>(null);
+
+  const setPhase = useCallback((nextPhase: ImageDraftLifecyclePhase) => {
+    phaseRef.current = nextPhase;
+
+    if (isMountedRef.current) {
+      setPhaseState(nextPhase);
+    }
+  }, []);
+
+  const clearError = useCallback(() => {
+    if (isMountedRef.current) {
+      setErrorState(null);
+    }
+  }, []);
+
+  const reportError = useCallback(
+    (nextError: Error, nextPhase?: ImageDraftLifecyclePhase) => {
+      if (isMountedRef.current) {
+        setErrorState(nextError);
+
+        if (nextPhase) {
+          setPhase(nextPhase);
+        }
+      }
+
+      optionsRef.current.onError?.(nextError);
+    },
+    [setPhase]
+  );
+
+  const releaseDraftPreviewObjectUrl = useCallback(() => {
+    draftPreviewObjectUrlRef.current?.revoke();
+    draftPreviewObjectUrlRef.current = null;
+  }, []);
+
+  const setDraftDescriptor = useCallback(
+    (nextDraft: ImageDraftDescriptor | null, ownedPreview?: ManagedObjectUrl | null) => {
+      if (draftPreviewObjectUrlRef.current?.url !== ownedPreview?.url) {
+        releaseDraftPreviewObjectUrl();
+      }
+
+      draftPreviewObjectUrlRef.current = ownedPreview ?? null;
+      draftRef.current = nextDraft;
+
+      if (isMountedRef.current) {
+        setDraftState(nextDraft);
+      }
+    },
+    [releaseDraftPreviewObjectUrl]
+  );
+
+  const discardDescriptorBestEffort = useCallback(
+    async (
+      nextDraft: ImageDraftDescriptor,
+      reason: DiscardImageDraftRequest['reason'],
+      notify = true
+    ) => {
+      try {
+        await optionsRef.current.discardDraft?.({ draft: nextDraft, reason });
+      } catch (nextError) {
+        if (!notify) {
+          return;
+        }
+
+        const lifecycleError = new ImageDraftLifecycleError(
+          'discard_failed',
+          'Draft discard failed.',
+          {
+            draftKey: nextDraft.draftKey,
+            reason
+          },
+          { cause: nextError }
+        );
+
+        optionsRef.current.onError?.(lifecycleError);
+      }
+    },
+    []
+  );
+
+  useEffect(() => {
+    committedValueRef.current = options.committedValue;
+    setCommittedValueState(options.committedValue);
+  }, [options.committedValue]);
+
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+      uploadRunIdRef.current += 1;
+
+      const currentDraft = draftRef.current;
+      releaseDraftPreviewObjectUrl();
+
+      if (currentDraft && optionsRef.current.autoDiscard?.onUnmount) {
+        void discardDescriptorBestEffort(currentDraft, 'unmount', false);
+      }
+    };
+  }, [discardDescriptorBestEffort, releaseDraftPreviewObjectUrl]);
+
+  const uploadForInput = useCallback<UploadAdapter>(async (file, context) => {
+    if (phaseRef.current === 'committing') {
+      const lifecycleError = createCommitInProgressError();
+
+      reportError(lifecycleError);
+
+      throw lifecycleError;
+    }
+
+    if (phaseRef.current === 'discarding') {
+      const lifecycleError = createDiscardInProgressError();
+
+      reportError(lifecycleError);
+
+      throw lifecycleError;
+    }
+
+    const runId = ++uploadRunIdRef.current;
+    const previousDraft = draftRef.current;
+
+    clearError();
+    setPhase('uploading-draft');
+
+    if (previousDraft && optionsRef.current.autoDiscard?.onReplace) {
+      setDraftDescriptor(null);
+      void discardDescriptorBestEffort(previousDraft, 'replace');
+    }
+
+    try {
+      const result = await optionsRef.current.uploadDraft(file, context);
+
+      if (runId !== uploadRunIdRef.current) {
+        if (optionsRef.current.autoDiscard?.onReplace) {
+          try {
+            const staleDraft = createDraftDescriptor(result, file, context);
+            void discardDescriptorBestEffort(staleDraft, 'replace', false);
+          } catch {
+            // If a stale upload cannot be identified, there is nothing useful to discard.
+          }
+        }
+
+        return result;
+      }
+
+      if (!isMountedRef.current) {
+        if (optionsRef.current.autoDiscard?.onUnmount) {
+          try {
+            const unmountedDraft = createDraftDescriptor(result, file, context);
+            void discardDescriptorBestEffort(unmountedDraft, 'unmount', false);
+          } catch {
+            // Server-side TTL remains the fallback for unidentifiable stale draft uploads.
+          }
+        }
+
+        return result;
+      }
+
+      const resultPreviewSrc = hasText(result.previewSrc) ? result.previewSrc : undefined;
+      let nextDraft = createDraftDescriptor(result, file, context, resultPreviewSrc);
+      let ownedPreviewObjectUrl: ManagedObjectUrl | null = null;
+
+      if (!nextDraft.src && !nextDraft.previewSrc) {
+        ownedPreviewObjectUrl = createObjectUrl(file);
+        nextDraft = {
+          ...nextDraft,
+          previewSrc: ownedPreviewObjectUrl.url
+        };
+      }
+
+      clearError();
+      setDraftDescriptor(nextDraft, ownedPreviewObjectUrl);
+      setPhase('draft-ready');
+
+      return result;
+    } catch (nextError) {
+      if (runId !== uploadRunIdRef.current || !isMountedRef.current) {
+        throw nextError;
+      }
+
+      const normalizedError = toError(nextError);
+
+      reportError(normalizedError, 'failed');
+
+      throw normalizedError;
+    }
+  }, [
+    clearError,
+    discardDescriptorBestEffort,
+    reportError,
+    setDraftDescriptor,
+    setPhase
+  ]);
+
+  const discard = useCallback<UseImageDraftLifecycleReturn['discard']>(
+    async (reason = 'manual') => {
+      if (phaseRef.current === 'committing') {
+        const lifecycleError = createCommitInProgressError();
+
+        reportError(lifecycleError);
+
+        throw lifecycleError;
+      }
+
+      const currentDraft = draftRef.current;
+
+      if (!currentDraft) {
+        return;
+      }
+
+      clearError();
+      setPhase('discarding');
+
+      try {
+        await optionsRef.current.discardDraft?.({
+          draft: currentDraft,
+          reason
+        });
+
+        if (!isMountedRef.current) {
+          return;
+        }
+
+        if (draftRef.current?.draftKey === currentDraft.draftKey) {
+          setDraftDescriptor(null);
+        }
+
+        setPhase('discarded');
+      } catch (nextError) {
+        if (!isMountedRef.current) {
+          return;
+        }
+
+        const lifecycleError = new ImageDraftLifecycleError(
+          'discard_failed',
+          'Draft discard failed.',
+          {
+            draftKey: currentDraft.draftKey,
+            phase: 'discarding',
+            reason
+          },
+          { cause: nextError }
+        );
+
+        reportError(lifecycleError, 'failed');
+
+        throw lifecycleError;
+      }
+    },
+    [clearError, reportError, setDraftDescriptor, setPhase]
+  );
+
+  const commit = useCallback<UseImageDraftLifecycleReturn['commit']>(async () => {
+    if (commitPromiseRef.current) {
+      return commitPromiseRef.current;
+    }
+
+    if (phaseRef.current === 'uploading-draft') {
+      const lifecycleError = new ImageDraftLifecycleError(
+        'draft_upload_in_progress',
+        'Cannot commit an image draft while its upload is still in progress.',
+        { phase: 'uploading-draft' }
+      );
+
+      reportError(lifecycleError, 'failed');
+
+      throw lifecycleError;
+    }
+
+    if (phaseRef.current === 'discarding') {
+      const lifecycleError = createDiscardInProgressError();
+
+      reportError(lifecycleError);
+
+      throw lifecycleError;
+    }
+
+    const currentDraft = draftRef.current;
+
+    if (!currentDraft) {
+      return committedValueRef.current;
+    }
+
+    const promise = (async () => {
+      clearError();
+      setPhase('committing');
+
+      let previousValue: PersistableImageValue | null;
+      let nextValue: PersistableImageValue;
+
+      try {
+        previousValue = toPersistableImageValue(committedValueRef.current);
+        const commitResult = await optionsRef.current.commitDraft({
+          draft: currentDraft,
+          previous: previousValue
+        });
+        const persistableValue = toPersistableImageValue(commitResult);
+
+        if (!persistableValue) {
+          throw new ImageDraftLifecycleError(
+            'commit_failed',
+            'commitDraft must return a persistable image value.',
+            { phase: 'committing' }
+          );
+        }
+
+        nextValue = persistableValue;
+      } catch (nextError) {
+        const lifecycleError = isImageDraftLifecycleError(nextError)
+          ? nextError
+          : new ImageDraftLifecycleError(
+              'commit_failed',
+              'Image draft commit failed.',
+              {
+                draftKey: currentDraft.draftKey,
+                phase: 'committing'
+              },
+              { cause: nextError }
+            );
+
+        reportError(lifecycleError, 'failed');
+
+        throw lifecycleError;
+      }
+
+      if (!isMountedRef.current) {
+        return nextValue;
+      }
+
+      clearError();
+      committedValueRef.current = nextValue;
+      setCommittedValueState(nextValue);
+      optionsRef.current.onCommittedValueChange?.(nextValue);
+      setDraftDescriptor(null);
+      setPhase('committed');
+
+      if (
+        previousValue &&
+        !sameImageReference(previousValue, nextValue) &&
+        optionsRef.current.cleanupPrevious
+      ) {
+        try {
+          await optionsRef.current.cleanupPrevious({
+            previous: previousValue,
+            next: nextValue
+          });
+        } catch (nextError) {
+          const cleanupError = new ImageDraftLifecycleError(
+            'cleanup_previous_failed',
+            'Previous image cleanup failed after the new image was committed.',
+            { phase: 'committed' },
+            { cause: nextError }
+          );
+
+          reportError(cleanupError);
+        }
+      }
+
+      return nextValue;
+    })();
+
+    commitPromiseRef.current = promise;
+
+    try {
+      return await promise;
+    } finally {
+      if (commitPromiseRef.current === promise) {
+        commitPromiseRef.current = null;
+      }
+    }
+  }, [clearError, reportError, setDraftDescriptor, setPhase]);
+
+  const resetToCommitted = useCallback(() => {
+    if (phaseRef.current === 'committing') {
+      reportError(createCommitInProgressError());
+      return;
+    }
+
+    if (phaseRef.current === 'discarding') {
+      reportError(createDiscardInProgressError());
+      return;
+    }
+
+    uploadRunIdRef.current += 1;
+
+    if (!draftRef.current) {
+      clearError();
+      setPhase('idle');
+      return;
+    }
+
+    if (optionsRef.current.autoDiscard?.onReset) {
+      void discard('reset').catch(() => undefined);
+      return;
+    }
+
+    clearError();
+    setDraftDescriptor(null);
+    setPhase('idle');
+  }, [clearError, discard, setDraftDescriptor, setPhase]);
+
+  const valueForInput = useMemo<ImageUploadValue | null>(() => {
+    if (draft) {
+      return draftToInputValue(draft);
+    }
+
+    return committedValue;
+  }, [committedValue, draft]);
+
+  const previous = draft ? committedValue : null;
+  const hasDraft = Boolean(draft);
+  const isBusy =
+    phase === 'uploading-draft' || phase === 'committing' || phase === 'discarding';
+  const canCommit = hasDraft && !isBusy;
+  const canDiscard = hasDraft && phase !== 'committing' && phase !== 'discarding';
+
+  return {
+    valueForInput,
+    uploadForInput,
+    phase,
+    draft,
+    previous,
+    committedValue,
+    error,
+    clearError,
+    commit,
+    discard,
+    resetToCommitted,
+    hasDraft,
+    canCommit,
+    canDiscard
+  };
+}

--- a/src/react/use-image-draft-lifecycle.ts
+++ b/src/react/use-image-draft-lifecycle.ts
@@ -571,9 +571,16 @@ export function useImageDraftLifecycle(
         throw lifecycleError;
       }
 
+      if (phaseRef.current === 'uploading-draft') {
+        staleUploadDiscardReasonsRef.current.set(uploadRunIdRef.current, reason);
+        uploadRunIdRef.current += 1;
+      }
+
       const currentDraft = draftRef.current;
 
       if (!currentDraft) {
+        clearError();
+        setPhase('idle');
         return;
       }
 
@@ -750,15 +757,22 @@ export function useImageDraftLifecycle(
       return;
     }
 
-    const activeUploadRunId = uploadRunIdRef.current;
+    const currentDraft = draftRef.current;
+    const shouldDiscardCurrentDraft = Boolean(
+      currentDraft && optionsRef.current.autoDiscard?.onReset
+    );
 
-    if (phaseRef.current === 'uploading-draft' && optionsRef.current.autoDiscard?.onReset) {
-      staleUploadDiscardReasonsRef.current.set(activeUploadRunId, 'reset');
+    if (phaseRef.current === 'uploading-draft' && !shouldDiscardCurrentDraft) {
+      const activeUploadRunId = uploadRunIdRef.current;
+
+      if (optionsRef.current.autoDiscard?.onReset) {
+        staleUploadDiscardReasonsRef.current.set(activeUploadRunId, 'reset');
+      }
+
+      uploadRunIdRef.current += 1;
     }
 
-    uploadRunIdRef.current += 1;
-
-    if (!draftRef.current) {
+    if (!currentDraft) {
       clearError();
       setPhase('idle');
       return;

--- a/src/react/use-image-draft-lifecycle.ts
+++ b/src/react/use-image-draft-lifecycle.ts
@@ -700,22 +700,15 @@ export function useImageDraftLifecycle(
         throw lifecycleError;
       }
 
-      if (!isMountedRef.current) {
-        return nextValue;
-      }
+      const cleanupPreviousValue = async () => {
+        if (
+          !previousValue ||
+          sameImageReference(previousValue, nextValue) ||
+          !optionsRef.current.cleanupPrevious
+        ) {
+          return;
+        }
 
-      clearError();
-      committedValueRef.current = nextValue;
-      setCommittedValueState(nextValue);
-      optionsRef.current.onCommittedValueChange?.(nextValue);
-      setDraftDescriptor(null);
-      setPhase('committed');
-
-      if (
-        previousValue &&
-        !sameImageReference(previousValue, nextValue) &&
-        optionsRef.current.cleanupPrevious
-      ) {
         try {
           await optionsRef.current.cleanupPrevious({
             previous: previousValue,
@@ -731,7 +724,21 @@ export function useImageDraftLifecycle(
 
           reportError(cleanupError);
         }
+      };
+
+      if (!isMountedRef.current) {
+        await cleanupPreviousValue();
+        return nextValue;
       }
+
+      clearError();
+      committedValueRef.current = nextValue;
+      setCommittedValueState(nextValue);
+      optionsRef.current.onCommittedValueChange?.(nextValue);
+      setDraftDescriptor(null);
+      setPhase('committed');
+
+      await cleanupPreviousValue();
 
       return nextValue;
     })();

--- a/tests/entrypoints.test.ts
+++ b/tests/entrypoints.test.ts
@@ -18,6 +18,9 @@ describe('package entrypoints', () => {
     expect(root).not.toHaveProperty('ImageBudgetError');
     expect(root).not.toHaveProperty('isImageBudgetError');
     expect(root).not.toHaveProperty('prepareImageToBudget');
+    expect(root).not.toHaveProperty('ImageDraftLifecycleError');
+    expect(root).not.toHaveProperty('isImageDraftLifecycleError');
+    expect(root).not.toHaveProperty('useImageDraftLifecycle');
     expect(root).not.toHaveProperty('createPresignedPutUploader');
     expect(root).not.toHaveProperty('useImageDropInput');
     expect(root).not.toHaveProperty('validateImage');
@@ -38,7 +41,10 @@ describe('package entrypoints', () => {
     expect(headless.assertPersistableImageValue).toBeTypeOf('function');
     expect(headless.isPersistableImageValue).toBeTypeOf('function');
     expect(headless.isTemporaryImageSrc).toBeTypeOf('function');
+    expect(headless.ImageDraftLifecycleError).toBeTypeOf('function');
+    expect(headless.isImageDraftLifecycleError).toBeTypeOf('function');
     expect(headless.useImageDropInput).toBeTypeOf('function');
+    expect(headless.useImageDraftLifecycle).toBeTypeOf('function');
     expect(headless.validateImage).toBeTypeOf('function');
   });
 });

--- a/tests/react/use-image-draft-lifecycle.test.tsx
+++ b/tests/react/use-image-draft-lifecycle.test.tsx
@@ -580,6 +580,106 @@ describe('useImageDraftLifecycle', () => {
     expect(result.current.phase).toBe('discarded');
   });
 
+  it('keeps manual discard from accepting an in-flight replacement upload', async () => {
+    let resolveReplacement: ((value: { draftKey: string }) => void) | undefined;
+    const discardDraft = vi.fn(async () => undefined);
+    const uploadDraftMock = vi
+      .fn<UseImageDraftLifecycleOptions['uploadDraft']>()
+      .mockResolvedValueOnce({ draftKey: 'drafts/first.webp' })
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ draftKey: string }>((resolve) => {
+            resolveReplacement = resolve;
+          })
+      );
+    const options = createOptions({
+      uploadDraft: uploadDraftMock,
+      discardDraft
+    });
+    const { result } = renderHook(() => useImageDraftLifecycle(options));
+    let replacementUpload: Promise<unknown>;
+
+    await act(async () => {
+      await result.current.uploadForInput(createFile('first.webp'), {});
+    });
+
+    act(() => {
+      replacementUpload = result.current.uploadForInput(createFile('second.webp'), {});
+    });
+
+    await waitFor(() => {
+      expect(result.current.phase).toBe('uploading-draft');
+    });
+
+    await act(async () => {
+      await result.current.discard('manual');
+    });
+
+    await act(async () => {
+      resolveReplacement?.({ draftKey: 'drafts/second.webp' });
+      await replacementUpload;
+    });
+
+    expect(result.current.draft).toBeNull();
+    expect(result.current.valueForInput).toEqual(committedImage);
+    expect(result.current.phase).toBe('discarded');
+    expect(discardDraft).toHaveBeenNthCalledWith(1, {
+      draft: expect.objectContaining({
+        draftKey: 'drafts/first.webp'
+      }),
+      reason: 'manual'
+    });
+    expect(discardDraft).toHaveBeenNthCalledWith(2, {
+      draft: expect.objectContaining({
+        draftKey: 'drafts/second.webp'
+      }),
+      reason: 'manual'
+    });
+  });
+
+  it('keeps manual discard from accepting an in-flight first upload', async () => {
+    let resolveUpload: ((value: { draftKey: string }) => void) | undefined;
+    const discardDraft = vi.fn(async () => undefined);
+    const options = createOptions({
+      uploadDraft: vi.fn(
+        () =>
+          new Promise<{ draftKey: string }>((resolve) => {
+            resolveUpload = resolve;
+          })
+      ),
+      discardDraft
+    });
+    const { result } = renderHook(() => useImageDraftLifecycle(options));
+    let uploadPromise: Promise<unknown>;
+
+    act(() => {
+      uploadPromise = result.current.uploadForInput(createFile(), {});
+    });
+
+    await waitFor(() => {
+      expect(result.current.phase).toBe('uploading-draft');
+    });
+
+    await act(async () => {
+      await result.current.discard('manual');
+    });
+
+    await act(async () => {
+      resolveUpload?.({ draftKey: 'drafts/stale-manual.webp' });
+      await uploadPromise;
+    });
+
+    expect(result.current.phase).toBe('idle');
+    expect(result.current.draft).toBeNull();
+    expect(result.current.valueForInput).toEqual(committedImage);
+    expect(discardDraft).toHaveBeenCalledWith({
+      draft: expect.objectContaining({
+        draftKey: 'drafts/stale-manual.webp'
+      }),
+      reason: 'manual'
+    });
+  });
+
   it('keeps a draft when user-triggered discard fails', async () => {
     const discardDraft = vi.fn(async () => {
       throw new Error('discard endpoint failed');

--- a/tests/react/use-image-draft-lifecycle.test.tsx
+++ b/tests/react/use-image-draft-lifecycle.test.tsx
@@ -888,6 +888,50 @@ describe('useImageDraftLifecycle', () => {
     expect(result.current.draft).toBeNull();
   });
 
+  it('clears stale discard reasons when an invalidated upload rejects', async () => {
+    let rejectUpload: ((reason: Error) => void) | undefined;
+    const deleteSpy = vi.spyOn(Map.prototype, 'delete');
+    const uploadError = new Error('upload failed after reset');
+    const options = createOptions({
+      uploadDraft: vi.fn(
+        () =>
+          new Promise<never>((_, reject) => {
+            rejectUpload = reject;
+          })
+      ),
+      autoDiscard: {
+        onReset: true
+      }
+    });
+    const { result } = renderHook(() => useImageDraftLifecycle(options));
+    let uploadPromise: Promise<unknown>;
+
+    try {
+      act(() => {
+        uploadPromise = result.current.uploadForInput(createFile(), {});
+      });
+
+      await waitFor(() => {
+        expect(result.current.phase).toBe('uploading-draft');
+      });
+
+      act(() => {
+        result.current.resetToCommitted();
+      });
+
+      await act(async () => {
+        rejectUpload?.(uploadError);
+        await expect(uploadPromise).rejects.toBe(uploadError);
+      });
+
+      expect(deleteSpy).toHaveBeenCalledWith(1);
+      expect(result.current.phase).toBe('idle');
+      expect(result.current.error).toBeNull();
+    } finally {
+      deleteSpy.mockRestore();
+    }
+  });
+
   it('best-effort discards a stale in-flight upload on unmount when configured', async () => {
     let resolveUpload: ((value: { draftKey: string }) => void) | undefined;
     const discardDraft = vi.fn(async () => undefined);

--- a/tests/react/use-image-draft-lifecycle.test.tsx
+++ b/tests/react/use-image-draft-lifecycle.test.tsx
@@ -34,6 +34,14 @@ function createFile(name = 'next.webp') {
   return new File(['image bytes'], name, { type: 'image/webp' });
 }
 
+function createAbortError() {
+  const error = new Error('Upload aborted.');
+
+  error.name = 'AbortError';
+
+  return error;
+}
+
 function createOptions(
   overrides: Partial<UseImageDraftLifecycleOptions> = {}
 ): UseImageDraftLifecycleOptions {
@@ -379,6 +387,46 @@ describe('useImageDraftLifecycle', () => {
     expect(result.current.error).toBeNull();
   });
 
+  it('does not discard the draft on unmount while commit is in flight', async () => {
+    let resolveCommit: ((value: PersistableImageValue) => void) | undefined;
+    const discardDraft = vi.fn(async () => undefined);
+    const commitDraft = vi.fn(
+      () =>
+        new Promise<PersistableImageValue>((resolve) => {
+          resolveCommit = resolve;
+        })
+    );
+    const options = createOptions({
+      commitDraft,
+      discardDraft,
+      autoDiscard: {
+        onUnmount: true
+      }
+    });
+    const { result, unmount } = renderHook(() => useImageDraftLifecycle(options));
+
+    await uploadDraft(result);
+
+    let commitPromise: Promise<PersistableImageValue | null>;
+
+    act(() => {
+      commitPromise = result.current.commit();
+    });
+
+    await waitFor(() => {
+      expect(result.current.phase).toBe('committing');
+    });
+
+    unmount();
+
+    await act(async () => {
+      resolveCommit?.(nextCommittedImage);
+      await commitPromise;
+    });
+
+    expect(discardDraft).not.toHaveBeenCalled();
+  });
+
   it('rejects commit and draft replacement while discard is in flight', async () => {
     let resolveDiscard: (() => void) | undefined;
     const discardDraft = vi.fn(
@@ -443,6 +491,32 @@ describe('useImageDraftLifecycle', () => {
         code: 'draft_upload_in_progress'
       });
     });
+  });
+
+  it('rethrows upload AbortError without marking the lifecycle as failed', async () => {
+    const abortError = createAbortError();
+    const onError = vi.fn();
+    const options = createOptions({
+      uploadDraft: vi.fn(async () => {
+        throw abortError;
+      }),
+      onError
+    });
+    const { result } = renderHook(() => useImageDraftLifecycle(options));
+    let caught: unknown;
+
+    await act(async () => {
+      try {
+        await result.current.uploadForInput(createFile(), {});
+      } catch (error) {
+        caught = error;
+      }
+    });
+
+    expect(caught).toBe(abortError);
+    expect(result.current.phase).toBe('idle');
+    expect(result.current.error).toBeNull();
+    expect(onError).not.toHaveBeenCalled();
   });
 
   it('clears a transient commit error when an in-flight draft upload later succeeds', async () => {
@@ -668,6 +742,91 @@ describe('useImageDraftLifecycle', () => {
     expect(result.current.phase).toBe('idle');
     expect(result.current.draft).toBeNull();
     expect(result.current.valueForInput).toEqual(committedImage);
+  });
+
+  it('best-effort discards a stale in-flight upload after reset when configured', async () => {
+    let resolveUpload: ((value: { draftKey: string }) => void) | undefined;
+    const discardDraft = vi.fn(async () => undefined);
+    const options = createOptions({
+      uploadDraft: vi.fn(
+        () =>
+          new Promise<{ draftKey: string }>((resolve) => {
+            resolveUpload = resolve;
+          })
+      ),
+      discardDraft,
+      autoDiscard: {
+        onReset: true
+      }
+    });
+    const { result } = renderHook(() => useImageDraftLifecycle(options));
+    let uploadPromise: Promise<unknown>;
+
+    act(() => {
+      uploadPromise = result.current.uploadForInput(createFile(), {});
+    });
+
+    await waitFor(() => {
+      expect(result.current.phase).toBe('uploading-draft');
+    });
+
+    act(() => {
+      result.current.resetToCommitted();
+    });
+
+    await act(async () => {
+      resolveUpload?.({ draftKey: 'drafts/stale-reset.webp' });
+      await uploadPromise;
+    });
+
+    expect(discardDraft).toHaveBeenCalledWith({
+      draft: expect.objectContaining({
+        draftKey: 'drafts/stale-reset.webp'
+      }),
+      reason: 'reset'
+    });
+    expect(result.current.draft).toBeNull();
+  });
+
+  it('best-effort discards a stale in-flight upload on unmount when configured', async () => {
+    let resolveUpload: ((value: { draftKey: string }) => void) | undefined;
+    const discardDraft = vi.fn(async () => undefined);
+    const options = createOptions({
+      uploadDraft: vi.fn(
+        () =>
+          new Promise<{ draftKey: string }>((resolve) => {
+            resolveUpload = resolve;
+          })
+      ),
+      discardDraft,
+      autoDiscard: {
+        onUnmount: true
+      }
+    });
+    const { result, unmount } = renderHook(() => useImageDraftLifecycle(options));
+    let uploadPromise: Promise<unknown>;
+
+    act(() => {
+      uploadPromise = result.current.uploadForInput(createFile(), {});
+    });
+
+    await waitFor(() => {
+      expect(result.current.phase).toBe('uploading-draft');
+    });
+
+    unmount();
+
+    await act(async () => {
+      resolveUpload?.({ draftKey: 'drafts/stale-unmount.webp' });
+      await uploadPromise;
+    });
+
+    expect(discardDraft).toHaveBeenCalledWith({
+      draft: expect.objectContaining({
+        draftKey: 'drafts/stale-unmount.webp'
+      }),
+      reason: 'unmount'
+    });
   });
 
   it('best-effort discards a ready draft on unmount when autoDiscard.onUnmount is enabled', async () => {

--- a/tests/react/use-image-draft-lifecycle.test.tsx
+++ b/tests/react/use-image-draft-lifecycle.test.tsx
@@ -1,0 +1,696 @@
+import '../setup';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PersistableImageValue } from '../../src/core/persistable-image-value';
+import {
+  ImageDraftLifecycleError,
+  isImageDraftLifecycleError,
+  useImageDraftLifecycle,
+  type UseImageDraftLifecycleReturn,
+  type UseImageDraftLifecycleOptions
+} from '../../src/react/use-image-draft-lifecycle';
+
+const committedImage: PersistableImageValue = {
+  src: 'https://cdn.example.com/avatars/current.webp',
+  key: 'avatars/current.webp',
+  fileName: 'current.webp',
+  mimeType: 'image/webp',
+  size: 128,
+  width: 64,
+  height: 64
+};
+
+const nextCommittedImage: PersistableImageValue = {
+  src: 'https://cdn.example.com/avatars/next.webp',
+  key: 'avatars/next.webp',
+  fileName: 'next.webp',
+  mimeType: 'image/webp',
+  size: 256,
+  width: 128,
+  height: 128
+};
+
+function createFile(name = 'next.webp') {
+  return new File(['image bytes'], name, { type: 'image/webp' });
+}
+
+function createOptions(
+  overrides: Partial<UseImageDraftLifecycleOptions> = {}
+): UseImageDraftLifecycleOptions {
+  return {
+    committedValue: committedImage,
+    uploadDraft: vi.fn(async () => ({
+      draftKey: 'drafts/next.webp',
+      fileName: 'next.webp',
+      mimeType: 'image/webp',
+      width: 128,
+      height: 128
+    })),
+    commitDraft: vi.fn(async () => nextCommittedImage),
+    ...overrides
+  };
+}
+
+async function uploadDraft(result: { current: UseImageDraftLifecycleReturn }) {
+  await act(async () => {
+    await result.current.uploadForInput(createFile(), {
+      fileName: 'next.webp',
+      mimeType: 'image/webp'
+    });
+  });
+}
+
+describe('useImageDraftLifecycle', () => {
+  beforeEach(() => {
+    vi.mocked(URL.createObjectURL).mockReset();
+    vi.mocked(URL.createObjectURL).mockReturnValue('blob:draft-preview');
+    vi.mocked(URL.revokeObjectURL).mockReset();
+  });
+
+  it('stores a draft descriptor and valueForInput after draft upload succeeds', async () => {
+    const options = createOptions();
+    const { result } = renderHook(() => useImageDraftLifecycle(options));
+
+    await uploadDraft(result);
+
+    expect(options.uploadDraft).toHaveBeenCalledWith(
+      expect.any(File),
+      expect.objectContaining({
+        fileName: 'next.webp',
+        mimeType: 'image/webp'
+      })
+    );
+    expect(result.current.phase).toBe('draft-ready');
+    expect(result.current.draft).toEqual(
+      expect.objectContaining({
+        draftKey: 'drafts/next.webp',
+        previewSrc: 'blob:draft-preview',
+        fileName: 'next.webp',
+        mimeType: 'image/webp',
+        size: createFile().size,
+        width: 128,
+        height: 128
+      })
+    );
+    expect(result.current.valueForInput).toEqual(
+      expect.objectContaining({
+        key: 'drafts/next.webp',
+        previewSrc: 'blob:draft-preview',
+        fileName: 'next.webp'
+      })
+    );
+    expect(result.current.previous).toEqual(committedImage);
+    expect(result.current.hasDraft).toBe(true);
+    expect(result.current.canCommit).toBe(true);
+    expect(result.current.canDiscard).toBe(true);
+  });
+
+  it('throws a typed error when a draft upload does not return draftKey or key', async () => {
+    const onError = vi.fn();
+    const options = createOptions({
+      uploadDraft: vi.fn(async () => ({
+        src: 'https://cdn.example.com/drafts/preview.webp'
+      })),
+      onError
+    });
+    const { result } = renderHook(() => useImageDraftLifecycle(options));
+    let caught: unknown;
+
+    await act(async () => {
+      try {
+        await result.current.uploadForInput(createFile(), {});
+      } catch (error) {
+        caught = error;
+      }
+    });
+
+    expect(caught).toBeInstanceOf(ImageDraftLifecycleError);
+    expect(isImageDraftLifecycleError(caught)).toBe(true);
+    expect(caught).toMatchObject({
+      code: 'missing_draft_key'
+    });
+    expect(result.current.phase).toBe('failed');
+    expect(result.current.error).toMatchObject({
+      code: 'missing_draft_key'
+    });
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ code: 'missing_draft_key' }));
+  });
+
+  it('returns the current committed value when commit is called without a draft', async () => {
+    const options = createOptions();
+    const { result } = renderHook(() => useImageDraftLifecycle(options));
+    let committed: PersistableImageValue | null = null;
+
+    await act(async () => {
+      committed = await result.current.commit();
+    });
+
+    expect(committed).toEqual(committedImage);
+    expect(options.commitDraft).not.toHaveBeenCalled();
+    expect(result.current.committedValue).toEqual(committedImage);
+  });
+
+  it('commits a draft with the previous committed value and clears preview-only state', async () => {
+    const onCommittedValueChange = vi.fn();
+    const commitDraft = vi.fn(async () => ({
+      ...nextCommittedImage,
+      previewSrc: 'blob:must-not-persist'
+    } as PersistableImageValue));
+    const options = createOptions({
+      commitDraft,
+      onCommittedValueChange
+    });
+    const { result } = renderHook(() => useImageDraftLifecycle(options));
+    let committed: PersistableImageValue | null = null;
+
+    await uploadDraft(result);
+
+    await act(async () => {
+      committed = await result.current.commit();
+    });
+
+    expect(commitDraft).toHaveBeenCalledWith({
+      draft: expect.objectContaining({
+        draftKey: 'drafts/next.webp'
+      }),
+      previous: committedImage
+    });
+    expect(committed).toEqual(nextCommittedImage);
+    expect(committed).not.toHaveProperty('previewSrc');
+    expect(onCommittedValueChange).toHaveBeenCalledWith(nextCommittedImage);
+    expect(result.current.draft).toBeNull();
+    expect(result.current.hasDraft).toBe(false);
+    expect(result.current.phase).toBe('committed');
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:draft-preview');
+  });
+
+  it('keeps the previous committed value and draft when commit fails', async () => {
+    const cleanupPrevious = vi.fn();
+    const commitError = new Error('database transaction failed');
+    const options = createOptions({
+      commitDraft: vi.fn(async () => {
+        throw commitError;
+      }),
+      cleanupPrevious
+    });
+    const { result } = renderHook(() => useImageDraftLifecycle(options));
+    let caught: unknown;
+
+    await uploadDraft(result);
+
+    await act(async () => {
+      try {
+        await result.current.commit();
+      } catch (error) {
+        caught = error;
+      }
+    });
+
+    expect(caught).toMatchObject({
+      name: 'ImageDraftLifecycleError',
+      code: 'commit_failed'
+    });
+    expect(result.current.committedValue).toEqual(committedImage);
+    expect(result.current.draft).toEqual(expect.objectContaining({ draftKey: 'drafts/next.webp' }));
+    expect(result.current.canCommit).toBe(true);
+    expect(cleanupPrevious).not.toHaveBeenCalled();
+  });
+
+  it('cleans up the previous image only after commit succeeds and does not rollback on cleanup failure', async () => {
+    const cleanupError = new Error('cleanup queue unavailable');
+    const onError = vi.fn();
+    const cleanupPrevious = vi.fn(async () => {
+      throw cleanupError;
+    });
+    const options = createOptions({
+      cleanupPrevious,
+      onError
+    });
+    const { result } = renderHook(() => useImageDraftLifecycle(options));
+    let committed: PersistableImageValue | null = null;
+
+    await uploadDraft(result);
+
+    await act(async () => {
+      committed = await result.current.commit();
+    });
+
+    expect(committed).toEqual(nextCommittedImage);
+    expect(cleanupPrevious).toHaveBeenCalledWith({
+      previous: committedImage,
+      next: nextCommittedImage
+    });
+    expect(result.current.committedValue).toEqual(nextCommittedImage);
+    expect(result.current.phase).toBe('committed');
+    expect(result.current.error).toMatchObject({
+      code: 'cleanup_previous_failed'
+    });
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: 'cleanup_previous_failed'
+      })
+    );
+  });
+
+  it('does not clean up the previous image when the durable src is unchanged', async () => {
+    const cleanupPrevious = vi.fn();
+    const options = createOptions({
+      commitDraft: vi.fn(async () => ({
+        src: committedImage.src,
+        fileName: 'current.webp',
+        mimeType: 'image/webp'
+      })),
+      cleanupPrevious
+    });
+    const { result } = renderHook(() => useImageDraftLifecycle(options));
+
+    await uploadDraft(result);
+
+    await act(async () => {
+      await result.current.commit();
+    });
+
+    expect(cleanupPrevious).not.toHaveBeenCalled();
+    expect(result.current.committedValue).toEqual({
+      src: committedImage.src,
+      fileName: 'current.webp',
+      mimeType: 'image/webp'
+    });
+  });
+
+  it('does not call cleanupPrevious when commit fails', async () => {
+    const cleanupPrevious = vi.fn();
+    const options = createOptions({
+      commitDraft: vi.fn(async () => {
+        throw new Error('commit failed');
+      }),
+      cleanupPrevious
+    });
+    const { result } = renderHook(() => useImageDraftLifecycle(options));
+
+    await uploadDraft(result);
+
+    await act(async () => {
+      await result.current.commit().catch(() => undefined);
+    });
+
+    expect(cleanupPrevious).not.toHaveBeenCalled();
+    expect(result.current.committedValue).toEqual(committedImage);
+  });
+
+  it('deduplicates double commit calls while a commit is in flight', async () => {
+    let resolveCommit: ((value: PersistableImageValue) => void) | undefined;
+    const commitDraft = vi.fn(
+      () =>
+        new Promise<PersistableImageValue>((resolve) => {
+          resolveCommit = resolve;
+        })
+    );
+    const options = createOptions({ commitDraft });
+    const { result } = renderHook(() => useImageDraftLifecycle(options));
+
+    await uploadDraft(result);
+
+    let firstCommit: Promise<PersistableImageValue | null>;
+    let secondCommit: Promise<PersistableImageValue | null>;
+
+    act(() => {
+      firstCommit = result.current.commit();
+      secondCommit = result.current.commit();
+    });
+
+    expect(commitDraft).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveCommit?.(nextCommittedImage);
+      await Promise.all([firstCommit, secondCommit]);
+    });
+
+    expect(result.current.committedValue).toEqual(nextCommittedImage);
+    expect(result.current.draft).toBeNull();
+  });
+
+  it('rejects draft replacement and discard while commit is in flight', async () => {
+    let resolveCommit: ((value: PersistableImageValue) => void) | undefined;
+    const discardDraft = vi.fn(async () => undefined);
+    const uploadDraftMock = vi.fn(createOptions().uploadDraft);
+    const commitDraft = vi.fn(
+      () =>
+        new Promise<PersistableImageValue>((resolve) => {
+          resolveCommit = resolve;
+        })
+    );
+    const options = createOptions({
+      uploadDraft: uploadDraftMock,
+      commitDraft,
+      discardDraft
+    });
+    const { result } = renderHook(() => useImageDraftLifecycle(options));
+    let commitPromise: Promise<PersistableImageValue | null>;
+
+    await uploadDraft(result);
+
+    act(() => {
+      commitPromise = result.current.commit();
+    });
+
+    await waitFor(() => {
+      expect(result.current.phase).toBe('committing');
+    });
+
+    await act(async () => {
+      await expect(result.current.uploadForInput(createFile('blocked.webp'), {})).rejects.toMatchObject({
+        code: 'commit_in_progress'
+      });
+      await expect(result.current.discard('manual')).rejects.toMatchObject({
+        code: 'commit_in_progress'
+      });
+    });
+
+    expect(uploadDraftMock).toHaveBeenCalledTimes(1);
+    expect(discardDraft).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveCommit?.(nextCommittedImage);
+      await commitPromise;
+    });
+
+    expect(result.current.committedValue).toEqual(nextCommittedImage);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('rejects commit and draft replacement while discard is in flight', async () => {
+    let resolveDiscard: (() => void) | undefined;
+    const discardDraft = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveDiscard = resolve;
+        })
+    );
+    const options = createOptions({ discardDraft });
+    const { result } = renderHook(() => useImageDraftLifecycle(options));
+    let discardPromise: Promise<void>;
+
+    await uploadDraft(result);
+
+    act(() => {
+      discardPromise = result.current.discard('manual');
+    });
+
+    await waitFor(() => {
+      expect(result.current.phase).toBe('discarding');
+    });
+
+    await act(async () => {
+      await expect(result.current.commit()).rejects.toMatchObject({
+        code: 'discard_in_progress'
+      });
+      await expect(result.current.uploadForInput(createFile('blocked.webp'), {})).rejects.toMatchObject({
+        code: 'discard_in_progress'
+      });
+    });
+
+    await act(async () => {
+      resolveDiscard?.();
+      await discardPromise;
+    });
+
+    expect(result.current.draft).toBeNull();
+    expect(result.current.valueForInput).toEqual(committedImage);
+  });
+
+  it('rejects commit while a draft upload is still in flight', async () => {
+    const options = createOptions({
+      uploadDraft: vi.fn(
+        () =>
+          new Promise<never>(() => {
+            // keep the draft upload pending
+          })
+      )
+    });
+    const { result } = renderHook(() => useImageDraftLifecycle(options));
+
+    act(() => {
+      void result.current.uploadForInput(createFile(), {});
+    });
+
+    await waitFor(() => {
+      expect(result.current.phase).toBe('uploading-draft');
+    });
+
+    await act(async () => {
+      await expect(result.current.commit()).rejects.toMatchObject({
+        code: 'draft_upload_in_progress'
+      });
+    });
+  });
+
+  it('clears a transient commit error when an in-flight draft upload later succeeds', async () => {
+    let resolveUpload: ((value: { draftKey: string }) => void) | undefined;
+    const options = createOptions({
+      uploadDraft: vi.fn(
+        () =>
+          new Promise<{ draftKey: string }>((resolve) => {
+            resolveUpload = resolve;
+          })
+      )
+    });
+    const { result } = renderHook(() => useImageDraftLifecycle(options));
+    let uploadPromise: Promise<unknown>;
+
+    act(() => {
+      uploadPromise = result.current.uploadForInput(createFile(), {});
+    });
+
+    await waitFor(() => {
+      expect(result.current.phase).toBe('uploading-draft');
+    });
+
+    await act(async () => {
+      await result.current.commit().catch(() => undefined);
+    });
+
+    expect(result.current.error).toMatchObject({
+      code: 'draft_upload_in_progress'
+    });
+
+    await act(async () => {
+      resolveUpload?.({ draftKey: 'drafts/next.webp' });
+      await uploadPromise;
+    });
+
+    expect(result.current.phase).toBe('draft-ready');
+    expect(result.current.error).toBeNull();
+  });
+
+  it('discards a draft with the requested reason and leaves the committed value intact', async () => {
+    const discardDraft = vi.fn(async () => undefined);
+    const options = createOptions({ discardDraft });
+    const { result } = renderHook(() => useImageDraftLifecycle(options));
+
+    await uploadDraft(result);
+
+    await act(async () => {
+      await result.current.discard('manual');
+    });
+
+    expect(discardDraft).toHaveBeenCalledWith({
+      draft: expect.objectContaining({
+        draftKey: 'drafts/next.webp'
+      }),
+      reason: 'manual'
+    });
+    expect(result.current.draft).toBeNull();
+    expect(result.current.valueForInput).toEqual(committedImage);
+    expect(result.current.committedValue).toEqual(committedImage);
+    expect(result.current.phase).toBe('discarded');
+  });
+
+  it('keeps a draft when user-triggered discard fails', async () => {
+    const discardDraft = vi.fn(async () => {
+      throw new Error('discard endpoint failed');
+    });
+    const options = createOptions({ discardDraft });
+    const { result } = renderHook(() => useImageDraftLifecycle(options));
+
+    await uploadDraft(result);
+
+    await act(async () => {
+      await result.current.discard('manual').catch(() => undefined);
+    });
+
+    expect(result.current.phase).toBe('failed');
+    expect(result.current.draft).toEqual(expect.objectContaining({ draftKey: 'drafts/next.webp' }));
+    expect(result.current.error).toMatchObject({
+      code: 'discard_failed'
+    });
+  });
+
+  it('discards the old draft on replace when autoDiscard.onReplace is enabled', async () => {
+    const discardDraft = vi.fn(async () => undefined);
+    const uploadDraftMock = vi
+      .fn<UseImageDraftLifecycleOptions['uploadDraft']>()
+      .mockResolvedValueOnce({ draftKey: 'drafts/first.webp' })
+      .mockResolvedValueOnce({ draftKey: 'drafts/second.webp' });
+    const options = createOptions({
+      uploadDraft: uploadDraftMock,
+      discardDraft,
+      autoDiscard: {
+        onReplace: true
+      }
+    });
+    const { result } = renderHook(() => useImageDraftLifecycle(options));
+
+    await act(async () => {
+      await result.current.uploadForInput(createFile('first.webp'), {});
+      await result.current.uploadForInput(createFile('second.webp'), {});
+    });
+
+    expect(discardDraft).toHaveBeenCalledWith({
+      draft: expect.objectContaining({
+        draftKey: 'drafts/first.webp'
+      }),
+      reason: 'replace'
+    });
+    expect(result.current.draft).toEqual(expect.objectContaining({ draftKey: 'drafts/second.webp' }));
+  });
+
+  it('ignores stale upload results and discards them best-effort during replacement', async () => {
+    let resolveFirst: ((value: { draftKey: string }) => void) | undefined;
+    let resolveSecond: ((value: { draftKey: string }) => void) | undefined;
+    const discardDraft = vi.fn(async () => undefined);
+    const uploadDraftMock = vi
+      .fn<UseImageDraftLifecycleOptions['uploadDraft']>()
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirst = resolve;
+          })
+      )
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveSecond = resolve;
+          })
+      );
+    const options = createOptions({
+      uploadDraft: uploadDraftMock,
+      discardDraft,
+      autoDiscard: {
+        onReplace: true
+      }
+    });
+    const { result } = renderHook(() => useImageDraftLifecycle(options));
+    let firstUpload: Promise<unknown>;
+    let secondUpload: Promise<unknown>;
+
+    act(() => {
+      firstUpload = result.current.uploadForInput(createFile('first.webp'), {});
+      secondUpload = result.current.uploadForInput(createFile('second.webp'), {});
+    });
+
+    await act(async () => {
+      resolveSecond?.({ draftKey: 'drafts/second.webp' });
+      await secondUpload;
+    });
+
+    await act(async () => {
+      resolveFirst?.({ draftKey: 'drafts/first.webp' });
+      await firstUpload;
+    });
+
+    expect(result.current.draft).toEqual(expect.objectContaining({ draftKey: 'drafts/second.webp' }));
+    expect(discardDraft).toHaveBeenCalledWith({
+      draft: expect.objectContaining({
+        draftKey: 'drafts/first.webp'
+      }),
+      reason: 'replace'
+    });
+  });
+
+  it('discards a draft on reset when autoDiscard.onReset is enabled', async () => {
+    const discardDraft = vi.fn(async () => undefined);
+    const options = createOptions({
+      discardDraft,
+      autoDiscard: {
+        onReset: true
+      }
+    });
+    const { result } = renderHook(() => useImageDraftLifecycle(options));
+
+    await uploadDraft(result);
+
+    act(() => {
+      result.current.resetToCommitted();
+    });
+
+    await waitFor(() => {
+      expect(discardDraft).toHaveBeenCalledWith({
+        draft: expect.objectContaining({
+          draftKey: 'drafts/next.webp'
+        }),
+        reason: 'reset'
+      });
+      expect(result.current.draft).toBeNull();
+    });
+  });
+
+  it('keeps reset from accepting a stale in-flight draft upload', async () => {
+    let resolveUpload: ((value: { draftKey: string }) => void) | undefined;
+    const options = createOptions({
+      uploadDraft: vi.fn(
+        () =>
+          new Promise<{ draftKey: string }>((resolve) => {
+            resolveUpload = resolve;
+          })
+      )
+    });
+    const { result } = renderHook(() => useImageDraftLifecycle(options));
+    let uploadPromise: Promise<unknown>;
+
+    act(() => {
+      uploadPromise = result.current.uploadForInput(createFile(), {});
+    });
+
+    await waitFor(() => {
+      expect(result.current.phase).toBe('uploading-draft');
+    });
+
+    act(() => {
+      result.current.resetToCommitted();
+    });
+
+    await act(async () => {
+      resolveUpload?.({ draftKey: 'drafts/stale.webp' });
+      await uploadPromise;
+    });
+
+    expect(result.current.phase).toBe('idle');
+    expect(result.current.draft).toBeNull();
+    expect(result.current.valueForInput).toEqual(committedImage);
+  });
+
+  it('best-effort discards a ready draft on unmount when autoDiscard.onUnmount is enabled', async () => {
+    const discardDraft = vi.fn(async () => undefined);
+    const options = createOptions({
+      discardDraft,
+      autoDiscard: {
+        onUnmount: true
+      }
+    });
+    const { result, unmount } = renderHook(() => useImageDraftLifecycle(options));
+
+    await uploadDraft(result);
+
+    unmount();
+
+    await waitFor(() => {
+      expect(discardDraft).toHaveBeenCalledWith({
+        draft: expect.objectContaining({
+          draftKey: 'drafts/next.webp'
+        }),
+        reason: 'unmount'
+      });
+    });
+  });
+});

--- a/tests/react/use-image-draft-lifecycle.test.tsx
+++ b/tests/react/use-image-draft-lifecycle.test.tsx
@@ -260,6 +260,48 @@ describe('useImageDraftLifecycle', () => {
     );
   });
 
+  it('runs previous cleanup after commit succeeds even when unmounted', async () => {
+    let resolveCommit: ((value: PersistableImageValue) => void) | undefined;
+    const cleanupPrevious = vi.fn(async () => undefined);
+    const onCommittedValueChange = vi.fn();
+    const commitDraft = vi.fn(
+      () =>
+        new Promise<PersistableImageValue>((resolve) => {
+          resolveCommit = resolve;
+        })
+    );
+    const options = createOptions({
+      commitDraft,
+      cleanupPrevious,
+      onCommittedValueChange
+    });
+    const { result, unmount } = renderHook(() => useImageDraftLifecycle(options));
+    let commitPromise: Promise<PersistableImageValue | null>;
+
+    await uploadDraft(result);
+
+    act(() => {
+      commitPromise = result.current.commit();
+    });
+
+    await waitFor(() => {
+      expect(result.current.phase).toBe('committing');
+    });
+
+    unmount();
+
+    await act(async () => {
+      resolveCommit?.(nextCommittedImage);
+      await expect(commitPromise).resolves.toEqual(nextCommittedImage);
+    });
+
+    expect(cleanupPrevious).toHaveBeenCalledWith({
+      previous: committedImage,
+      next: nextCommittedImage
+    });
+    expect(onCommittedValueChange).not.toHaveBeenCalled();
+  });
+
   it('does not clean up the previous image when the durable src is unchanged', async () => {
     const cleanupPrevious = vi.fn();
     const options = createOptions({


### PR DESCRIPTION
## Summary

- Add a headless `useImageDraftLifecycle()` API for draft upload, commit, discard, reset, and previous-image cleanup flows.
- Export lifecycle request/response types and typed lifecycle errors from the headless entrypoint.
- Add lifecycle tests covering commit failure safety, cleanup failure behavior, replacement/reset/unmount discard, stale upload races, discard/commit concurrency, and double commit deduping.
- Add draft lifecycle docs and a Next.js recipe for server-owned form/image consistency.

## Validation

- `npm run verify`
- `npm run smoke:consumer`