### PR TITLE
Clarify adoption evidence boundaries

### DIFF
--- a/.github/ISSUE_TEMPLATE/usage-report.yml
+++ b/.github/ISSUE_TEMPLATE/usage-report.yml
@@ -64,6 +64,7 @@ body:
     id: package-version
     attributes:
       label: Package version
+      description: Use the installed version, or write "Not installed yet" / "Not sure" if the report is still an evaluation.
       placeholder: "0.3.2"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/usage-report.yml
+++ b/.github/ISSUE_TEMPLATE/usage-report.yml
@@ -71,7 +71,7 @@ body:
     id: package-source
     attributes:
       label: Package source
-      description: Published npm installs are stronger evidence than local links or packed workspace tarballs.
+      description: Published npm installs are stronger evidence than local links or packed workspace tarballs. Maintainer-owned external demos should use the published package by version.
       options:
         - Published npm package
         - Packed tarball from this repository

--- a/.github/ISSUE_TEMPLATE/usage-report.yml
+++ b/.github/ISSUE_TEMPLATE/usage-report.yml
@@ -1,11 +1,11 @@
 name: Usage report
-description: Share real-world usage signals for product prioritization.
+description: Share usage or integration evidence for product prioritization.
 title: "usage: "
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for sharing how image-drop-input is being used. These reports help prioritize docs, compatibility, and release polish. They are product signals, not a showcase requirement.
+        Thanks for sharing concrete image-drop-input usage or integration evidence. These reports help prioritize docs, compatibility, and release polish. They are prioritization signals, not a showcase requirement.
 
         Please label the relationship honestly. A maintainer-owned demo that installs the published npm package can prove that the package works outside this repository, but it is not third-party adoption.
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/usage-report.yml
+++ b/.github/ISSUE_TEMPLATE/usage-report.yml
@@ -6,6 +6,33 @@ body:
     attributes:
       value: |
         Thanks for sharing how image-drop-input is being used. These reports help prioritize docs, compatibility, and release polish. They are product signals, not a showcase requirement.
+
+        Please label the relationship honestly. A maintainer-owned demo can prove that the published npm package works outside this repository, but it is not third-party adoption.
+  - type: dropdown
+    id: evidence-category
+    attributes:
+      label: Evidence category
+      description: Pick the closest fit. This keeps repo-maintained examples, maintainer-owned demos, third-party usage, and production-adjacent evidence separate.
+      options:
+        - Third-party evaluation
+        - Third-party product integration
+        - Production-adjacent case study
+        - Maintainer-owned external demo
+        - Repo-maintained example or report
+        - Other
+    validations:
+      required: true
+  - type: dropdown
+    id: reporter-relationship
+    attributes:
+      label: Reporter relationship
+      options:
+        - External user or evaluator
+        - Project contributor
+        - Maintainer
+        - Other
+    validations:
+      required: true
   - type: dropdown
     id: use-case
     attributes:
@@ -19,11 +46,37 @@ body:
         - Other
     validations:
       required: true
+  - type: dropdown
+    id: integration-status
+    attributes:
+      label: Integration status
+      description: This is about where the package was tried, not whether the product is public.
+      options:
+        - Evaluating
+        - Prototype or demo
+        - Internal/admin tool
+        - Staging product flow
+        - Production product flow
+        - Not applicable
+    validations:
+      required: true
   - type: input
     id: package-version
     attributes:
       label: Package version
       placeholder: "0.3.2"
+    validations:
+      required: true
+  - type: dropdown
+    id: package-source
+    attributes:
+      label: Package source
+      description: Published npm installs are stronger evidence than local links or packed workspace tarballs.
+      options:
+        - Published npm package
+        - Packed tarball from this repository
+        - Local workspace link
+        - Not sure
     validations:
       required: true
   - type: input
@@ -46,8 +99,9 @@ body:
       label: Integration mode
       options:
         - Local preview only
-        - Upload after prepare
-        - Both local preview and upload
+        - Prepare and upload
+        - Draft lifecycle
+        - Persistable guard only
         - Evaluating
     validations:
       required: true
@@ -60,6 +114,8 @@ body:
         - Presigned PUT
         - Multipart POST
         - Raw PUT
+        - App endpoint upload
+        - Mock/no upload
         - Custom adapter
         - Not sure yet
     validations:
@@ -83,6 +139,14 @@ body:
       placeholder: "Presign route, draft commit endpoint, discard endpoint, TTL cleanup..."
     validations:
       required: false
+  - type: input
+    id: public-evidence-link
+    attributes:
+      label: Public evidence link
+      description: Optional. Link a demo repo, public app page, docs page, issue, PR, or write-up only if it is safe to share.
+      placeholder: "https://github.com/owner/repo"
+    validations:
+      required: false
   - type: textarea
     id: what-worked
     attributes:
@@ -95,6 +159,27 @@ body:
     attributes:
       label: Pain points, missing docs, or adoption blockers
       description: What slowed adoption, caused uncertainty, or needed extra local code? Leave this blank if nothing blocked you.
+    validations:
+      required: false
+  - type: textarea
+    id: evidence-proves
+    attributes:
+      label: What does this evidence prove?
+      description: "Examples: published npm install works in Next.js, draft lifecycle matched the form boundary, or the persistable guard caught preview-only state."
+    validations:
+      required: false
+  - type: textarea
+    id: evidence-limits
+    attributes:
+      label: What does this evidence not prove?
+      description: "Examples: not a production endorsement, no real storage security review, no malware scanning, no CDN invalidation, or no public customer adoption."
+    validations:
+      required: false
+  - type: textarea
+    id: bug-prevention
+    attributes:
+      label: Did it prevent a real bug or reduce risk?
+      description: For example, avoided saving blob URLs, avoided deleting the previous image too early, or clarified the server transaction.
     validations:
       required: false
   - type: input

--- a/.github/ISSUE_TEMPLATE/usage-report.yml
+++ b/.github/ISSUE_TEMPLATE/usage-report.yml
@@ -7,7 +7,7 @@ body:
       value: |
         Thanks for sharing how image-drop-input is being used. These reports help prioritize docs, compatibility, and release polish. They are product signals, not a showcase requirement.
 
-        Please label the relationship honestly. A maintainer-owned demo can prove that the published npm package works outside this repository, but it is not third-party adoption.
+        Please label the relationship honestly. A maintainer-owned demo that installs the published npm package can prove that the package works outside this repository, but it is not third-party adoption.
   - type: dropdown
     id: evidence-category
     attributes:

--- a/README.md
+++ b/README.md
@@ -450,13 +450,17 @@ import {
 
 The root entry stays UI-first. Low-level utilities live under `/headless`.
 
-## Usage reports welcome
+## Adoption evidence
 
-Using this package in a real product? Open a [usage report](https://github.com/mt4110/image-drop-input/issues/new?template=usage-report.yml) so docs, compatibility, and release polish can be prioritized from real integrations.
+The project values concrete integration signals over download counts:
 
-Useful reports include the use case, framework or bundler, upload pattern, and anything that slowed adoption. Public quotation is opt-in.
+- [Repo-maintained integration report](./docs/integration-report.md): documents the single-image product form boundary against shipped APIs.
+- Maintainer-owned external demo: planned Next.js draft lifecycle repo that installs the published npm package by version. This will not be labeled as third-party adoption.
+- [Third-party usage reports](https://github.com/mt4110/image-drop-input/issues/new?template=usage-report.yml): public reports from users or evaluators outside the maintainer workflow.
 
-The project values evidence over download counts. See [docs/adoption-evidence.md](./docs/adoption-evidence.md) for what repo-maintained examples, separate demo repos, and third-party reports prove.
+Using this package in a real product or evaluating it for one? Open a usage report so docs, compatibility, and release polish can be prioritized from real integrations. Useful reports include the use case, framework or bundler, package source, upload pattern, what worked, and anything that slowed adoption. Public quotation is opt-in.
+
+See [docs/adoption-evidence.md](./docs/adoption-evidence.md) for what repo-maintained examples, maintainer-owned demos, third-party reports, and production-adjacent case studies prove.
 
 ## When not to use this
 

--- a/README.md
+++ b/README.md
@@ -458,7 +458,7 @@ Current repo-maintained evidence includes the [integration report](./docs/integr
 
 The next external evidence target is a maintainer-owned Next.js draft lifecycle demo that installs the published npm package by version. That can prove repo-external package consumption, not third-party adoption.
 
-Using this package in a real product or evaluating it for one? Open a [usage report](https://github.com/mt4110/image-drop-input/issues/new?template=usage-report.yml) so docs, compatibility, and release polish can be prioritized from concrete integration context. Useful reports include the relationship, use case, framework or bundler, package source, upload pattern, what worked, and anything that slowed adoption. Public quotation is opt-in.
+Using this package in a product, internal tool, or external demo, or evaluating it for one? Open a [usage report](https://github.com/mt4110/image-drop-input/issues/new?template=usage-report.yml) so docs, compatibility, and release polish can be prioritized from concrete integration context. Useful reports include the relationship, use case, framework or bundler, package source, upload pattern, what worked, and anything that slowed adoption. Public quotation is opt-in.
 
 See [docs/adoption-evidence.md](./docs/adoption-evidence.md) for what repo-maintained examples, maintainer-owned demos, third-party reports, and production-adjacent case studies prove.
 

--- a/README.md
+++ b/README.md
@@ -452,11 +452,11 @@ The root entry stays UI-first. Low-level utilities live under `/headless`.
 
 ## Adoption evidence
 
-The project values concrete integration signals over download counts:
+The project values concrete integration signals over download counts.
 
-- [Repo-maintained integration report](./docs/integration-report.md): documents the single-image product form boundary against shipped APIs.
-- Maintainer-owned external demo: planned Next.js draft lifecycle repo that installs the published npm package by version. This will not be labeled as third-party adoption.
-- [Third-party usage reports](https://github.com/mt4110/image-drop-input/issues/new?template=usage-report.yml): public reports from users or evaluators outside the maintainer workflow.
+Current repo-maintained evidence includes the [integration report](./docs/integration-report.md), which documents the single-image product form boundary against shipped APIs.
+
+The next external evidence target is a maintainer-owned Next.js draft lifecycle demo that installs the published npm package by version. Until there is a report from someone outside the maintainer workflow, it should not be read as third-party adoption.
 
 Using this package in a real product or evaluating it for one? Open a usage report so docs, compatibility, and release polish can be prioritized from real integrations. Useful reports include the use case, framework or bundler, package source, upload pattern, what worked, and anything that slowed adoption. Public quotation is opt-in.
 

--- a/README.md
+++ b/README.md
@@ -454,11 +454,11 @@ The root entry stays UI-first. Low-level utilities live under `/headless`.
 
 The project values concrete integration signals over download counts.
 
-Current repo-maintained evidence includes the [integration report](./docs/integration-report.md), which documents the single-image product form boundary against shipped APIs. It is not production evidence or a customer endorsement.
+Current repo-maintained evidence includes the [integration report](./docs/integration-report.md), which documents the single-image product form boundary against shipped APIs. It is not production-adjacent evidence or a customer endorsement.
 
 The next external evidence target is a maintainer-owned Next.js draft lifecycle demo that installs the published npm package by version. That can prove repo-external package consumption, not third-party adoption.
 
-Using this package in a real product or evaluating it for one? Open a [usage report](https://github.com/mt4110/image-drop-input/issues/new?template=usage-report.yml) so docs, compatibility, and release polish can be prioritized from real integrations. Useful reports include the relationship, use case, framework or bundler, package source, upload pattern, what worked, and anything that slowed adoption. Public quotation is opt-in.
+Using this package in a real product or evaluating it for one? Open a [usage report](https://github.com/mt4110/image-drop-input/issues/new?template=usage-report.yml) so docs, compatibility, and release polish can be prioritized from concrete integration context. Useful reports include the relationship, use case, framework or bundler, package source, upload pattern, what worked, and anything that slowed adoption. Public quotation is opt-in.
 
 See [docs/adoption-evidence.md](./docs/adoption-evidence.md) for what repo-maintained examples, maintainer-owned demos, third-party reports, and production-adjacent case studies prove.
 

--- a/README.md
+++ b/README.md
@@ -454,11 +454,11 @@ The root entry stays UI-first. Low-level utilities live under `/headless`.
 
 The project values concrete integration signals over download counts.
 
-Current repo-maintained evidence includes the [integration report](./docs/integration-report.md), which documents the single-image product form boundary against shipped APIs.
+Current repo-maintained evidence includes the [integration report](./docs/integration-report.md), which documents the single-image product form boundary against shipped APIs. It is not production evidence or a customer endorsement.
 
-The next external evidence target is a maintainer-owned Next.js draft lifecycle demo that installs the published npm package by version. Until there is a report from someone outside the maintainer workflow, it should not be read as third-party adoption.
+The next external evidence target is a maintainer-owned Next.js draft lifecycle demo that installs the published npm package by version. That can prove repo-external package consumption, not third-party adoption.
 
-Using this package in a real product or evaluating it for one? Open a usage report so docs, compatibility, and release polish can be prioritized from real integrations. Useful reports include the use case, framework or bundler, package source, upload pattern, what worked, and anything that slowed adoption. Public quotation is opt-in.
+Using this package in a real product or evaluating it for one? Open a [usage report](https://github.com/mt4110/image-drop-input/issues/new?template=usage-report.yml) so docs, compatibility, and release polish can be prioritized from real integrations. Useful reports include the relationship, use case, framework or bundler, package source, upload pattern, what worked, and anything that slowed adoption. Public quotation is opt-in.
 
 See [docs/adoption-evidence.md](./docs/adoption-evidence.md) for what repo-maintained examples, maintainer-owned demos, third-party reports, and production-adjacent case studies prove.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,7 +48,7 @@ Security, privacy, and adoption:
 - [Security model](./security.md): storage credentials, signed URLs, drafts, and product save boundaries
 - [Telemetry and privacy](./telemetry-and-privacy.md): safe error tags, redaction patterns, and product copy mapping
 - [Integration report](./integration-report.md): repo-maintained report for the single-image product form boundary
-- [Adoption evidence](./adoption-evidence.md): what external examples and usage reports prove
+- [Adoption evidence](./adoption-evidence.md): what repo-maintained examples, maintainer-owned demos, third-party reports, and case studies prove
 - [Release verification](./release-verification.md): packed package, npm metadata, provenance, and local verification checks
 - [Maintenance governance](./maintenance-governance.md): scope decisions, non-goals, and semver policy
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -48,7 +48,7 @@ Security, privacy, and adoption:
 - [Security model](./security.md): storage credentials, signed URLs, drafts, and product save boundaries
 - [Telemetry and privacy](./telemetry-and-privacy.md): safe error tags, redaction patterns, and product copy mapping
 - [Integration report](./integration-report.md): repo-maintained report for the single-image product form boundary
-- [Adoption evidence](./adoption-evidence.md): what repo-maintained examples, maintainer-owned demos, third-party reports, and case studies prove
+- [Adoption evidence](./adoption-evidence.md): what repo-maintained examples, maintainer-owned demos, third-party reports, and production-adjacent case studies prove
 - [Release verification](./release-verification.md): packed package, npm metadata, provenance, and local verification checks
 - [Maintenance governance](./maintenance-governance.md): scope decisions, non-goals, and semver policy
 

--- a/docs/adoption-evidence.md
+++ b/docs/adoption-evidence.md
@@ -40,13 +40,13 @@ Use these labels consistently:
 
 Do not relabel maintainer-owned work as third-party evidence. If the same person maintains both repositories, say so.
 
-## Current evidence
+## Current public materials
 
-| Evidence | Label | What it supports |
+| Material | Role | What it supports |
 | --- | --- | --- |
 | [Integration report](./integration-report.md) | Repo-maintained integration report | The single-image product form boundary is documented against shipped APIs. |
 | Consumer smoke fixtures | Repo-maintained verification | The packed package resolves in root TypeScript, headless CommonJS, and Vite React UI consumer shapes. |
-| [Usage report template](https://github.com/mt4110/image-drop-input/issues/new?template=usage-report.yml) | Evidence intake template | Reports can capture relationship, category, package source, framework, storage pattern, friction, and evidence limits. |
+| [Usage report template](https://github.com/mt4110/image-drop-input/issues/new?template=usage-report.yml) | Evidence intake | Reports can capture relationship, category, package source, framework, storage pattern, friction, and evidence limits. |
 
 ## External integration repo target
 
@@ -89,7 +89,7 @@ The external demo README should include:
 
 ## Usage reports
 
-Ask for usage reports when someone is using or evaluating the package in a real product. Useful reports include:
+Ask for usage reports when someone is using or evaluating the package in a product, internal tool, or external demo. Useful reports include:
 
 - package version
 - framework or bundler

--- a/docs/adoption-evidence.md
+++ b/docs/adoption-evidence.md
@@ -42,6 +42,8 @@ Do not relabel maintainer-owned work as third-party evidence. If the same person
 
 ## Current public materials
 
+These rows are not all adoption evidence. The role column keeps evidence, verification, and intake materials separate.
+
 | Material | Role | What it supports |
 | --- | --- | --- |
 | [Integration report](./integration-report.md) | Repo-maintained integration report | The single-image product form boundary is documented against shipped APIs. |

--- a/docs/adoption-evidence.md
+++ b/docs/adoption-evidence.md
@@ -19,7 +19,7 @@ Evidence should stay modest. A maintainer-owned demo can be useful without being
 | --- | --- | --- | --- |
 | 0 | Repo-maintained examples and recipes | Public APIs can be composed into supported flows. | Independent adoption or real app fit. |
 | 1 | Repo-maintained integration report | A documented product-form boundary is traceable to shipped APIs and verification checks. | Customer endorsement, benchmark quality, or storage-provider integration. |
-| 2 | Separate maintainer-owned integration repo | The published npm package works outside this repository in a realistic app shape. | Third-party adoption or production use. |
+| 2 | Maintainer-owned external demo repo | The published npm package works outside this repository in a realistic app shape. | Third-party adoption or production use. |
 | 3 | Third-party usage report | Someone outside the maintainer workflow evaluated or used the package and reported context. | Production maturity unless the report says so. |
 | 4 | Production-adjacent case study | A real app or internal tool describes workflow, storage pattern, blockers, and version used. | Universal fit, security review, compliance readiness, or long-term support guarantees. |
 | 5 | Downstream issue or PR from real integration | A real integration found a docs gap, compatibility edge, or product need. | Broad adoption by itself. |
@@ -46,7 +46,7 @@ Do not relabel maintainer-owned work as third-party evidence. If the same person
 | --- | --- | --- |
 | [Integration report](./integration-report.md) | Repo-maintained integration report | The single-image product form boundary is documented against shipped APIs. |
 | Consumer smoke fixtures | Repo-maintained verification | The packed package resolves in root TypeScript, headless CommonJS, and Vite React UI consumer shapes. |
-| [Usage report template](https://github.com/mt4110/image-drop-input/issues/new?template=usage-report.yml) | Third-party or production-adjacent intake | Reports can capture category, package source, framework, storage pattern, friction, and evidence limits. |
+| [Usage report template](https://github.com/mt4110/image-drop-input/issues/new?template=usage-report.yml) | Evidence intake template | Reports can capture relationship, category, package source, framework, storage pattern, friction, and evidence limits. |
 
 ## External integration repo target
 

--- a/docs/adoption-evidence.md
+++ b/docs/adoption-evidence.md
@@ -2,7 +2,7 @@
 
 Download counts are noisy. A smaller number of concrete integration signals is more useful than a vague download spike.
 
-This project values evidence that helps maintainers answer:
+This project values evidence that helps answer:
 
 - Which product workflow used the package?
 - Which framework, bundler, and React version were involved?
@@ -11,26 +11,46 @@ This project values evidence that helps maintainers answer:
 - What was confusing?
 - Which docs or tests would have reduced adoption risk?
 
+Evidence should stay modest. A maintainer-owned demo can be useful without being called third-party adoption.
+
 ## Evidence ladder
 
-| Level | Evidence | What it proves |
-| --- | --- | --- |
-| 0 | Repo-maintained examples and recipes | Public APIs can be composed into supported flows. |
-| 1 | Separate maintainer-owned integration repo | The published npm package works outside this repository. |
-| 2 | Third-party usage report | Someone outside the maintainer workflow evaluated or adopted it. |
-| 3 | Production-adjacent case study | A real app describes the workflow, storage pattern, blockers, and version used. |
+| Level | Evidence | What it can prove | What it does not prove |
+| --- | --- | --- | --- |
+| 0 | Repo-maintained examples and recipes | Public APIs can be composed into supported flows. | Independent adoption or real app fit. |
+| 1 | Repo-maintained integration report | A documented product-form boundary is traceable to shipped APIs and verification checks. | Customer endorsement, benchmark quality, or storage-provider integration. |
+| 2 | Separate maintainer-owned integration repo | The published npm package works outside this repository in a realistic app shape. | Third-party adoption or production use. |
+| 3 | Third-party usage report | Someone outside the maintainer workflow evaluated or used the package and reported context. | Production maturity unless the report says so. |
+| 4 | Production-adjacent case study | A real app or internal tool describes workflow, storage pattern, blockers, and version used. | Universal fit, security review, compliance readiness, or long-term support guarantees. |
+| 5 | Downstream issue or PR from real integration | A real integration found a docs gap, compatibility edge, or product need. | Broad adoption by itself. |
 
-Repo-maintained examples are useful, but they are not third-party adoption. Keep that distinction explicit.
+Repo-maintained examples are useful, but they are not third-party adoption. Keep that distinction explicit in issue titles, release notes, README links, and project boards.
+
+## Evidence labels
+
+Use these labels consistently:
+
+| Label | Use it for |
+| --- | --- |
+| Repo-maintained example | Examples, recipes, fixtures, and demos inside this repository. |
+| Repo-maintained integration report | A report written and maintained with this repository's docs and checks. |
+| Maintainer-owned external demo | A separate public repo owned by a maintainer that installs the published npm package. |
+| Third-party usage report | A report from someone outside the maintainer workflow. |
+| Production-adjacent case study | A real app, admin tool, or product workflow with enough context to describe risk and fit. |
+
+Do not relabel maintainer-owned work as third-party evidence. If the same person maintains both repositories, say so.
 
 ## Current evidence
 
-- [Integration report](./integration-report.md): repo-maintained report for the single-image product form boundary.
-- Consumer smoke fixtures: packed-package root types, headless CommonJS, and Vite React UI build.
-- Public usage report template: collects use case, framework, integration mode, upload pattern, and blockers.
+| Evidence | Label | What it supports |
+| --- | --- | --- |
+| [Integration report](./integration-report.md) | Repo-maintained integration report | The single-image product form boundary is documented against shipped APIs. |
+| Consumer smoke fixtures | Repo-maintained verification | The packed package resolves in root TypeScript, headless CommonJS, and Vite React UI consumer shapes. |
+| [Usage report template](https://github.com/mt4110/image-drop-input/issues/new?template=usage-report.yml) | Third-party or production-adjacent intake | Reports can capture category, package source, framework, storage pattern, friction, and evidence limits. |
 
 ## External integration repo target
 
-The first separate repo should install `image-drop-input` from npm by version and demonstrate:
+The first separate repo should be labeled as a maintainer-owned external demo unless ownership changes. It should install `image-drop-input` from npm by version and demonstrate:
 
 - Next.js App Router
 - product profile form
@@ -41,13 +61,31 @@ The first separate repo should install `image-drop-input` from npm by version an
 - product submit endpoint that commits draft and saves fields together
 - README that explains what the example proves and what it does not prove
 
-Suggested repository name:
+Suggested repository name and eventual link shape:
 
 ```txt
 image-drop-input-next-draft-demo
+https://github.com/mt4110/image-drop-input-next-draft-demo
 ```
 
-If the repo is maintainer-owned, label it that way. Do not call it third-party evidence.
+When the repo exists, link it with wording like:
+
+```md
+Maintainer-owned external demo: [Next.js draft lifecycle demo](https://github.com/mt4110/image-drop-input-next-draft-demo)
+```
+
+That wording proves the package was installed outside this repository. It does not claim third-party adoption.
+
+The external demo README should include:
+
+- exact package version tested
+- framework and React version
+- package source, ideally `npm install image-drop-input@x.y.z`
+- flow diagram for select, prepare, upload draft, commit, discard, and previous cleanup
+- mock backend boundaries and the production responsibilities left to the app
+- failure cases such as oversized output, failed draft upload, failed commit, discard failure, and expired draft
+- a "what this proves" section
+- a "what this does not prove" section
 
 ## Usage reports
 
@@ -63,3 +101,7 @@ Ask for usage reports when someone is using or evaluating the package in a real 
 - what docs were missing or unclear
 
 Public quotation is opt-in. Company, project name, and URL should stay optional.
+
+Reports should also say whether the package came from the published npm registry, a packed tarball, or a local workspace link. Published npm installs are stronger external evidence than local links.
+
+Good reports are allowed to include friction. "This was confusing" is more useful than vague praise because it points to docs, compatibility, or API boundaries that need work.

--- a/docs/integration-report.md
+++ b/docs/integration-report.md
@@ -6,6 +6,20 @@ This is a repo-maintained integration report for the public docs. It records how
 
 The target integration is deliberately narrow: one image field in a profile, workspace, CMS, or product form where the saved record must not confuse browser preview state, draft upload state, and durable product state.
 
+## Evidence classification
+
+| Field | Value |
+| --- | --- |
+| Evidence label | Repo-maintained integration report |
+| Maintainer-owned | Yes |
+| Third-party usage | No |
+| Production-adjacent | No |
+| Package surface | Public APIs and packaged docs |
+
+This report supports one modest claim: the documented single-image product form boundary can be assembled from shipped APIs without adding provider SDKs or changing the public API.
+
+It does not prove production adoption, storage security, malware scanning, CDN invalidation, customer endorsement, or suitability for multi-file upload products.
+
 ## Scenario
 
 A React product form starts with an existing image value from the server:

--- a/meta/design/P1-08-adoption-hardening.md
+++ b/meta/design/P1-08-adoption-hardening.md
@@ -128,12 +128,14 @@ Acceptance criteria:
 
 ### 4. Adoption proof
 
-The project already has a usage report template. The missing layer is at least one concrete report from a real integration.
+The project already has a usage report template and an evidence taxonomy. The missing layer is at least one concrete report from a real integration while keeping ownership and evidence strength explicit.
 
 Acceptance criteria:
 
-- Open one self-authored usage report from a real app or integration test repo.
+- Open one self-authored usage report from a real app or integration test repo, and label it as maintainer-owned unless ownership is independent.
 - Confirm at least one path from the docs works outside this repository, preferably Next.js App Router or React Hook Form/Zod.
+- For the next external demo target, use `image-drop-input-next-draft-demo`, install the published npm package by version, and link it as a maintainer-owned external demo.
+- Do not present a repo-maintained integration report or maintainer-owned external demo as third-party adoption, production evidence, or customer endorsement.
 - Link the report in release notes or maintainer notes only if it is useful and the report grants public quotation permission.
 - Treat pain points from the first report as docs or compatibility fixes before adding new features.
 
@@ -152,6 +154,6 @@ The v0.3 adoption hardening pass is done when:
 - a tokenless trusted publish path has been verified end to end
 - the main hook has a smaller upload orchestration boundary
 - upload failures can be classified without parsing English messages
-- at least one real usage report or equivalent integration proof exists
+- at least one real usage report or equivalent integration proof exists with relationship, package source, and evidence limits visible
 
 That is the bridge from "good package" to "safe dependency."


### PR DESCRIPTION
## Summary

- Separate repo-maintained integration reports, maintainer-owned external demos, third-party usage reports, and production-adjacent case studies in the adoption evidence docs.
- Tighten the README entry point so current evidence is useful without reading as production evidence or a customer endorsement.
- Expand the usage report intake around reporter relationship, package source, public evidence links, and evidence limits.
- Align the adoption hardening plan around the `image-drop-input-next-draft-demo` target and published npm installs by version.

## Validation

- `git diff --check`
- Issue Form YAML/schema sanity check: 23 body items, 22 field ids
- Local relative-link check across README and touched docs
- `npm run publish:check`