### PR TITLE
Harden draft transactions and byte-budget solver

### DIFF
--- a/docs/backend-contracts.md
+++ b/docs/backend-contracts.md
@@ -41,7 +41,7 @@ Keep provider credentials and provider SDKs on the server side of your app. Do n
 
 Never infer `publicUrl` from `uploadUrl`. Signed upload URLs often use different hosts, temporary query strings, provider-specific paths, or private buckets.
 
-Do not treat a draft `objectKey` as the durable product `key`. The commit response is the boundary where the app receives the final image reference.
+Do not treat a draft `objectKey` as the durable product `key`. The same storage-looking string can mean different things before and after commit; server-side metadata decides the scope. The commit response is the boundary where the app receives the final image reference.
 
 ## Contract 1: create draft upload target
 
@@ -142,6 +142,8 @@ Do not delete the previous image before the new image is committed. A successful
 
 If the browser sends `previousKey`, treat it as a hint only. The server should load the current product record and use that authoritative value when deciding whether previous cleanup is allowed.
 
+Use a draft state transition, idempotency key, or unique constraint so a retry for the same draft/product cannot create multiple final objects. A duplicate commit can return the existing durable image value, or a safe conflict after the product state has changed.
+
 ## Contract 3: discard draft
 
 Use this endpoint when the user cancels, resets, unmounts, or replaces an uncommitted draft.
@@ -219,6 +221,8 @@ Server
 
 This avoids the split-brain case where `commitDraft()` succeeds but the product form save fails afterward.
 
+The browser sends draft identity, not a durable image key. The server returns the durable image value after the transaction commits.
+
 The simpler client sequence is acceptable for low-risk forms:
 
 ```ts
@@ -239,6 +243,8 @@ A common policy is:
 - background cleanup cadence: shorter than or equal to the maximum draft lifetime your product tolerates
 
 The exact numbers are app policy. The fallback is mandatory.
+
+Make the cleanup job idempotent and scoped to uncommitted drafts. It should delete expired draft metadata and draft objects, return success when an expired draft is already gone, and never delete a committed product image.
 
 ## App-side Next.js shape
 

--- a/docs/byte-budget.md
+++ b/docs/byte-budget.md
@@ -36,6 +36,8 @@ For PNG output, browser canvas quality settings are not reliable, so the helper 
 
 The helper does not upscale. If the source image or the fitted `maxWidth` / `maxHeight` dimensions cannot satisfy `minWidth` / `minHeight`, it throws `budget_unreachable` before encoding.
 
+Attempt order is deterministic inside one browser runtime. Browser canvas encoders can still produce different byte sizes across engines, so avoid treating the output as byte-identical between browsers.
+
 The result describes the prepared output, not the source image:
 
 ```ts

--- a/docs/draft-lifecycle.md
+++ b/docs/draft-lifecycle.md
@@ -85,6 +85,8 @@ type ImageDraftUploadResult = {
 
 `src` is optional. If the draft object is not publicly renderable, the hook keeps a local `previewSrc` for display. The package never infers a public URL from a signed upload URL.
 
+`draftKey` is a temporary reference. If your upload adapter returns `key` instead of `draftKey`, the hook treats that `key` as the draft identifier for lifecycle operations. Do not persist it as the product image key. The durable `key` comes from the commit response.
+
 ## Backend contracts
 
 Draft upload creates a temporary object:
@@ -106,6 +108,8 @@ type CommitImageDraftRequest = {
   previous: PersistableImageValue | null;
 };
 ```
+
+`previous` is the hook's last committed value. Treat it as a client hint only. A server transaction should load the current product record before deciding which previous image can be cleaned up.
 
 Discard deletes a temporary draft when the user cancels, replaces it, resets the form, or unmounts:
 
@@ -170,11 +174,12 @@ That is easier to wire, but it can split consistency if `image.commit()` succeed
 | Commit fails | previous committed value remains, draft stays retryable/discardable |
 | Commit succeeds but product save fails in client-only sequence | app must retry product save or run compensating cleanup; prefer server transaction |
 | Cleanup previous fails | new committed value remains, error is reported |
+| Previous cleanup is retried | cleanup stays idempotent and returns success if the previous object is already gone |
 | Discard succeeds | draft clears, committed value remains |
 | Discard fails | draft remains so the user can retry or leave it to TTL cleanup |
 | Replace draft | old draft is discarded when `autoDiscard.onReplace` is enabled |
 | Unmount | draft discard is best-effort when `autoDiscard.onUnmount` is enabled |
-| Double commit | the in-flight commit is reused; backend commit is not duplicated |
+| Double commit | the in-flight commit is reused; backend commit or product submit must not create a second final object |
 | Stale draft token | server rejects commit/discard; current product image stays unchanged |
 | Expired draft | server rejects commit; user uploads again |
 | Browser sends stale `previousKey` | server loads the current product record before cleanup |

--- a/docs/recipes/nextjs-draft-lifecycle.md
+++ b/docs/recipes/nextjs-draft-lifecycle.md
@@ -219,6 +219,8 @@ async function discardDraft(request: DiscardImageDraftRequest) {
 
 Do not write `target.uploadUrl` or `target.draftToken` to browser logs, analytics, or user-facing error messages. If `publicUrl` is not returned, the hook keeps a local preview for display. Do not derive a render URL from `uploadUrl`, and do not save `image.valueForInput` as record data before the commit response returns a durable image value.
 
+`toImageDraftPayload()` sends only temporary draft identity. The `/api/profile` response is where the client receives the durable image value for state and persistence.
+
 `image.resetToCommitted()` clears the local draft state. With `autoDiscard.onReset` enabled, it also calls the discard route for the draft when one exists.
 
 ## `/api/images/drafts/presign`
@@ -415,6 +417,7 @@ async function commitProfileImageDraft(_input: {
 }): Promise<PersistableImageValue> {
   // Validate owner, expiry, token, purpose, MIME type, object existence, and profile permissions.
   // Move/copy the draft object to a final key or mark it final.
+  // Use a draft state transition or unique constraint so duplicate submits do not create two final objects.
   // Return a durable value with explicit src and/or key.
   throw new Error('Connect this route to your image commit service.');
 }

--- a/docs/recipes/product-submit-with-image-draft.md
+++ b/docs/recipes/product-submit-with-image-draft.md
@@ -66,6 +66,8 @@ async function submitProduct(fields: ProductFields) {
 
 Do not send `previewSrc` to the server. If the form is local-preview-only, use `toPersistableImageValue()` before submit. If the form uses drafts, let the server return the final durable image after commit.
 
+`imageDraft.draftKey` is temporary. The saved product response, not the draft upload response, is where the client receives the durable image `key`.
+
 ## Weaker client-only sequence
 
 This is easier to wire:
@@ -87,7 +89,7 @@ The caveat is real. If `image.commit()` succeeds and `saveProduct()` fails, the 
 | Product save succeeds but previous cleanup fails | New image remains committed; cleanup is retried or reported separately. |
 | Discard fails | Draft remains retryable or expires by TTL; committed value remains safe. |
 | Unmount auto-discard does not complete | Server TTL cleanup is the fallback. |
-| Duplicate commit call | Client hook should reuse the in-flight commit; server endpoint should also be idempotent. |
+| Duplicate commit or submit retry | Client hook should reuse the in-flight commit; server commit/submit should not create a second final object. |
 | Stale draft token | Server rejects commit/discard and leaves current product image unchanged. |
 | Expired draft | Server rejects commit; client should ask the user to upload again. |
 | Browser sends `previousKey` that is no longer authoritative | Server loads the current product row and ignores the stale hint. |
@@ -131,6 +133,8 @@ export async function updateProduct(request: Request, productId: string) {
         })
       : product.image;
 
+    // The locked product row owns previous-image cleanup decisions.
+    // Do not trust a browser-sent previousKey for deletion.
     const saved = await tx.products.update(product.id, {
       ...fields,
       image: nextImage

--- a/src/core/prepare-image-to-budget/attempts.ts
+++ b/src/core/prepare-image-to-budget/attempts.ts
@@ -1,0 +1,31 @@
+import type {
+  ImageBudgetAttempt,
+  ImageBudgetOutputType,
+  ImageBudgetStrategy,
+  ImageDimensions
+} from './types';
+
+export function cloneImageBudgetAttempts(attempts: ImageBudgetAttempt[]): ImageBudgetAttempt[] {
+  return attempts.slice();
+}
+
+export function createImageBudgetAttempt(input: {
+  attempt: number;
+  dimensions: ImageDimensions;
+  quality?: number;
+  mimeType: ImageBudgetOutputType;
+  size: number;
+  withinBudget: boolean;
+  strategy: ImageBudgetStrategy;
+}): ImageBudgetAttempt {
+  return {
+    attempt: input.attempt,
+    width: input.dimensions.width,
+    height: input.dimensions.height,
+    ...(typeof input.quality === 'number' ? { quality: input.quality } : {}),
+    mimeType: input.mimeType,
+    size: input.size,
+    withinBudget: input.withinBudget,
+    strategy: input.strategy
+  };
+}

--- a/src/core/prepare-image-to-budget/encode.ts
+++ b/src/core/prepare-image-to-budget/encode.ts
@@ -1,5 +1,6 @@
 import { createImageCanvas } from '../canvas-image';
 import type { DecodedImage } from '../decode-image';
+import { cloneImageBudgetAttempts, createImageBudgetAttempt } from './attempts';
 import { ImageBudgetError } from './errors';
 import type {
   EncodedImageCandidate,
@@ -49,7 +50,7 @@ export async function encodeImageAttempt(
         outputMaxBytes: policy.outputMaxBytes,
         minWidth: policy.minWidth,
         minHeight: policy.minHeight,
-        attempts: attempts.slice()
+        attempts: cloneImageBudgetAttempts(attempts)
       },
       { cause: error }
     );
@@ -63,21 +64,20 @@ export async function encodeImageAttempt(
         outputMaxBytes: policy.outputMaxBytes,
         minWidth: policy.minWidth,
         minHeight: policy.minHeight,
-        attempts: attempts.slice()
+        attempts: cloneImageBudgetAttempts(attempts)
       }
     );
   }
 
-  const attempt: ImageBudgetAttempt = {
+  const attempt = createImageBudgetAttempt({
     attempt: attempts.length + 1,
-    width: dimensions.width,
-    height: dimensions.height,
-    ...(typeof quality === 'number' ? { quality } : {}),
+    dimensions,
+    quality,
     mimeType: outputType,
     size: blob.size,
     withinBudget: blob.size <= policy.outputMaxBytes,
     strategy
-  };
+  });
 
   attempts.push(attempt);
 

--- a/src/core/prepare-image-to-budget/errors.ts
+++ b/src/core/prepare-image-to-budget/errors.ts
@@ -1,3 +1,4 @@
+import { cloneImageBudgetAttempts } from './attempts';
 import { isSupportedOutputType } from './mime';
 import {
   imageBudgetStrategyList,
@@ -132,7 +133,7 @@ export function createBudgetUnreachableError(
       outputMaxBytes: policy.outputMaxBytes,
       minWidth: policy.minWidth,
       minHeight: policy.minHeight,
-      attempts: attempts.slice()
+      attempts: cloneImageBudgetAttempts(attempts)
     }
   );
 }

--- a/src/core/prepare-image-to-budget/index.ts
+++ b/src/core/prepare-image-to-budget/index.ts
@@ -13,6 +13,10 @@ import {
 import { resolveOriginalFileName, resolveOutputFileName } from './file-name';
 import { toMimeType } from './mime';
 import { resolvePolicy } from './policy';
+import {
+  createPreparedImageToBudgetResult,
+  createSourceWithinBudgetResult
+} from './result';
 import { solveLossyBudget, solvePngBudget } from './search';
 import type {
   ImageBudgetAttempt,
@@ -33,10 +37,6 @@ export type {
 
 function isObjectRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
-function getCompressionRatio(size: number, originalSize: number): number {
-  return size / originalSize;
 }
 
 function assertDecodedImageDimensions(
@@ -123,23 +123,15 @@ export async function prepareImageToBudget(
       sourceType === resolvedPolicy.outputType &&
       sourceFitsMaxDimensions
     ) {
-      return {
+      return createSourceWithinBudgetResult({
         file,
         fileName: outputFileName,
         mimeType: resolvedPolicy.outputType,
-        size: file.size,
         width: decodedImage.width,
         height: decodedImage.height,
         originalFileName,
-        ...(file.type ? { originalMimeType: file.type } : {}),
-        originalSize: file.size,
-        originalWidth: decodedImage.width,
-        originalHeight: decodedImage.height,
-        outputMaxBytes: resolvedPolicy.outputMaxBytes,
-        compressionRatio: getCompressionRatio(file.size, file.size),
-        attempts: [],
-        strategy: 'source-within-budget'
-      };
+        outputMaxBytes: resolvedPolicy.outputMaxBytes
+      });
     }
 
     const attempts: ImageBudgetAttempt[] = [];
@@ -164,23 +156,17 @@ export async function prepareImageToBudget(
       throw createBudgetUnreachableError(resolvedPolicy, attempts);
     }
 
-    return {
-      file: candidate.blob,
+    return createPreparedImageToBudgetResult({
+      file,
+      candidate,
       fileName: outputFileName,
       mimeType: resolvedPolicy.outputType,
-      size: candidate.blob.size,
-      width: candidate.attempt.width,
-      height: candidate.attempt.height,
       originalFileName,
-      ...(file.type ? { originalMimeType: file.type } : {}),
-      originalSize: file.size,
       originalWidth: decodedImage.width,
       originalHeight: decodedImage.height,
       outputMaxBytes: resolvedPolicy.outputMaxBytes,
-      compressionRatio: getCompressionRatio(candidate.blob.size, file.size),
-      attempts,
-      strategy: candidate.attempt.strategy
-    };
+      attempts
+    });
   } finally {
     decodedImage.cleanup();
   }

--- a/src/core/prepare-image-to-budget/result.ts
+++ b/src/core/prepare-image-to-budget/result.ts
@@ -1,0 +1,72 @@
+import type {
+  EncodedImageCandidate,
+  ImageBudgetAttempt,
+  ImageBudgetOutputType,
+  PreparedImageToBudgetResult
+} from './types';
+
+function getCompressionRatio(size: number, originalSize: number): number {
+  return size / originalSize;
+}
+
+function getOriginalMimeType(file: Blob): { originalMimeType?: string } {
+  return file.type ? { originalMimeType: file.type } : {};
+}
+
+export function createSourceWithinBudgetResult(input: {
+  file: File | Blob;
+  fileName: string;
+  mimeType: ImageBudgetOutputType;
+  width: number;
+  height: number;
+  originalFileName: string;
+  outputMaxBytes: number;
+}): PreparedImageToBudgetResult {
+  return {
+    file: input.file,
+    fileName: input.fileName,
+    mimeType: input.mimeType,
+    size: input.file.size,
+    width: input.width,
+    height: input.height,
+    originalFileName: input.originalFileName,
+    ...getOriginalMimeType(input.file),
+    originalSize: input.file.size,
+    originalWidth: input.width,
+    originalHeight: input.height,
+    outputMaxBytes: input.outputMaxBytes,
+    compressionRatio: getCompressionRatio(input.file.size, input.file.size),
+    attempts: [],
+    strategy: 'source-within-budget'
+  };
+}
+
+export function createPreparedImageToBudgetResult(input: {
+  file: File | Blob;
+  candidate: EncodedImageCandidate;
+  fileName: string;
+  mimeType: ImageBudgetOutputType;
+  originalFileName: string;
+  originalWidth: number;
+  originalHeight: number;
+  outputMaxBytes: number;
+  attempts: ImageBudgetAttempt[];
+}): PreparedImageToBudgetResult {
+  return {
+    file: input.candidate.blob,
+    fileName: input.fileName,
+    mimeType: input.mimeType,
+    size: input.candidate.blob.size,
+    width: input.candidate.attempt.width,
+    height: input.candidate.attempt.height,
+    originalFileName: input.originalFileName,
+    ...getOriginalMimeType(input.file),
+    originalSize: input.file.size,
+    originalWidth: input.originalWidth,
+    originalHeight: input.originalHeight,
+    outputMaxBytes: input.outputMaxBytes,
+    compressionRatio: getCompressionRatio(input.candidate.blob.size, input.file.size),
+    attempts: input.attempts,
+    strategy: input.candidate.attempt.strategy
+  };
+}

--- a/tests/core/prepare-image-to-budget.test.ts
+++ b/tests/core/prepare-image-to-budget.test.ts
@@ -135,6 +135,20 @@ describe('prepareImageToBudget', () => {
     expect(result.strategy).toBe('source-within-budget');
   });
 
+  it('keeps an explicit output fileName as-is while reporting the encoded MIME type', async () => {
+    const source = new File([new Uint8Array(600_000)], 'avatar.jpg', { type: 'image/jpeg' });
+    const result = await prepareImageToBudget(source, {
+      outputMaxBytes: 300_000,
+      outputType: 'image/webp',
+      fileName: 'avatar.custom-name'
+    });
+
+    expect(result.fileName).toBe('avatar.custom-name');
+    expect(result.mimeType).toBe('image/webp');
+    expect(result.file.type).toBe('image/webp');
+    expect(result.size).toBeLessThanOrEqual(300_000);
+  });
+
   it('converts to WebP and reports matching output metadata', async () => {
     const source = new File([new Uint8Array(600_000)], 'avatar.jpg', { type: 'image/jpeg' });
     const result = await prepareImageToBudget(source, {
@@ -228,6 +242,37 @@ describe('prepareImageToBudget', () => {
     expect(first.attempts.length).toBeGreaterThan(2);
     expect(first.attempts[0]).toMatchObject({ quality: 0.9, withinBudget: false });
     expect(first.attempts[1]).toMatchObject({ quality: 0.4, withinBudget: true });
+  });
+
+  it('uses WebP quality search before resizing when lower quality can reach the budget', async () => {
+    const source = new File([new Uint8Array(800_000)], 'cover.webp', { type: 'image/webp' });
+    const result = await prepareImageToBudget(source, {
+      outputMaxBytes: 130_000,
+      outputType: 'image/webp',
+      initialQuality: 0.9,
+      minQuality: 0.6,
+      maxEncodeAttempts: 8
+    });
+
+    expect(result.size).toBeLessThanOrEqual(130_000);
+    expect(result.strategy).toBe('quality-search');
+    expect(result.width).toBe(1000);
+    expect(result.height).toBe(800);
+    expect(result.attempts[0]).toMatchObject({
+      mimeType: 'image/webp',
+      quality: 0.9,
+      withinBudget: false,
+      strategy: 'quality-search'
+    });
+    expect(result.attempts[1]).toMatchObject({
+      mimeType: 'image/webp',
+      quality: 0.6,
+      withinBudget: true,
+      strategy: 'quality-search'
+    });
+    expect(
+      result.attempts.every((attempt) => attempt.width === 1000 && attempt.height === 800)
+    ).toBe(true);
   });
 
   it('resizes when minimum lossy quality cannot reach the budget', async () => {

--- a/tests/react/use-image-draft-lifecycle.test.tsx
+++ b/tests/react/use-image-draft-lifecycle.test.tsx
@@ -221,6 +221,7 @@ describe('useImageDraftLifecycle', () => {
     expect(result.current.committedValue).toEqual(committedImage);
     expect(result.current.draft).toEqual(expect.objectContaining({ draftKey: 'drafts/next.webp' }));
     expect(result.current.canCommit).toBe(true);
+    expect(result.current.canDiscard).toBe(true);
     expect(cleanupPrevious).not.toHaveBeenCalled();
   });
 
@@ -737,6 +738,7 @@ describe('useImageDraftLifecycle', () => {
 
     expect(result.current.phase).toBe('failed');
     expect(result.current.draft).toEqual(expect.objectContaining({ draftKey: 'drafts/next.webp' }));
+    expect(result.current.canDiscard).toBe(true);
     expect(result.current.error).toMatchObject({
       code: 'discard_failed'
     });


### PR DESCRIPTION
## Summary
- Clarify draft identity versus durable image keys across draft lifecycle, backend contract, and product submit docs.
- Add atomic submit and cleanup wording for duplicate commits, stale previous hints, TTL cleanup, and idempotent previous cleanup.
- Split byte-budget attempt creation and result normalization into internal modules without changing public exports.
- Add regression coverage for explicit fileName overrides, WebP quality search, and draft failure discardability.

## Self-review
- Public API, package exports, package version, and dependencies are unchanged.
- Draft docs distinguish temporary draft identity from durable committed keys and keep previous cleanup after commit success.
- Lifecycle tests assert commit/discard failures leave drafts retryable or discardable.
- Byte-budget changes are internal-only and preserve successful `size <= outputMaxBytes` behavior.
- Phase 5 telemetry/privacy docs already exist and are intentionally out of scope for this Phase 3-4 PR.
- `.private_docs` is not included.

## Validation
- `npm run verify`
- `npm run publish:check`
- `npm run smoke:consumer`
- `git diff --check`
- README/docs relative link check: 34 markdown files