### PR TITLE
docs: add app-owned backend image lifecycle contracts

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -104,6 +104,8 @@ pick / drop / paste
 
 user に見えている preview と、DB に保存してよい画像参照は同じではありません。
 
+draft upload を form save 時に commit し、cancel 時に discard し、previous image を commit 後だけ cleanup したい場合は、server 側の契約を app で持ってください。詳しくは [Backend contracts](./docs/backend-contracts.md)、[Draft lifecycle](./docs/draft-lifecycle.md)、[Next.js draft lifecycle recipe](./docs/recipes/nextjs-draft-lifecycle.md) を参照してください。
+
 ## Validation と byte limit
 
 validation は transform の前後で走ります。
@@ -179,8 +181,11 @@ async function submitProfile() {
 
 ## Recipes
 
+- [Backend contracts](./docs/backend-contracts.md)
+- [Draft lifecycle](./docs/draft-lifecycle.md)
 - [Next.js App Router](./docs/recipes/nextjs-app-router.md)
 - [Next.js presign route](./docs/recipes/nextjs-presign-route.md)
+- [Next.js draft lifecycle](./docs/recipes/nextjs-draft-lifecycle.md)
 - [React Hook Form and Zod](./docs/recipes/react-hook-form-zod.md)
 
 ## Upload examples

--- a/README.md
+++ b/README.md
@@ -254,6 +254,8 @@ type PresignedPutTarget = {
 
 See [docs/uploads.md](./docs/uploads.md) for presigned PUT, multipart POST, raw PUT, custom adapters, progress, and abort behavior.
 
+For product forms that upload a temporary draft and only make it durable when the form is saved, keep the backend lifecycle in your app: [backend contracts](./docs/backend-contracts.md), [draft lifecycle](./docs/draft-lifecycle.md), and the [Next.js draft lifecycle recipe](./docs/recipes/nextjs-draft-lifecycle.md).
+
 ## Upload error handling
 
 Built-in upload helpers throw `ImageUploadError` with stable `code` and `details` fields. Use `isImageUploadError()` for product copy, retry labels, and telemetry instead of parsing English messages.
@@ -325,6 +327,8 @@ Read more in [docs/transforms.md](./docs/transforms.md).
 
 ## Recipes
 
+- [Backend contracts](./docs/backend-contracts.md)
+- [Draft lifecycle](./docs/draft-lifecycle.md)
 - [Local preview](./docs/recipes/local-preview.md)
 - [Avatar field](./docs/recipes/avatar.md)
 - [Compression](./docs/recipes/compression.md)
@@ -332,6 +336,7 @@ Read more in [docs/transforms.md](./docs/transforms.md).
 - [Presigned PUT](./docs/recipes/presigned-put.md)
 - [Next.js App Router](./docs/recipes/nextjs-app-router.md)
 - [Next.js presign route](./docs/recipes/nextjs-presign-route.md)
+- [Next.js draft lifecycle](./docs/recipes/nextjs-draft-lifecycle.md)
 - [React Hook Form and Zod](./docs/recipes/react-hook-form-zod.md)
 - [Multipart POST](./docs/recipes/multipart-post.md)
 - [Raw PUT](./docs/recipes/raw-put.md)
@@ -380,8 +385,10 @@ import {
   createRawPutUploader,
   isImageBudgetError,
   prepareImageToBudget,
+  useImageDraftLifecycle,
   useImageDropInput,
   validateImage,
+  type ImageDraftDescriptor,
   type UseImageDropInputReturn
 } from 'image-drop-input/headless';
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ Start with:
 - [Validation](./validation.md): source limits, output limits, dimensions, pixels, and error codes
 - [Byte budget solver](./byte-budget.md): prepare images to fit an output byte budget
 - [Draft lifecycle](./draft-lifecycle.md): upload drafts, commit on form save, discard on cancel, and cleanup previous images
+- [Backend contracts](./backend-contracts.md): app-owned auth, signed URLs, commit, discard, previous cleanup, and TTL cleanup
 - [Uploads](./uploads.md): adapter contracts, signed upload boundaries, progress, typed upload errors, and aborts
 - [Transforms](./transforms.md): compression, WebP conversion, return shapes, and MIME consistency
 - [Accessibility](./accessibility.md): keyboard, paste, status, dialog, and headless responsibilities

--- a/docs/backend-contracts.md
+++ b/docs/backend-contracts.md
@@ -208,11 +208,11 @@ Browser
     -> submit form fields plus draft identity
 
 Server
-  POST /api/profile
+  POST /api/products/:id
     -> validate form fields
     -> validate draft ownership and expiry
     -> commit draft to final image
-    -> update profile row with final image value
+    -> update product row with final image value
     -> enqueue previous cleanup after the transaction succeeds
     -> return durable image value
 ```

--- a/docs/backend-contracts.md
+++ b/docs/backend-contracts.md
@@ -1,0 +1,258 @@
+# Backend contracts
+
+`image-drop-input` keeps the browser image field small on purpose. It does not include a storage provider SDK, create signed URLs, choose object keys, authorize users, commit product records, or delete old images.
+
+These contracts describe the server shape your app can expose when you want draft uploads, form-submit commits, discard, and previous-image cleanup. The TypeScript snippets are app-side examples, not package code.
+
+## Ownership boundary
+
+The package owns:
+
+- browser preview state
+- input and output validation
+- optional client-side transform and byte-budget preparation
+- upload adapter invocation
+- draft lifecycle state when `useImageDraftLifecycle()` is used
+
+Your app server owns:
+
+- authentication and authorization
+- object key generation
+- signed upload URL creation
+- draft metadata and expiry
+- product form validation
+- commit transactions
+- previous image cleanup
+- server-side TTL cleanup
+- audit logging, malware scanning, and CDN invalidation when your product needs them
+
+Keep provider credentials and provider SDKs on the server side of your app. Do not add S3, R2, GCS, Azure Blob, or similar SDKs to the browser package.
+
+## Terms
+
+| Term | Meaning |
+| --- | --- |
+| `uploadUrl` | Temporary URL used to upload bytes. It may be private, scoped, and short-lived. |
+| `publicUrl` | URL your UI can render. Return it explicitly when one exists. |
+| `objectKey` | Storage object key returned by your backend. For draft responses, this is still a draft reference unless the server says otherwise. |
+| `draftKey` | App-owned identifier for a temporary draft image. It may be the object key or a database id. |
+| `draftToken` | Optional short-lived token authorizing commit or discard for one draft. Treat it as sensitive. |
+| `previousKey` | Durable key for the image that may be cleaned up after a successful replacement commit. |
+
+Never infer `publicUrl` from `uploadUrl`. Signed upload URLs often use different hosts, temporary query strings, provider-specific paths, or private buckets.
+
+Do not treat a draft `objectKey` as the durable product `key`. The commit response is the boundary where the app receives the final image reference.
+
+## Contract 1: create draft upload target
+
+Use this endpoint before the browser uploads image bytes.
+
+```http
+POST /api/images/drafts/presign
+Content-Type: application/json
+```
+
+```ts
+type ImagePurpose = 'avatar' | 'cover' | 'product' | 'custom';
+
+type CreateImageDraftUploadTargetRequest = {
+  fileName: string;
+  originalFileName?: string;
+  mimeType: string;
+  size: number;
+  width?: number;
+  height?: number;
+  purpose: ImagePurpose;
+};
+
+type CreateImageDraftUploadTargetResponse = {
+  uploadUrl: string;
+  headers?: Record<string, string>;
+
+  draftKey: string;
+  draftToken?: string;
+  expiresAt: string;
+
+  publicUrl?: string;
+  objectKey?: string;
+};
+```
+
+Server rules:
+
+- Validate the user session and product permission before signing.
+- Validate MIME type, byte size, dimensions, and purpose server-side. Client validation is UX, not authority.
+- Generate an object key on the server.
+- Store draft owner, purpose, size policy, object key, and expiry in server-side metadata.
+- Return `publicUrl` only when the draft can safely render immediately.
+- Return `objectKey` only when the client needs a storage reference, and make clear whether it is a draft key or a final key.
+- Keep `expiresAt` explicit so the UI and docs can reason about draft lifetime.
+
+Security rules:
+
+- Do not expose storage credentials.
+- Do not log signed `uploadUrl` values.
+- Do not log `draftToken`.
+- Keep `draftToken` short-lived, scoped to one draft, and accepted only by commit/discard endpoints that require it.
+- Sign the same content type and provider headers the browser will send.
+
+## Contract 2: commit draft
+
+Use this endpoint when a draft should become durable product state.
+
+This can be a standalone endpoint, or it can be folded into the product submit endpoint described below.
+
+```http
+POST /api/images/drafts/commit
+Content-Type: application/json
+```
+
+```ts
+type CommitImageDraftRequestBody = {
+  draftKey: string;
+  draftToken?: string;
+  previousKey?: string;
+  purpose: ImagePurpose;
+};
+
+type CommitImageDraftResponseBody = {
+  image: {
+    src?: string;
+    key: string;
+    fileName?: string;
+    mimeType?: string;
+    size?: number;
+    width?: number;
+    height?: number;
+  };
+};
+```
+
+Server behavior:
+
+1. Validate the user session.
+2. Validate the user may commit this image for this product record.
+3. Validate draft ownership, purpose, token, expiry, MIME type, and object existence.
+4. Move/copy the draft object to a final location, or mark the draft object as final.
+5. Persist the final key in the product record if this endpoint owns the product update.
+6. Return a durable image value with an explicit `key`, plus `src` when the image can be rendered directly.
+7. Enqueue previous-image cleanup only after the commit transaction succeeds.
+
+Do not delete the previous image before the new image is committed. A successful upload is not the same thing as a successful product save.
+
+If the browser sends `previousKey`, treat it as a hint only. The server should load the current product record and use that authoritative value when deciding whether previous cleanup is allowed.
+
+## Contract 3: discard draft
+
+Use this endpoint when the user cancels, resets, unmounts, or replaces an uncommitted draft.
+
+```http
+POST /api/images/drafts/discard
+Content-Type: application/json
+```
+
+```ts
+type DiscardImageDraftRequestBody = {
+  draftKey: string;
+  draftToken?: string;
+  reason: 'replace' | 'reset' | 'unmount' | 'manual';
+};
+```
+
+Server behavior:
+
+- Validate the user session and draft ownership.
+- Delete only draft objects, never committed objects.
+- Make the operation idempotent.
+- Return success when the draft is already gone.
+- Treat discard as best effort. Browser tabs can close and `keepalive` requests can fail.
+
+Server-side TTL cleanup is still required even when client discard is wired.
+
+## Contract 4: cleanup previous
+
+Previous-image cleanup should run after a new image is durably committed.
+
+```http
+POST /api/images/cleanup-previous
+Content-Type: application/json
+```
+
+```ts
+type CleanupPreviousImageRequestBody = {
+  previousKey: string;
+  nextKey: string;
+  reason: 'replace-committed';
+};
+```
+
+Server behavior:
+
+- Prefer an internal queue or background job over a direct browser-triggered delete.
+- Validate that `nextKey` is already committed to the product record.
+- Validate that `previousKey` is no longer referenced by that product record.
+- Make cleanup idempotent.
+- Return success when the previous object is already gone.
+- Do not rollback the new image if cleanup fails.
+
+Cleanup can fail independently from commit. Report or retry cleanup separately; the new committed image remains authoritative.
+
+## Recommended atomic form submit
+
+For product records, prefer one submit endpoint that commits the draft and saves the rest of the form together.
+
+```txt
+Browser
+  ImageDropInput
+    -> upload draft bytes with a signed URL
+    -> submit form fields plus draft identity
+
+Server
+  POST /api/profile
+    -> validate form fields
+    -> validate draft ownership and expiry
+    -> commit draft to final image
+    -> update profile row with final image value
+    -> enqueue previous cleanup after the transaction succeeds
+    -> return durable image value
+```
+
+This avoids the split-brain case where `commitDraft()` succeeds but the product form save fails afterward.
+
+The simpler client sequence is acceptable for low-risk forms:
+
+```ts
+const image = await imageDraft.commit();
+await saveProduct({ ...fields, image });
+```
+
+The caveat is real: if the image commit succeeds and `saveProduct()` fails, your app must decide whether to retry the product save, keep the draft/final image reachable, or run a compensating cleanup. User-facing profile, CMS, and product records usually deserve the atomic server submit.
+
+## TTL cleanup
+
+Client discard is not a cleanup guarantee. Add a server-side lifecycle rule, scheduled job, or queue worker that deletes expired draft metadata and draft objects.
+
+A common policy is:
+
+- signed upload URL lifetime: minutes
+- draft commit lifetime: 15 to 60 minutes
+- background cleanup cadence: shorter than or equal to the maximum draft lifetime your product tolerates
+
+The exact numbers are app policy. The fallback is mandatory.
+
+## App-side Next.js shape
+
+These routes are app-side examples. Replace the placeholder helpers with your own storage service, database, queue, and auth layer.
+
+```txt
+app/api/images/drafts/presign/route.ts
+app/api/profile/route.ts
+app/api/images/drafts/discard/route.ts
+app/api/images/cleanup-previous/route.ts
+```
+
+For a complete App Router recipe, see [Next.js draft lifecycle](./recipes/nextjs-draft-lifecycle.md).
+
+## Package defaults stay opt-in
+
+The default `ImageDropInput` behavior does not change for apps that only use local preview or a normal upload adapter. Draft commit/discard/cleanup is an advanced pattern you opt into with `useImageDraftLifecycle()` and your own backend contracts.

--- a/docs/draft-lifecycle.md
+++ b/docs/draft-lifecycle.md
@@ -33,6 +33,8 @@ committed image A
 
 The package does not include an object-storage SDK. Your app owns signed URLs, auth, object keys, draft TTLs, transactions, and cleanup policy.
 
+For the app-side endpoint shapes, security rules, and atomic submit caveat, read [Backend contracts](./backend-contracts.md).
+
 ## Hook
 
 ```tsx

--- a/docs/recipes/nextjs-draft-lifecycle.md
+++ b/docs/recipes/nextjs-draft-lifecycle.md
@@ -2,7 +2,7 @@
 
 Use this pattern when a profile, product, or CMS form needs image replacement to stay consistent with the saved record.
 
-The client uploads a draft object first. The form submit route then commits that draft and updates the product record in one server-owned operation. The snippets below are app-side examples. They intentionally use placeholder storage, auth, database, and queue helpers instead of provider SDK code.
+The client uploads a draft object first. The form submit route then commits that draft and updates the profile record in one server-owned operation. The snippets below are app-side examples. They intentionally use placeholder storage, auth, database, and queue helpers instead of provider SDK code.
 
 Read the contract details in [Backend contracts](../backend-contracts.md).
 
@@ -217,7 +217,7 @@ async function discardDraft(request: DiscardImageDraftRequest) {
 }
 ```
 
-Do not write `target.uploadUrl` or `target.draftToken` to browser logs, analytics, or user-facing error messages. If `publicUrl` is not returned, the hook keeps a local preview for display. Do not derive a render URL from `uploadUrl`, and do not save `image.valueForInput` as product data before the commit response returns a durable image value.
+Do not write `target.uploadUrl` or `target.draftToken` to browser logs, analytics, or user-facing error messages. If `publicUrl` is not returned, the hook keeps a local preview for display. Do not derive a render URL from `uploadUrl`, and do not save `image.valueForInput` as record data before the commit response returns a durable image value.
 
 `image.resetToCommitted()` clears the local draft state. With `autoDiscard.onReset` enabled, it also calls the discard route for the draft when one exists.
 
@@ -413,7 +413,7 @@ async function commitProfileImageDraft(_input: {
   purpose: ImagePurpose;
   previous: PersistableImageValue | null;
 }): Promise<PersistableImageValue> {
-  // Validate owner, expiry, token, purpose, MIME type, object existence, and product permissions.
+  // Validate owner, expiry, token, purpose, MIME type, object existence, and profile permissions.
   // Move/copy the draft object to a final key or mark it final.
   // Return a durable value with explicit src and/or key.
   throw new Error('Connect this route to your image commit service.');
@@ -448,7 +448,7 @@ function sameImageReference(previous: PersistableImageValue, next: PersistableIm
 }
 ```
 
-This submit route is the safer shape because it commits the draft and updates the product record together. The current profile row, not the browser payload, decides which previous image is eligible for cleanup.
+This submit route is the safer shape because it commits the draft and updates the profile record together. The current profile row, not the browser payload, decides which previous image is eligible for cleanup.
 
 ## Best-effort discard route
 
@@ -539,4 +539,4 @@ Run previous cleanup only after the new image is committed. A cleanup failure sh
 
 Client discard is a convenience, not a guarantee. Add a server-side lifecycle rule or scheduled cleanup that removes expired draft objects and draft metadata. A good default is a short expiry, such as 15 to 60 minutes, depending on how long your form can reasonably stay open.
 
-Never delete the previous committed image before the new image has been committed with the product record.
+Never delete the previous committed image before the new image has been committed with the saved record.

--- a/docs/recipes/nextjs-draft-lifecycle.md
+++ b/docs/recipes/nextjs-draft-lifecycle.md
@@ -2,13 +2,16 @@
 
 Use this pattern when a profile, product, or CMS form needs image replacement to stay consistent with the saved record.
 
-The client uploads a draft object first. The profile submit route then commits that draft and updates the profile in one server-owned operation.
+The client uploads a draft object first. The form submit route then commits that draft and updates the product record in one server-owned operation. The snippets below are app-side examples. They intentionally use placeholder storage, auth, database, and queue helpers instead of provider SDK code.
+
+Read the contract details in [Backend contracts](../backend-contracts.md).
 
 ## Client component
 
 ```tsx
 'use client';
 
+import type { FormEvent } from 'react';
 import { useRef, useState } from 'react';
 import { ImageDropInput } from 'image-drop-input';
 import {
@@ -26,7 +29,8 @@ type ProfileForm = {
 
 type ImageDraftPayload = {
   draftKey: string;
-  previous: PersistableImageValue | null;
+  draftToken?: string;
+  purpose: 'avatar';
 };
 
 export function ProfileEditor({ initialProfile }: { initialProfile: ProfileForm }) {
@@ -42,6 +46,10 @@ export function ProfileEditor({ initialProfile }: { initialProfile: ProfileForm 
     uploadDraft,
     async commitDraft(request) {
       const body = await submitProfile(toImageDraftPayload(request));
+      if (!body.image) {
+        throw new Error('Profile API did not return a committed image.');
+      }
+
       return body.image;
     },
     discardDraft,
@@ -66,10 +74,10 @@ export function ProfileEditor({ initialProfile }: { initialProfile: ProfileForm 
       throw new Error('Profile save failed.');
     }
 
-    return (await response.json()) as { image: PersistableImageValue };
+    return (await response.json()) as { image: PersistableImageValue | null };
   }
 
-  async function handleSubmit(event: React.FormEvent) {
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
 
     if (image.hasDraft) {
@@ -79,6 +87,10 @@ export function ProfileEditor({ initialProfile }: { initialProfile: ProfileForm 
 
     const body = await submitProfile();
     setFields((current) => ({ ...current, image: body.image }));
+  }
+
+  function handleResetImage() {
+    image.resetToCommitted();
   }
 
   return (
@@ -110,18 +122,35 @@ export function ProfileEditor({ initialProfile }: { initialProfile: ProfileForm 
       >
         Save
       </button>
+
+      <button
+        type="button"
+        onClick={handleResetImage}
+        disabled={image.phase === 'committing' || image.phase === 'discarding'}
+      >
+        Reset image
+      </button>
     </form>
   );
 }
 
 async function uploadDraft(file: Blob, context: UploadContext) {
+  const fileName = context.fileName ?? context.originalFileName ?? 'image';
+  const mimeType = context.mimeType || file.type;
+
+  if (!mimeType) {
+    throw new Error('Image MIME type is required before creating a draft.');
+  }
+
   const presign = await fetch('/api/images/drafts/presign', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
-      fileName: context.fileName,
-      mimeType: context.mimeType ?? file.type,
-      size: file.size
+      fileName,
+      originalFileName: context.originalFileName,
+      mimeType,
+      size: file.size,
+      purpose: 'avatar'
     }),
     signal: context.signal
   });
@@ -134,7 +163,10 @@ async function uploadDraft(file: Blob, context: UploadContext) {
     uploadUrl: string;
     headers?: Record<string, string>;
     draftKey: string;
+    draftToken?: string;
     expiresAt: string;
+    publicUrl?: string;
+    objectKey?: string;
   };
 
   const upload = await fetch(target.uploadUrl, {
@@ -150,9 +182,11 @@ async function uploadDraft(file: Blob, context: UploadContext) {
 
   return {
     draftKey: target.draftKey,
+    draftToken: target.draftToken,
+    src: target.publicUrl,
     expiresAt: target.expiresAt,
-    fileName: context.fileName,
-    mimeType: context.mimeType ?? file.type,
+    fileName,
+    mimeType,
     size: file.size
   };
 }
@@ -160,7 +194,8 @@ async function uploadDraft(file: Blob, context: UploadContext) {
 function toImageDraftPayload(request: CommitImageDraftRequest): ImageDraftPayload {
   return {
     draftKey: request.draft.draftKey,
-    previous: request.previous
+    draftToken: request.draft.draftToken,
+    purpose: 'avatar'
   };
 }
 
@@ -170,6 +205,7 @@ async function discardDraft(request: DiscardImageDraftRequest) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       draftKey: request.draft.draftKey,
+      draftToken: request.draft.draftToken,
       reason: request.reason
     }),
     keepalive: request.reason === 'unmount'
@@ -181,26 +217,38 @@ async function discardDraft(request: DiscardImageDraftRequest) {
 }
 ```
 
+Do not write `target.uploadUrl` or `target.draftToken` to browser logs, analytics, or user-facing error messages. If `publicUrl` is not returned, the hook keeps a local preview for display. Do not derive a render URL from `uploadUrl`, and do not save `image.valueForInput` as product data before the commit response returns a durable image value.
+
+`image.resetToCommitted()` clears the local draft state. With `autoDiscard.onReset` enabled, it also calls the discard route for the draft when one exists.
+
 ## `/api/images/drafts/presign`
 
 ```ts
 // app/api/images/drafts/presign/route.ts
 import { NextResponse, type NextRequest } from 'next/server';
 
+type ImagePurpose = 'avatar' | 'cover' | 'product' | 'custom';
+
 type PresignDraftRequest = {
-  fileName?: string;
+  fileName: string;
+  originalFileName?: string;
   mimeType: string;
   size: number;
+  purpose: ImagePurpose;
 };
 
 type PresignDraftResponse = {
   uploadUrl: string;
   headers?: Record<string, string>;
   draftKey: string;
+  draftToken?: string;
   expiresAt: string;
+  publicUrl?: string;
+  objectKey?: string;
 };
 
 const allowedMimeTypes = new Set(['image/jpeg', 'image/png', 'image/webp']);
+const allowedPurposes = new Set<ImagePurpose>(['avatar', 'cover', 'product', 'custom']);
 const maxUploadBytes = 5 * 1024 * 1024;
 
 export const runtime = 'nodejs';
@@ -210,26 +258,36 @@ export async function POST(request: NextRequest) {
   const body = (await request.json()) as Partial<PresignDraftRequest>;
 
   if (
+    typeof body.fileName !== 'string' ||
+    body.fileName.length === 0 ||
     !body.mimeType ||
     !allowedMimeTypes.has(body.mimeType) ||
     typeof body.size !== 'number' ||
     body.size <= 0 ||
-    body.size > maxUploadBytes
+    body.size > maxUploadBytes ||
+    !body.purpose ||
+    !allowedPurposes.has(body.purpose)
   ) {
     return NextResponse.json({ error: 'Invalid draft upload request.' }, { status: 400 });
   }
 
   const draft = await createDraftUploadTarget({
     userId: user.id,
+    fileName: body.fileName,
+    originalFileName: body.originalFileName,
     mimeType: body.mimeType,
-    size: body.size
+    size: body.size,
+    purpose: body.purpose
   });
 
   return NextResponse.json({
     uploadUrl: draft.uploadUrl,
     headers: draft.headers,
     draftKey: draft.draftKey,
-    expiresAt: draft.expiresAt
+    draftToken: draft.draftToken,
+    expiresAt: draft.expiresAt,
+    publicUrl: draft.publicUrl,
+    objectKey: draft.objectKey
   } satisfies PresignDraftResponse);
 }
 
@@ -239,20 +297,27 @@ async function requireUser(_request: NextRequest) {
 
 async function createDraftUploadTarget(_input: {
   userId: string;
+  fileName: string;
+  originalFileName?: string;
   mimeType: string;
   size: number;
-}) {
-  // Replace with your storage service or internal upload service.
-  // Store draft ownership, MIME type, size, and expiry server-side.
+  purpose: ImagePurpose;
+}): Promise<PresignDraftResponse> {
+  // App-side code: connect this to your storage service or internal upload service.
+  // Store draft ownership, purpose, MIME type, size, object key, and expiry server-side.
   throw new Error('Connect this route to your storage layer.');
 }
 ```
+
+`objectKey` in this response is still a draft storage reference. Keep the durable product `key` for the submit response after commit.
 
 ## `/api/profile` submit with image draft
 
 ```ts
 // app/api/profile/route.ts
 import { NextResponse, type NextRequest } from 'next/server';
+
+type ImagePurpose = 'avatar' | 'cover' | 'product' | 'custom';
 
 type PersistableImageValue = {
   src?: string;
@@ -268,8 +333,14 @@ type ProfileSubmitRequest = {
   displayName: string;
   imageDraft?: {
     draftKey: string;
-    previous: PersistableImageValue | null;
+    draftToken?: string;
+    purpose: ImagePurpose;
   };
+};
+
+type PreviousCleanupJob = {
+  previous: PersistableImageValue;
+  next: PersistableImageValue;
 };
 
 export const runtime = 'nodejs';
@@ -277,6 +348,7 @@ export const runtime = 'nodejs';
 export async function POST(request: NextRequest) {
   const user = await requireUser(request);
   const body = (await request.json()) as ProfileSubmitRequest;
+  let cleanupAfterCommit: PreviousCleanupJob | null = null;
 
   const result = await runTransaction(async () => {
     const currentProfile = await getProfileForUpdate(user.id);
@@ -284,6 +356,8 @@ export async function POST(request: NextRequest) {
       ? await commitProfileImageDraft({
           userId: user.id,
           draftKey: body.imageDraft.draftKey,
+          draftToken: body.imageDraft.draftToken,
+          purpose: body.imageDraft.purpose,
           previous: currentProfile.image
         })
       : currentProfile.image;
@@ -295,14 +369,22 @@ export async function POST(request: NextRequest) {
     });
 
     if (currentProfile.image && nextImage && !sameImageReference(currentProfile.image, nextImage)) {
-      await enqueuePreviousImageCleanup({
+      cleanupAfterCommit = {
         previous: currentProfile.image,
         next: nextImage
-      });
+      };
     }
 
     return profile;
   });
+
+  const cleanupJob = cleanupAfterCommit;
+
+  if (cleanupJob) {
+    await enqueuePreviousImageCleanup(cleanupJob).catch((error) => {
+      reportCleanupFailure(error, cleanupJob);
+    });
+  }
 
   return NextResponse.json({
     image: result.image
@@ -327,10 +409,13 @@ async function getProfileForUpdate(_userId: string) {
 async function commitProfileImageDraft(_input: {
   userId: string;
   draftKey: string;
+  draftToken?: string;
+  purpose: ImagePurpose;
   previous: PersistableImageValue | null;
-}) {
-  // Validate owner, expiry, MIME type, object existence, and product permissions.
-  // Move/copy the draft object to a final key and return the durable image value.
+}): Promise<PersistableImageValue> {
+  // Validate owner, expiry, token, purpose, MIME type, object existence, and product permissions.
+  // Move/copy the draft object to a final key or mark it final.
+  // Return a durable value with explicit src and/or key.
   throw new Error('Connect this route to your image commit service.');
 }
 
@@ -338,15 +423,16 @@ async function updateProfile(_input: {
   userId: string;
   displayName: string;
   image: PersistableImageValue | null;
-}) {
+}): Promise<{ image: PersistableImageValue | null }> {
   throw new Error('Connect this route to your database.');
 }
 
-async function enqueuePreviousImageCleanup(_input: {
-  previous: PersistableImageValue;
-  next: PersistableImageValue;
-}) {
+async function enqueuePreviousImageCleanup(_input: PreviousCleanupJob) {
   // Prefer a queue or idempotent background job.
+}
+
+function reportCleanupFailure(_error: unknown, _job: PreviousCleanupJob) {
+  // Record enough context to retry by key, but do not log signed URLs or draft tokens.
 }
 
 function sameImageReference(previous: PersistableImageValue, next: PersistableImageValue) {
@@ -362,6 +448,8 @@ function sameImageReference(previous: PersistableImageValue, next: PersistableIm
 }
 ```
 
+This submit route is the safer shape because it commits the draft and updates the product record together. The current profile row, not the browser payload, decides which previous image is eligible for cleanup.
+
 ## Best-effort discard route
 
 ```ts
@@ -372,6 +460,7 @@ export async function POST(request: NextRequest) {
   const user = await requireUser(request);
   const body = (await request.json()) as {
     draftKey?: string;
+    draftToken?: string;
     reason?: 'replace' | 'reset' | 'unmount' | 'manual';
   };
 
@@ -382,10 +471,11 @@ export async function POST(request: NextRequest) {
   await discardImageDraft({
     userId: user.id,
     draftKey: body.draftKey,
+    draftToken: body.draftToken,
     reason: body.reason ?? 'manual'
   });
 
-  return NextResponse.json({ ok: true });
+  return new Response(null, { status: 204 });
 }
 
 async function requireUser(_request: NextRequest) {
@@ -395,11 +485,55 @@ async function requireUser(_request: NextRequest) {
 async function discardImageDraft(_input: {
   userId: string;
   draftKey: string;
+  draftToken?: string;
   reason: 'replace' | 'reset' | 'unmount' | 'manual';
 }) {
-  // Delete only drafts owned by this user and still in draft storage.
+  // App-side code: delete only drafts owned by this user and still in draft storage.
+  // Make this idempotent. Returning success for an already-deleted draft is fine.
 }
 ```
+
+Discard must not delete committed objects. It is also not a guarantee: requests sent during unmount can be interrupted.
+
+## Optional previous cleanup route or worker
+
+Prefer an internal queue worker for previous cleanup. If you expose a route, keep it server-to-server or otherwise protected, and make it idempotent.
+
+```ts
+// app/api/images/cleanup-previous/route.ts
+import { NextResponse, type NextRequest } from 'next/server';
+
+export async function POST(request: NextRequest) {
+  await requireInternalCaller(request);
+  const body = (await request.json()) as {
+    previousKey?: string;
+    nextKey?: string;
+    reason?: 'replace-committed';
+  };
+
+  if (!body.previousKey || !body.nextKey || body.reason !== 'replace-committed') {
+    return NextResponse.json({ error: 'Invalid cleanup request.' }, { status: 400 });
+  }
+
+  await cleanupPreviousImage({
+    previousKey: body.previousKey,
+    nextKey: body.nextKey
+  });
+
+  return new Response(null, { status: 204 });
+}
+
+async function requireInternalCaller(_request: NextRequest) {
+  // Verify a queue signature, service token, or job runner identity.
+}
+
+async function cleanupPreviousImage(_input: { previousKey: string; nextKey: string }) {
+  // Confirm nextKey is committed and previousKey is no longer referenced before deleting.
+  // Return success if previousKey is already gone.
+}
+```
+
+Run previous cleanup only after the new image is committed. A cleanup failure should be retried or reported separately; it should not rollback the profile update.
 
 ## TTL reminder
 


### PR DESCRIPTION
## Summary

- Add backend contracts for draft upload target creation, draft commit, draft discard, previous-image cleanup, atomic form submit, and TTL cleanup.
- Expand the Next.js draft lifecycle recipe with app-side examples for presign, profile submit, discard, and optional cleanup worker flows.
- Update README and docs index links so advanced lifecycle guidance is discoverable.

## Notes

- No provider SDKs or storage-specific server implementations were added to package code.
- The default `ImageDropInput` behavior is unchanged.
- Snippets are documented as app-side examples, with signed upload URL, `draftToken`, public URL inference, commit, discard, cleanup, and TTL caveats called out.

## Validation

- `npm run verify`
- `npm run smoke:consumer`
- Markdown TS/TSX snippet syntax check
- Next.js recipe snippets typecheck with local `next/server` stub
- Local Markdown link check
- `git diff --check`
- `npm pack --dry-run --json`