### PR TITLE
release: 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Notable changes for `image-drop-input` are tracked here.
 
+## 0.3.2 - 2026-05-03
+
+### Added
+
+- Added the repository-maintained integration report that connects persistable value, byte-budget, draft lifecycle, backend contract, and consumer smoke checks into one single-image product form flow.
+
 ## 0.3.1 - 2026-05-01
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "image-drop-input",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "image-drop-input",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "MIT",
       "workspaces": [
         "examples/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "image-drop-input",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Product-safe React image field for durable image state, byte-budget preparation, explicit uploads, and draft lifecycle.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

- release version: 0.3.2
- dist-tag: latest
- scope: publish the final integration-report documentation evidence from PR #35 as a patch package release

## Highlights

- Bumped package metadata from 0.3.1 to 0.3.2.
- Added release-facing changelog notes for the repository-maintained integration report connecting persistable value, byte-budget, draft lifecycle, backend contract, and consumer smoke checks into one single-image product form flow.

## Checks

- [x] `package.json` and `package-lock.json` carry the intended version
- [x] `CHANGELOG.md` includes the release-facing notes
- [x] release-facing notes are included in the PR body
- [x] `npm run release:pr:check`
- [x] packed package contains the English canonical `README.md`, docs, license, dist files, and no local-only files
- [x] `npm run smoke:consumer`
- [x] `npm pack --dry-run`
- [ ] demo still looks right in the consumer you care about

## Publish Readiness

- [ ] npm Trusted Publisher is configured for `mt4110/image-drop-input`, workflow filename `release.yml`, and environment `npm-publish`
- [x] the release workflow uses OIDC for publish and does not depend on `NPM_TOKEN` or `NODE_AUTH_TOKEN`

## Publish Plan

- [ ] merge to `main`
- [ ] run the `Release` workflow from `main` with `publish` off and confirm the rehearsal passed
- [ ] confirm the rehearsal resolved exactly one package tarball artifact
- [ ] create and push signed tag `v0.3.2` from the merged release commit
- [ ] publish GitHub Release `v0.3.2` to trigger the trusted npm publish path
- [ ] confirm the publish run resolved exactly one package tarball before `npm publish`
- [ ] confirm the publish job used the `npm-publish` environment

## Post-publish Checks

- [ ] npm package page version matches `package.json` on `main`
- [ ] npm package page README starts with the English canonical `README.md`
- [ ] npm install snippet is `npm install image-drop-input react`
- [ ] npm homepage link opens the GitHub Pages demo
- [ ] npm repository link opens `mt4110/image-drop-input`
- [ ] npm bugs link opens the GitHub issue tracker
- [ ] docs link from the npm README opens successfully
- [ ] npm provenance is visible for the published version
- [ ] npm provenance details point back to the expected GitHub workflow run

## Notes

- breaking changes: none
- follow-up work: complete the release workflow rehearsal, signed tag, GitHub Release publish, and npm post-publish checks after merge
