### PR TITLE
Polish product-safe docs and server boundary

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -2,7 +2,7 @@
 
 [English README](./README.md) · [Public docs](./docs/README.md) · [Demo](https://mt4110.github.io/image-drop-input/) · [Issues](https://github.com/mt4110/image-drop-input/issues)
 
-フォーム保存に耐える、React 向けの単一画像フィールド。
+プロダクト保存に耐える React 単一画像フィールド。
 
 ローカルプレビュー、ポリシーに沿った画像準備、明示的なアップロード、
 そして保存可能な画像状態だけの永続化を支援します。
@@ -12,6 +12,8 @@ avatar、workspace logo、CMS thumbnail、article cover、product image、admin 
 - Persistable value guard: `toPersistableImageValue()` で submit 前に一時 `previewSrc` を落とす
 - Byte-budget solver: `prepareImageToBudget()` で upload policy に収まる画像を準備する
 - Draft lifecycle: `useImageDraftLifecycle()` で draft upload、commit、discard、previous cleanup を分ける
+
+**Upload success is not product save success.** upload の成功と product form の保存成功を分け、browser preview、prepared bytes、draft upload、committed image、保存 payload を混ぜないための package です。
 
 詳細な公開 docs は現時点では English README と [docs](./docs/README.md) を canonical としています。この日本語 README は主要な導入と設計思想を押さえるための短い入口です。
 
@@ -90,6 +92,20 @@ export function AvatarField() {
   );
 }
 ```
+
+## Pick your path
+
+### 1. Local preview only
+
+preview、paste、drag/drop、keyboard access、safe removal だけが必要なら `ImageDropInput` から始めてください。upload lifecycle は不要です。
+
+### 2. Prepare and upload one image
+
+転送前に upload policy へ収めたい場合は、`prepareImageToBudget()` と明示的な upload adapter を足してください。upload wiring は app 側で所有します。
+
+### 3. Product-safe replacement flow
+
+draft upload を product save まで persisted state にしたくない場合は、`toPersistableImageValue()` と `useImageDraftLifecycle()` を使ってください。
 
 ## 何が入っているか
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ product images, and admin forms. Not generic file queues.
 
 **Upload success is not product save success.** The package is built around that boundary: browser preview, prepared bytes, draft upload, committed image, and persisted form payload stay separate.
 
+New readers can pick the path that matches their need: local preview, prepared upload, or product-safe replacement.
+
 [Demo](https://mt4110.github.io/image-drop-input/) · [Docs](./docs/README.md) · [Recipes](#recipes) · [Usage reports](https://github.com/mt4110/image-drop-input/issues/new?template=usage-report.yml) · [Japanese README](./README.ja.md) · [Issues](https://github.com/mt4110/image-drop-input/issues)
 
 ![image-drop-input demo showing preview, prepared metadata, and upload state](./docs/assets/demo-light.png)
@@ -114,19 +116,19 @@ Users can drop an image, browse for one, paste from the clipboard, preview it, a
 
 ### 1. Local preview only
 
-Use `ImageDropInput` when you just need a single-image field with preview, paste, drag/drop, keyboard access, and safe removal.
+Use `ImageDropInput` when you just need a single-image field with preview, paste, drag/drop, keyboard access, and safe removal. No upload lifecycle is required.
 
 Start with the [local preview recipe](./docs/recipes/local-preview.md).
 
 ### 2. Prepare and upload one image
 
-Add `prepareImageToBudget()` and an explicit upload adapter when the image must fit upload policy before transfer.
+Add `prepareImageToBudget()` and an explicit upload adapter when the image must fit upload policy before transfer. Upload wiring stays app-owned and explicit.
 
 Start with the [byte-budget guide](./docs/byte-budget.md), [presigned PUT recipe](./docs/recipes/presigned-put.md), and [upload docs](./docs/uploads.md).
 
 ### 3. Product-safe replacement flow
 
-Use `toPersistableImageValue()` and `useImageDraftLifecycle()` when upload success must remain separate from form save success.
+Use `toPersistableImageValue()` and `useImageDraftLifecycle()` when a draft upload must wait for product save before it becomes persisted state.
 
 Start with the [draft lifecycle guide](./docs/draft-lifecycle.md), [backend contracts](./docs/backend-contracts.md), and [product submit recipe](./docs/recipes/product-submit-with-image-draft.md).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,27 +4,23 @@
 
 Preview locally, prepare to policy, upload explicitly, and persist only durable image state.
 
-Start with the path that matches your product:
+**Upload success is not product save success.**
+
+Pick the path that matches your product:
 
 - Local preview only: [Local preview](./recipes/local-preview.md)
 - Prepare and upload one image: [Byte budget solver](./byte-budget.md) and [Uploads](./uploads.md)
 - Product-safe replacement flow: [Draft lifecycle](./draft-lifecycle.md), [Backend contracts](./backend-contracts.md), and [Product submit with image draft](./recipes/product-submit-with-image-draft.md)
 
-Deep docs:
+Core docs:
 
 - [Value model](./value-model.md): how `src`, `previewSrc`, `key`, and metadata fit together
-- [Persistable value guard](./persistable-value.md): remove temporary preview state before submit
-- [Validation](./validation.md): source limits, output limits, dimensions, pixels, and error codes
+- [Persistable value guard](./persistable-value.md): remove temporary preview state before submit and mirror the rule on the server
 - [Byte budget solver](./byte-budget.md): prepare images to fit an output byte budget
 - [Draft lifecycle](./draft-lifecycle.md): upload drafts, commit on form save, discard on cancel, and cleanup previous images
 - [Backend contracts](./backend-contracts.md): app-owned auth, signed URLs, commit, discard, previous cleanup, and TTL cleanup
+- [Validation](./validation.md): source limits, output limits, dimensions, pixels, and error codes
 - [Error taxonomy](./error-taxonomy.md): stable error codes for product copy, retries, and safe telemetry
-- [Telemetry and privacy](./telemetry-and-privacy.md): safe error tags, redaction patterns, and product copy mapping
-- [Security model](./security.md): storage credentials, signed URLs, drafts, and product save boundaries
-- [Integration report](./integration-report.md): repo-maintained report for the single-image product form boundary
-- [Adoption evidence](./adoption-evidence.md): what external examples and usage reports prove
-- [Release verification](./release-verification.md): packed package, npm metadata, provenance, and local verification checks
-- [Maintenance governance](./maintenance-governance.md): scope decisions, non-goals, and semver policy
 - [Uploads](./uploads.md): adapter contracts, signed upload boundaries, progress, typed upload errors, and aborts
 - [Transforms](./transforms.md): compression, WebP conversion, return shapes, and MIME consistency
 - [Accessibility](./accessibility.md): keyboard, paste, status, dialog, and headless responsibilities
@@ -46,5 +42,14 @@ Recipes:
 - [Multipart POST](./recipes/multipart-post.md)
 - [Raw PUT](./recipes/raw-put.md)
 - [Headless UI](./recipes/headless-ui.md)
+
+Security, privacy, and adoption:
+
+- [Security model](./security.md): storage credentials, signed URLs, drafts, and product save boundaries
+- [Telemetry and privacy](./telemetry-and-privacy.md): safe error tags, redaction patterns, and product copy mapping
+- [Integration report](./integration-report.md): repo-maintained report for the single-image product form boundary
+- [Adoption evidence](./adoption-evidence.md): what external examples and usage reports prove
+- [Release verification](./release-verification.md): packed package, npm metadata, provenance, and local verification checks
+- [Maintenance governance](./maintenance-governance.md): scope decisions, non-goals, and semver policy
 
 The package stays single-image first. Use Uppy, FilePond, Uploady, or provider widgets when you need queues, remote sources, resumable uploads, image editing, or storage-as-a-service. Use this package when one image field must keep temporary preview state, draft upload state, and persisted product state separate.

--- a/docs/persistable-value.md
+++ b/docs/persistable-value.md
@@ -134,6 +134,24 @@ type ProfilePayload = {
 
 Validate the payload again on the server with your own schema. This package keeps browser state out of the client payload, but the server still owns authorization, storage policy, and persistence.
 
+## Server schema handoff
+
+The client guard keeps browser state out of the request. The server schema decides whether the durable reference is allowed.
+
+Use the [Zod schema recipe](./recipes/server-persistable-image-zod.md) or the [custom validator recipe](./recipes/server-persistable-image-custom.md) to mirror the submit-boundary rules without adding a runtime schema dependency to this package.
+
+At minimum, the server-side contract should:
+
+- accept `null` for optional image fields
+- reject `previewSrc`
+- reject `blob:`, `filesystem:`, and `data:` `src` values
+- require at least one durable reference: `src` or `key`
+- validate `size`, `width`, and `height` metadata
+- restrict MIME types to the product field policy
+- optionally require `key` for private buckets
+
+Shape validation is still not product authority. After parsing, the server must verify user authorization, record ownership, storage object existence, draft/final state, and storage policy. Never trust `previousKey` from the browser as authority for cleanup; load the current product record first.
+
 ## Common mistakes
 
 Do not save `previewSrc`. It is usually a local `blob:` URL.

--- a/docs/recipes/server-persistable-image-custom.md
+++ b/docs/recipes/server-persistable-image-custom.md
@@ -7,7 +7,7 @@ Client sanitization is UX. Server validation is authority.
 ## Validator
 
 ```ts
-type ServerPersistableImageValue = {
+type PersistableImageObject = {
   src?: string;
   key?: string;
   fileName?: string;
@@ -17,7 +17,9 @@ type ServerPersistableImageValue = {
   height?: number;
 };
 
-const allowedMimeTypes = new Set<NonNullable<ServerPersistableImageValue['mimeType']>>([
+type PersistableImagePayload = PersistableImageObject | null;
+
+const allowedMimeTypes = new Set<NonNullable<PersistableImageObject['mimeType']>>([
   'image/jpeg',
   'image/png',
   'image/webp'
@@ -81,11 +83,11 @@ function readOptionalPositiveInteger(
 
 function isAllowedMimeType(
   value: string
-): value is NonNullable<ServerPersistableImageValue['mimeType']> {
-  return allowedMimeTypes.has(value as NonNullable<ServerPersistableImageValue['mimeType']>);
+): value is NonNullable<PersistableImageObject['mimeType']> {
+  return allowedMimeTypes.has(value as NonNullable<PersistableImageObject['mimeType']>);
 }
 
-function readOptionalMimeType(value: unknown): ServerPersistableImageValue['mimeType'] {
+function readOptionalMimeType(value: unknown): PersistableImageObject['mimeType'] {
   if (typeof value === 'undefined') {
     return undefined;
   }
@@ -99,9 +101,9 @@ function readOptionalMimeType(value: unknown): ServerPersistableImageValue['mime
   return mimeType;
 }
 
-export function parsePersistableImageValue(
+export function parsePersistableImagePayload(
   value: unknown
-): ServerPersistableImageValue | null {
+): PersistableImagePayload {
   if (value === null) {
     return null;
   }
@@ -163,6 +165,14 @@ export function parsePersistableImageValue(
 ```
 
 `src` may be an absolute CDN URL or a durable app-relative path such as `/images/avatar.webp`. The validator checks the URI scheme directly so it can reject temporary browser values without requiring `new URL(src)` to parse successfully.
+
+Use the parser at the server boundary, before writing to the product record:
+
+```ts
+const body = await request.json();
+const image = parsePersistableImagePayload(body.image);
+await saveProfileImage({ image });
+```
 
 ## Server policy checks
 


### PR DESCRIPTION
## Summary

- Clarify the public README path selection around local preview, prepared upload, and product-safe replacement.
- Align the docs index around the product-safe image field thesis and the durable state boundary.
- Strengthen the server schema handoff by linking persistable value docs to server recipes and aligning the custom validator example with `parsePersistableImagePayload()`.

## Self-review

- Phase 0 baseline branch exists and package/dist public-surface snapshots were recorded locally.
- Phase 1 public face now surfaces “Product-safe React image field”, “Upload success is not product save success”, and “Pick your path” for first-time readers.
- Phase 2 server docs explicitly say client sanitization is UX and server validation is authority.
- No runtime behavior, public API, dependency, version, package lock, or private planning docs changed.

## Verification

- `npm run verify`
- `npm run publish:check`
- `npm run smoke:consumer`
- `git diff --check`
- README/docs relative link check