### PR TITLE
Harden release verification gates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -12,6 +12,14 @@
 
 - 
 
+## Verification Summary
+
+- Local checks:
+- Release rehearsal:
+- Publish path:
+- Registry metadata:
+- Provenance:
+
 ## Checks
 
 - [ ] `package.json` and `package-lock.json` carry the intended version
@@ -33,11 +41,16 @@
 - [ ] confirm the rehearsal resolved exactly one package tarball artifact
 - [ ] rerun the `Release` workflow from `main` with `publish` on
 - [ ] confirm the publish run resolved exactly one package tarball before `npm publish`
+- [ ] confirm `npm publish` used the explicit resolved tarball path
 - [ ] confirm the publish job used the `npm-publish` environment
 
 ## Post-publish Checks
 
 - [ ] npm package page version matches `package.json` on `main`
+- [ ] `npm view image-drop-input@<version> version` matches `package.json`
+- [ ] `npm view image-drop-input dist-tags.latest` matches the released version
+- [ ] `npm view image-drop-input@<version> repository.url` matches `package.json`
+- [ ] `npm view image-drop-input@<version> engines.node` matches `package.json`
 - [ ] npm package page README starts with the English canonical `README.md`
 - [ ] npm install snippet is `npm install image-drop-input react`
 - [ ] npm homepage link opens the GitHub Pages demo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,20 +52,7 @@ jobs:
 
       - name: Resolve packed artifact
         id: packed-artifact
-        shell: bash
-        run: |
-          mapfile -t tarballs < <(find artifacts -maxdepth 1 -type f -name '*.tgz' -print | sort)
-
-          if [ "${#tarballs[@]}" -ne 1 ]; then
-            echo "Expected exactly one npm package tarball in artifacts, found ${#tarballs[@]}." >&2
-            if [ "${#tarballs[@]}" -gt 0 ]; then
-              printf 'Found tarballs:\n' >&2
-              printf '  %s\n' "${tarballs[@]}" >&2
-            fi
-            exit 1
-          fi
-
-          echo "tarball=./${tarballs[0]#./}" >> "$GITHUB_OUTPUT"
+        run: node scripts/resolve-npm-tarball.mjs artifacts --expect-package-json package.json --github-output "$GITHUB_OUTPUT"
 
       - uses: actions/upload-artifact@v7
         with:
@@ -73,6 +60,16 @@ jobs:
           path: ${{ steps.packed-artifact.outputs.tarball }}
           if-no-files-found: error
           retention-days: 7
+
+      - name: Summarize release artifact gate
+        run: |
+          {
+            echo "### Release artifact gate"
+            echo "- Workflow concurrency uses \`cancel-in-progress: false\`."
+            echo "- Verification command: \`npm run release:pr:check\`."
+            echo "- Packed artifact: \`${{ steps.packed-artifact.outputs.tarball }}\`."
+            echo "- Tarball count before upload: exactly one."
+          } >> "$GITHUB_STEP_SUMMARY"
 
   publish:
     needs: verify
@@ -109,20 +106,7 @@ jobs:
 
       - name: Resolve publish artifact
         id: publish-artifact
-        shell: bash
-        run: |
-          mapfile -t tarballs < <(find artifacts -maxdepth 1 -type f -name '*.tgz' -print | sort)
-
-          if [ "${#tarballs[@]}" -ne 1 ]; then
-            echo "Expected exactly one npm package tarball in artifacts, found ${#tarballs[@]}." >&2
-            if [ "${#tarballs[@]}" -gt 0 ]; then
-              printf 'Found tarballs:\n' >&2
-              printf '  %s\n' "${tarballs[@]}" >&2
-            fi
-            exit 1
-          fi
-
-          echo "tarball=./${tarballs[0]#./}" >> "$GITHUB_OUTPUT"
+        run: node scripts/resolve-npm-tarball.mjs artifacts --expect-package-json package.json --github-output "$GITHUB_OUTPUT"
 
       - name: Publish to npm
         run: npm publish "${{ steps.publish-artifact.outputs.tarball }}" --access public
@@ -164,3 +148,16 @@ jobs:
           echo "repository.url: expected $EXPECTED_REPOSITORY_URL, received ${REPOSITORY_URL:-'(missing)'}" >&2
           echo "engines.node: expected $EXPECTED_ENGINES_NODE, received ${ENGINES_NODE:-'(missing)'}" >&2
           exit 1
+
+      - name: Summarize npm publish gate
+        run: |
+          PACKAGE_SPEC="$(node -p 'require("./package.json").name + "@" + require("./package.json").version')"
+
+          {
+            echo "### npm publish gate"
+            echo "- Published artifact: \`${{ steps.publish-artifact.outputs.tarball }}\`."
+            echo "- Tarball count before npm publish: exactly one."
+            echo "- Authentication path: npm Trusted Publishing / OIDC."
+            echo "- Registry metadata checked: exact version, \`dist-tags.latest\`, \`repository.url\`, and \`engines.node\`."
+            echo "- Provenance follow-up: confirm npm shows provenance for \`${PACKAGE_SPEC}\` and links it to this workflow run."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -68,11 +68,32 @@ Use these sources for context:
    npm run release:pr:check
    ```
 
-   This includes the packed package face check: `npm pack --json --dry-run`, README inclusion,
-   package metadata links, and deny-list validation for files that must stay out of the published tarball.
+   This includes release workflow gate checks, the packed package face check, temporary tarball creation, README inclusion,
+   package metadata links, exact tarball count, and deny-list validation for files that must stay out of the published tarball.
+
+   To isolate the tarball gate locally:
+
+   ```bash
+   ARTIFACT_DIR="$(mktemp -d)"
+   trap 'rm -rf "$ARTIFACT_DIR"' EXIT
+
+   npm pack --pack-destination "$ARTIFACT_DIR"
+   node scripts/resolve-npm-tarball.mjs "$ARTIFACT_DIR" --expect-package-json package.json
+   ```
 
 3. Add release-facing notes to the release PR body.
    Update `CHANGELOG.md` in the same PR.
+
+   Include a verification summary that can also be reused in the GitHub release notes:
+
+   ```text
+   Verification summary:
+   - Local checks: npm run verify, npm run smoke:consumer, npm run publish:check
+   - Release rehearsal: Release workflow passed with publish off and resolved exactly one tarball
+   - Publish: npm-publish environment used npm Trusted Publishing / OIDC and published the explicit tarball path
+   - Registry metadata: exact version, dist-tags.latest, repository.url, and engines.node matched package.json
+   - Provenance: npm provenance was visible and pointed back to the expected workflow run
+   ```
 
 4. Open a pull request with the `Release` template.
    Use a short release branch and a neutral title such as `release/0.2.0` and `release: 0.2.0`.
@@ -83,6 +104,7 @@ Use these sources for context:
    - first with `publish` turned off for a rehearsal; this runs the verification job, confirms there is exactly one package tarball, and stores that checked tarball as a short-lived workflow artifact
    - then with `publish` turned on for the real publish; this enters the `npm-publish` environment, confirms the downloaded artifact still contains exactly one package tarball, and publishes that resolved tarball path with OIDC
    - after publish, the workflow reads npm registry metadata for the package version, `latest` dist-tag, repository URL, and Node engine floor
+   - use the workflow summary as the source for the release verification summary
 
 6. After publishing, complete the release follow-up checklist.
 
@@ -104,6 +126,33 @@ Use these sources for context:
    - the docs link from the README opens successfully
    - provenance is visible for the published version
    - the provenance details point back to the expected GitHub workflow run
+
+   Registry metadata commands:
+
+   ```bash
+   PACKAGE=image-drop-input
+   VERSION="$(node -p 'require("./package.json").version')"
+
+   npm view "$PACKAGE@$VERSION" version
+   npm view "$PACKAGE" dist-tags.latest
+   npm view "$PACKAGE@$VERSION" repository.url
+   npm view "$PACKAGE@$VERSION" engines.node
+   npm view "$PACKAGE@$VERSION" dist.integrity
+   ```
+
+   Provenance/signature CLI check from a fresh project:
+
+   ```bash
+   PACKAGE=image-drop-input
+   VERSION="$(node -p 'require("./package.json").version')"
+   VERIFY_DIR="$(mktemp -d)"
+   trap 'rm -rf "$VERIFY_DIR"' EXIT
+
+   cd "$VERIFY_DIR"
+   npm init -y
+   npm install "$PACKAGE@$VERSION"
+   npm audit signatures
+   ```
 
    Token and package settings hardening:
 

--- a/docs/release-verification.md
+++ b/docs/release-verification.md
@@ -18,7 +18,17 @@ What they cover:
 | --- | --- |
 | `npm run verify` | Typecheck, unit tests, example builds, package linting, and type resolution checks. |
 | `npm run smoke:consumer` | Packs the package and installs it into root type, headless CJS, and Vite React UI consumer fixtures. |
-| `npm run publish:check` | Verifies the dry-run package manifest, included docs, tarball count, metadata links, and deny-listed files. |
+| `npm run publish:check` | Verifies release workflow gates, then creates a temporary package tarball and checks manifest metadata, included docs, exact tarball count, metadata links, and deny-listed files. |
+
+To reproduce the release workflow tarball gate locally:
+
+```bash
+ARTIFACT_DIR="$(mktemp -d)"
+trap 'rm -rf "$ARTIFACT_DIR"' EXIT
+
+npm pack --pack-destination "$ARTIFACT_DIR"
+node scripts/resolve-npm-tarball.mjs "$ARTIFACT_DIR" --expect-package-json package.json
+```
 
 ## Package manifest invariants
 
@@ -44,6 +54,21 @@ Keep these stable unless a release intentionally changes them:
 - normal publish path uses npm Trusted Publishing with OIDC, not a long-lived publish token
 - post-publish verification checks exact package version, `dist-tags.latest`, `repository.url`, and `engines.node`
 
+The workflow summary includes the resolved tarball path and registry checks so release notes can include a short verification summary.
+
+## Release notes verification summary
+
+Use this shape in release PRs and GitHub release notes:
+
+```text
+Verification summary:
+- Local checks: npm run verify, npm run smoke:consumer, npm run publish:check
+- Release rehearsal: Release workflow passed with publish off and resolved exactly one tarball
+- Publish: npm-publish environment used npm Trusted Publishing / OIDC and published the explicit tarball path
+- Registry metadata: exact version, dist-tags.latest, repository.url, and engines.node matched package.json
+- Provenance: npm provenance was visible and pointed back to the expected workflow run
+```
+
 ## Post-publish npm checks
 
 After publish, confirm the registry face:
@@ -59,6 +84,21 @@ npm view "$PACKAGE@$VERSION" engines.node
 npm view "$PACKAGE@$VERSION" dist.integrity
 ```
 
+For an assertion-style check:
+
+```bash
+PACKAGE=image-drop-input
+VERSION="$(node -p 'require("./package.json").version')"
+EXPECTED_REPOSITORY_URL="$(node -p 'require("./package.json").repository.url')"
+EXPECTED_ENGINES_NODE="$(node -p 'require("./package.json").engines.node')"
+
+test "$(npm view "$PACKAGE@$VERSION" version)" = "$VERSION"
+test "$(npm view "$PACKAGE" dist-tags.latest)" = "$VERSION"
+test "$(npm view "$PACKAGE@$VERSION" repository.url)" = "$EXPECTED_REPOSITORY_URL"
+test "$(npm view "$PACKAGE@$VERSION" engines.node)" = "$EXPECTED_ENGINES_NODE"
+npm view "$PACKAGE@$VERSION" dist.integrity
+```
+
 Manual checks:
 
 - npm README starts with the canonical English README.
@@ -67,6 +107,24 @@ Manual checks:
 - repository and bugs links point to `mt4110/image-drop-input`.
 - provenance is visible for the published version.
 - provenance points back to the expected GitHub workflow run.
+
+## Provenance verification
+
+The npm package page should show provenance for the published version. The provenance details should link to the source commit and the release workflow run that published the tarball.
+
+To verify downloaded registry signatures and provenance attestations from the CLI:
+
+```bash
+PACKAGE=image-drop-input
+VERSION="$(node -p 'require("./package.json").version')"
+VERIFY_DIR="$(mktemp -d)"
+trap 'rm -rf "$VERIFY_DIR"' EXIT
+
+cd "$VERIFY_DIR"
+npm init -y
+npm install "$PACKAGE@$VERSION"
+npm audit signatures
+```
 
 ## Optional SBOM
 

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "smoke:consumer:vite-react-ui:run": "npm run smoke:consumer:vite-react-ui:install && npm run smoke:consumer:vite-react-ui:build",
     "smoke:consumer:vite-react-ui": "npm run pack:consumer-smoke && npm run smoke:consumer:vite-react-ui:run",
     "smoke:consumer": "npm run pack:consumer-smoke && npm run smoke:consumer:root-types && npm run smoke:consumer:headless-cjs && npm run smoke:consumer:vite-react-ui:run",
-    "publish:check": "node scripts/verify-pack-manifest.mjs",
+    "publish:check": "node scripts/verify-release-workflow.mjs && node scripts/verify-pack-manifest.mjs",
     "release:pr:check": "npm run verify && npm run publish:check",
     "typecheck:examples": "npm run typecheck --workspace examples/vite && npm run typecheck --workspace examples/rsbuild",
     "typecheck": "tsc -p tsconfig.json --noEmit && npm run build:lib && npm run typecheck:examples",

--- a/scripts/resolve-npm-tarball.mjs
+++ b/scripts/resolve-npm-tarball.mjs
@@ -1,0 +1,141 @@
+import { appendFileSync, readFileSync, readdirSync } from 'node:fs';
+import { basename, isAbsolute, join, relative, resolve, sep } from 'node:path';
+
+const args = process.argv.slice(2);
+const directoryArg = args.shift();
+let expectedPackageJsonPath;
+let githubOutputPath;
+let outputName = 'tarball';
+
+function usage() {
+  console.error(
+    [
+      'Usage: node scripts/resolve-npm-tarball.mjs <directory> [options]',
+      '',
+      'Options:',
+      '  --expect-package-json <path>  Require the tarball name to match package name/version.',
+      '  --github-output <path>        Append the resolved tarball path to a GitHub output file.',
+      '  --output-name <name>          GitHub output name. Defaults to tarball.'
+    ].join('\n')
+  );
+}
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}
+
+function expectedTarballNameFromPackageJson(packageJsonPath) {
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+
+  if (!packageJson.name || !packageJson.version) {
+    fail(`Expected ${packageJsonPath} to include package name and version.`);
+  }
+
+  const packageName = packageJson.name.replace(/^@/, '').replace('/', '-');
+  return `${packageName}-${packageJson.version}.tgz`;
+}
+
+function formatPathForShell(filePath) {
+  const relativePath = relative(process.cwd(), filePath);
+  const path =
+    relativePath && !relativePath.startsWith('..') && !isAbsolute(relativePath)
+      ? relativePath
+      : filePath;
+  const normalizedPath = path.split(sep).join('/');
+
+  if (normalizedPath.startsWith('.') || normalizedPath.startsWith('/')) {
+    return normalizedPath;
+  }
+
+  return `./${normalizedPath}`;
+}
+
+for (let index = 0; index < args.length; index += 1) {
+  const arg = args[index];
+  const value = args[index + 1];
+
+  if (arg === '--expect-package-json') {
+    if (!value) {
+      usage();
+      fail('Missing value for --expect-package-json.');
+    }
+
+    expectedPackageJsonPath = resolve(process.cwd(), value);
+    index += 1;
+  } else if (arg === '--github-output') {
+    if (!value) {
+      usage();
+      fail('Missing value for --github-output.');
+    }
+
+    githubOutputPath = value;
+    index += 1;
+  } else if (arg === '--output-name') {
+    if (!value) {
+      usage();
+      fail('Missing value for --output-name.');
+    }
+
+    outputName = value;
+    index += 1;
+  } else {
+    usage();
+    fail(`Unknown option: ${arg}`);
+  }
+}
+
+if (!directoryArg) {
+  usage();
+  process.exit(1);
+}
+
+const directory = resolve(process.cwd(), directoryArg);
+let entries;
+
+try {
+  entries = readdirSync(directory, { withFileTypes: true });
+} catch (error) {
+  fail(`Could not read tarball directory ${directory}: ${error.message}`);
+}
+
+const tarballs = entries
+  .filter((entry) => entry.isFile() && entry.name.endsWith('.tgz'))
+  .map((entry) => join(directory, entry.name))
+  .sort();
+
+if (tarballs.length !== 1) {
+  console.error(
+    `Expected exactly one npm package tarball in ${directory}, found ${tarballs.length}.`
+  );
+
+  if (tarballs.length > 0) {
+    console.error('Found tarballs:');
+
+    for (const tarball of tarballs) {
+      console.error(`  ${formatPathForShell(tarball)}`);
+    }
+  }
+
+  process.exit(1);
+}
+
+const tarball = tarballs[0];
+
+if (expectedPackageJsonPath) {
+  const expectedTarballName = expectedTarballNameFromPackageJson(expectedPackageJsonPath);
+
+  if (basename(tarball) !== expectedTarballName) {
+    fail(
+      `Expected tarball ${expectedTarballName}, received ${basename(tarball)}.`
+    );
+  }
+}
+
+const outputPath = formatPathForShell(tarball);
+
+if (githubOutputPath) {
+  appendFileSync(githubOutputPath, `${outputName}=${outputPath}\n`);
+}
+
+console.log(`Resolved npm package tarball: ${outputPath}`);

--- a/scripts/resolve-npm-tarball.mjs
+++ b/scripts/resolve-npm-tarball.mjs
@@ -42,9 +42,15 @@ function formatPathForShell(filePath) {
     relativePath && !relativePath.startsWith('..') && !isAbsolute(relativePath)
       ? relativePath
       : filePath;
+  const pathIsAbsolute = isAbsolute(path);
   const normalizedPath = path.split(sep).join('/');
 
-  if (normalizedPath.startsWith('.') || normalizedPath.startsWith('/')) {
+  if (
+    pathIsAbsolute ||
+    normalizedPath.startsWith('.') ||
+    normalizedPath.startsWith('/') ||
+    /^[a-zA-Z]:\//.test(normalizedPath)
+  ) {
     return normalizedPath;
   }
 

--- a/scripts/verify-pack-manifest.mjs
+++ b/scripts/verify-pack-manifest.mjs
@@ -1,9 +1,9 @@
 import { execFileSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, join, resolve } from 'node:path';
 
 const npmExecutable = process.platform === 'win32' ? 'npm.cmd' : 'npm';
-const npmPackArgs = ['pack', '--json', '--dry-run', '--workspaces=false'];
 const npmWorkspaceConfigKeys = new Set([
   'npm_config_include_workspace_root',
   'npm_config_workspace',
@@ -12,7 +12,17 @@ const npmWorkspaceConfigKeys = new Set([
 const packageJsonPath = resolve(process.cwd(), 'package.json');
 const readmePath = resolve(process.cwd(), 'README.md');
 const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
-const expectedTarballFilename = `${packageJson.name}-${packageJson.version}.tgz`;
+const expectedPackageTarballName = packageJson.name.replace(/^@/, '').replace('/', '-');
+const expectedTarballFilename = `${expectedPackageTarballName}-${packageJson.version}.tgz`;
+const tempDirectoryPrefix = packageJson.name.replace(/[^a-zA-Z0-9._-]/g, '-');
+const packDestination = mkdtempSync(join(tmpdir(), `${tempDirectoryPrefix}-pack-`));
+const npmPackArgs = [
+  'pack',
+  '--json',
+  '--pack-destination',
+  packDestination,
+  '--workspaces=false'
+];
 const expectedMetadata = [
   ['homepage', packageJson.homepage, 'https://mt4110.github.io/image-drop-input/'],
   ['repository.type', packageJson.repository?.type, 'git'],
@@ -62,6 +72,19 @@ const failures = [];
 function fail(message) {
   failures.push(message);
 }
+
+function cleanupPackDestination() {
+  try {
+    rmSync(packDestination, {
+      force: true,
+      recursive: true
+    });
+  } catch {
+    // The verification result is more important than cleanup diagnostics.
+  }
+}
+
+process.on('exit', cleanupPackDestination);
 
 function getRootPackEnv() {
   const env = { ...process.env };
@@ -128,6 +151,18 @@ function getPackedFilePaths(packResult) {
   return files;
 }
 
+function getPackedTarballPaths() {
+  try {
+    return readdirSync(packDestination, { withFileTypes: true })
+      .filter((entry) => entry.isFile() && entry.name.endsWith('.tgz'))
+      .map((entry) => join(packDestination, entry.name))
+      .sort();
+  } catch (error) {
+    fail(`Could not read temporary pack directory: ${error.message}`);
+    return [];
+  }
+}
+
 function isAllowedPackPath(path) {
   return allowedFiles.has(path) || allowedPrefixes.some((prefix) => path.startsWith(prefix));
 }
@@ -157,9 +192,36 @@ function verifyPackMetadata(packResult) {
     );
   }
 
-  if (packResult.filename !== expectedTarballFilename) {
+  if (basename(packResult.filename ?? '') !== expectedTarballFilename) {
     fail(
       `Expected tarball filename ${expectedTarballFilename}, received ${
+        packResult.filename ?? '(missing)'
+      }.`
+    );
+  }
+}
+
+function verifyTarballArtifact(packResult) {
+  const tarballs = getPackedTarballPaths();
+
+  if (tarballs.length !== 1) {
+    fail(
+      `Expected npm pack to create exactly one tarball, received ${tarballs.length}.`
+    );
+    return;
+  }
+
+  const tarballFilename = basename(tarballs[0]);
+
+  if (tarballFilename !== expectedTarballFilename) {
+    fail(
+      `Expected packed tarball ${expectedTarballFilename}, received ${tarballFilename}.`
+    );
+  }
+
+  if (basename(packResult.filename ?? '') !== tarballFilename) {
+    fail(
+      `Expected npm pack manifest filename to match ${tarballFilename}, received ${
         packResult.filename ?? '(missing)'
       }.`
     );
@@ -236,6 +298,7 @@ if (packResult) {
   const files = getPackedFilePaths(packResult);
 
   verifyPackMetadata(packResult);
+  verifyTarballArtifact(packResult);
   verifyPackageJsonMetadata();
   verifyFiles(files);
   verifyReadmeFace(files);
@@ -243,7 +306,7 @@ if (packResult) {
   if (failures.length === 0) {
     console.log(
       `Verified pack manifest for ${packageJson.name}@${packageJson.version}: ` +
-        `${files.size} files, ${packResult.filename}.`
+        `${files.size} files, ${expectedTarballFilename}.`
     );
   }
 }

--- a/scripts/verify-release-workflow.mjs
+++ b/scripts/verify-release-workflow.mjs
@@ -2,13 +2,34 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 const workflowPath = resolve(process.cwd(), '.github/workflows/release.yml');
-const workflow = readFileSync(workflowPath, 'utf8');
-const lines = workflow.split(/\r?\n/);
 const failures = [];
 
 function fail(message) {
   failures.push(message);
 }
+
+function readWorkflow() {
+  try {
+    return readFileSync(workflowPath, 'utf8');
+  } catch (error) {
+    fail(`Could not read release workflow at ${workflowPath}: ${error.message}`);
+    return undefined;
+  }
+}
+
+const workflow = readWorkflow();
+
+if (workflow === undefined) {
+  console.error('Release workflow verification failed:');
+
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+
+  process.exit(1);
+}
+
+const lines = workflow.split(/\r?\n/);
 
 function getIndent(line) {
   return line.match(/^\s*/)?.[0].length ?? 0;

--- a/scripts/verify-release-workflow.mjs
+++ b/scripts/verify-release-workflow.mjs
@@ -1,0 +1,146 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const workflowPath = resolve(process.cwd(), '.github/workflows/release.yml');
+const workflow = readFileSync(workflowPath, 'utf8');
+const lines = workflow.split(/\r?\n/);
+const failures = [];
+
+function fail(message) {
+  failures.push(message);
+}
+
+function getIndent(line) {
+  return line.match(/^\s*/)?.[0].length ?? 0;
+}
+
+function getBlock(headerPattern, label) {
+  const startIndex = lines.findIndex((line) => headerPattern.test(line));
+
+  if (startIndex === -1) {
+    fail(`Expected release workflow to include ${label}.`);
+    return '';
+  }
+
+  const startIndent = getIndent(lines[startIndex]);
+  let endIndex = lines.length;
+
+  for (let index = startIndex + 1; index < lines.length; index += 1) {
+    const line = lines[index];
+
+    if (line.trim() && getIndent(line) <= startIndent) {
+      endIndex = index;
+      break;
+    }
+  }
+
+  return lines.slice(startIndex, endIndex).join('\n');
+}
+
+function requireIncludes(source, expected, message) {
+  if (!source.includes(expected)) {
+    fail(message);
+  }
+}
+
+function requireAbsent(source, denied, message) {
+  if (source.includes(denied)) {
+    fail(message);
+  }
+}
+
+const concurrencyBlock = getBlock(/^concurrency:\s*$/, 'top-level concurrency');
+const verifyJob = getBlock(/^  verify:\s*$/, 'verify job');
+const publishJob = getBlock(/^  publish:\s*$/, 'publish job');
+
+requireIncludes(
+  concurrencyBlock,
+  'cancel-in-progress: false',
+  'Expected release concurrency to keep cancel-in-progress: false.'
+);
+
+requireIncludes(
+  verifyJob,
+  'npm run release:pr:check',
+  'Expected verify job to run npm run release:pr:check.'
+);
+requireIncludes(
+  verifyJob,
+  'npm pack --pack-destination artifacts',
+  'Expected verify job to create the package tarball in artifacts.'
+);
+requireIncludes(
+  verifyJob,
+  'node scripts/resolve-npm-tarball.mjs artifacts --expect-package-json package.json --github-output "$GITHUB_OUTPUT"',
+  'Expected verify job to resolve exactly one package tarball before upload.'
+);
+requireIncludes(
+  verifyJob,
+  'path: ${{ steps.packed-artifact.outputs.tarball }}',
+  'Expected verify job to upload the resolved package tarball only.'
+);
+
+requireIncludes(publishJob, 'needs: verify', 'Expected publish job to depend on verify.');
+requireIncludes(
+  publishJob,
+  'id-token: write',
+  'Expected publish job to request id-token: write for npm Trusted Publishing.'
+);
+requireIncludes(
+  publishJob,
+  'actions/download-artifact',
+  'Expected publish job to download the verified package artifact.'
+);
+requireIncludes(
+  publishJob,
+  'node scripts/resolve-npm-tarball.mjs artifacts --expect-package-json package.json --github-output "$GITHUB_OUTPUT"',
+  'Expected publish job to re-check exactly one package tarball before npm publish.'
+);
+requireIncludes(
+  publishJob,
+  'npm publish "${{ steps.publish-artifact.outputs.tarball }}" --access public',
+  'Expected npm publish to use the explicit resolved tarball path.'
+);
+requireIncludes(
+  publishJob,
+  'PUBLISHED_VERSION="$(npm_view_or_empty "$PACKAGE_SPEC" version)"',
+  'Expected post-publish verification to check the exact published package version.'
+);
+requireIncludes(
+  publishJob,
+  'dist-tags.latest',
+  'Expected post-publish verification to check dist-tags.latest.'
+);
+requireIncludes(
+  publishJob,
+  'repository.url',
+  'Expected post-publish verification to check repository.url.'
+);
+requireIncludes(
+  publishJob,
+  'engines.node',
+  'Expected post-publish verification to check engines.node.'
+);
+
+requireAbsent(
+  workflow,
+  'NPM_TOKEN',
+  'Release workflow must not use NPM_TOKEN for the normal publish path.'
+);
+requireAbsent(
+  workflow,
+  'NODE_AUTH_TOKEN',
+  'Release workflow must not use NODE_AUTH_TOKEN for the normal publish path.'
+);
+
+if (failures.length > 0) {
+  console.error('Release workflow verification failed:');
+
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+
+  process.exit(1);
+}
+
+console.log('Verified release workflow gates.');


### PR DESCRIPTION
## Summary

- Reuse a shared tarball resolver in the release workflow so verify and publish both enforce exactly one expected package tarball.
- Add local release workflow gate verification to `publish:check`, covering concurrency, verify-to-publish dependency, OIDC publishing, explicit tarball publish, and post-publish npm metadata checks.
- Expand release docs and the release PR template with Trusted Publishing, provenance, registry metadata, and verification-summary guidance.

## Validation

- `npm run verify`
- `npm run smoke:consumer`
- `npm run publish:check`
- `git diff --check`

## Notes

- No public API, runtime behavior, package version, or dependency changes.
- No `.private_docs` changes staged.
- Normal publish path remains npm Trusted Publishing / OIDC, without `NPM_TOKEN` or `NODE_AUTH_TOKEN`.