### PR TITLE
Harden maintenance governance

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -8,6 +8,8 @@ body:
     attributes:
       value: |
         Thanks for suggesting an improvement. Please describe the product workflow first; that makes it easier to keep the API small and predictable.
+
+        This project is focused on one product image field. Multi-file queues, resumable uploads, remote sources, storage provider SDK wrappers, storage-as-a-service behavior, and built-in cropper/editor UI are usually better handled by app code or dedicated uploader/editor tools.
   - type: dropdown
     id: use-case
     attributes:
@@ -42,18 +44,25 @@ body:
     validations:
       required: true
   - type: dropdown
-    id: lifecycle-boundary
+    id: scope-checklist
     attributes:
-      label: Product-state boundary
-      description: Which durable image-state boundary does this request improve?
+      label: Scope decision checklist item
+      description: Which governance reason does this request satisfy?
       options:
-        - Local preview vs saved value
-        - Prepared bytes vs source file
-        - Upload success vs product save success
-        - Draft commit/discard/cleanup
-        - Server schema or storage contract
-        - Release, docs, or consumer verification
-        - Not related to product image state
+        - Durable product image state
+        - Submit-boundary safety
+        - Byte-policy verification
+        - Draft commit/discard/cleanup correctness
+        - Explicit upload boundary without storage lock-in
+        - Adoption trust without expanding scope
+        - Not sure / may be outside scope
+    validations:
+      required: true
+  - type: textarea
+    id: governance-fit
+    attributes:
+      label: Governance fit
+      description: Explain how this satisfies the checklist item above. If you selected "Not sure / may be outside scope", describe why it still belongs in this project.
     validations:
       required: true
   - type: textarea
@@ -89,9 +98,9 @@ body:
     attributes:
       label: Scope check
       options:
-        - label: This request is for a single-image input workflow.
+        - label: This request is for one image field in a product workflow, not a generic upload queue.
           required: true
-        - label: This request does not require adding a cloud SDK to the runtime bundle.
+        - label: This request does not require adding a cloud SDK, storage service, remote source connector, or built-in image editor.
           required: true
-        - label: This request is about durable image state, byte policy, draft lifecycle, upload boundaries, docs, or verification.
+        - label: This request fits one checklist item above, or the issue explains why the governance policy should change.
           required: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ This repo values software that feels quiet and durable in everyday use.
 
 ## Scope decisions
 
-Before accepting a feature, answer:
+Before accepting a feature, answer the same checklist used by the issue template:
 
 1. Does it protect durable product image state?
 2. Does it improve submit-boundary safety?
@@ -84,14 +84,16 @@ Before accepting a feature, answer:
 5. Does it improve explicit upload boundaries without storage lock-in?
 6. Does it improve adoption trust without expanding scope?
 
-If the answer is no, reject or redirect the request. Multi-file queues, resumable upload orchestration, remote sources, storage SDK wrappers, built-in image editing, and storage-as-a-service behavior are out of scope.
+A yes should be concrete and tied to the requested behavior. If the answer is no, reject or redirect the request. Multi-file queues, resumable upload orchestration, remote sources, storage provider SDK wrappers, built-in image editing, and storage-as-a-service behavior are out of scope.
 
 See [docs/maintenance-governance.md](./docs/maintenance-governance.md) for response templates, suggested labels, and semver policy.
 
 ## Semver
 
+Public contracts include exported subpaths, component props, hook options and return types, render props, message and customization keys, `ImageUploadValue`, persistable value helpers, upload adapter contracts, validation and budget helpers, and documented error codes or fields used for narrowing.
+
 Patch releases may include bug fixes, docs fixes, CI hardening, and internal refactors that preserve public behavior.
 
-Minor releases may add helpers, recipes, optional public types, or new non-breaking error codes.
+Minor releases may add helpers, recipes, optional public types, optional props that preserve current defaults, or new non-breaking error codes.
 
-Major releases are required for breaking public type changes, persistable guard behavior changes, lifecycle phase changes that affect user code, removed exports, renamed exports, or stricter runtime requirements.
+Major releases are required for breaking public type changes, persistable guard behavior changes, lifecycle phase changes that affect user code, removed exports, renamed exports, changed defaults that alter existing app outcomes, or new required peer, browser, framework, or runtime requirements.

--- a/README.md
+++ b/README.md
@@ -405,6 +405,8 @@ Use `image-drop-input` when you need one image field that keeps browser-only pre
 | Multi-file queues, retries, remote sources, or editors | Uppy, FilePond, Uploady, or a provider widget |
 | Single-image form field with a durable image-state boundary | `image-drop-input` |
 
+Maintainers use the [maintenance governance guide](./docs/maintenance-governance.md) to evaluate whether new requests deepen this boundary or belong in app code and dedicated uploader/editor tools.
+
 ## Accessibility
 
 The default component includes keyboard operation, paste support, action labels, status text, and a focus-managed preview dialog. The headless hook exposes the same behavior when you need custom markup.
@@ -472,6 +474,7 @@ Use another tool if you need:
 - drag sorting between lists
 - full crop, rotate, or annotation editing
 - provider-specific SDK wrappers
+- storage-as-a-service behavior
 - Node-side image processing
 
 This package is intentionally single-image first.

--- a/docs/maintenance-governance.md
+++ b/docs/maintenance-governance.md
@@ -2,7 +2,9 @@
 
 The project should stay a product-safe React image field, not expand into a general uploader, storage service, or image editor.
 
-Use this checklist before accepting a feature:
+The goal is clarity, not gatekeeping. Accept work that deepens the single-image product-state boundary. Redirect work that mainly belongs to queue orchestration, storage ownership, source picking, or image editing.
+
+Use this checklist before accepting a feature. A "yes" should describe the direct user-facing boundary the change improves, not just a nearby convenience.
 
 1. Does it protect durable product image state?
 2. Does it improve submit-boundary safety?
@@ -11,11 +13,11 @@ Use this checklist before accepting a feature:
 5. Does it improve explicit upload boundaries without storage lock-in?
 6. Does it improve adoption trust without expanding scope?
 
-If the answer is no, reject or redirect the request.
+If the answer is no, reject or redirect the request. A docs-only recipe can still fit when it explains how an app can integrate an outside tool while keeping this package boundary unchanged.
 
 ## Non-goals
 
-Keep these out of scope:
+Redirect these to dedicated tools or app-owned code:
 
 - multi-file queues
 - resumable or chunked upload orchestration
@@ -32,8 +34,11 @@ Integration hooks are welcome when they preserve the boundary. For example, a co
 ## Suggested labels
 
 - `scope:product-state`
+- `scope:submit-boundary`
 - `scope:byte-policy`
 - `scope:draft-lifecycle`
+- `scope:upload-boundary`
+- `scope:adoption-trust`
 - `scope:docs`
 - `scope:ci-release`
 - `scope:out-of-scope`
@@ -42,6 +47,8 @@ Integration hooks are welcome when they preserve the boundary. For example, a co
 - `needs-usage-evidence`
 
 ## Response templates
+
+Use these as calm starting points. Add concrete context from the issue when possible, and offer a redirect when the request belongs in app code or a dedicated uploader/editor.
 
 Multi-file queues:
 
@@ -52,7 +59,7 @@ Thanks for the idea. Multi-file queues are intentionally out of scope. This pack
 Built-in cropper:
 
 ```md
-Thanks. Built-in cropping/editing is intentionally out of scope. The package may integrate with a cropper through `transform`, but it should not become an image editor.
+Thanks. Built-in cropping, rotating, annotation, and editing UI are intentionally out of scope. The package may integrate with a cropper through `transform`, but it should not become an image editor.
 ```
 
 Provider SDK wrapper:
@@ -61,7 +68,30 @@ Provider SDK wrapper:
 Thanks. Provider SDK wrappers are intentionally out of scope. The consuming app owns storage, auth, object keys, and signed URLs. This package provides explicit upload and draft lifecycle contracts without storage lock-in.
 ```
 
+Remote source picker:
+
+```md
+Thanks for the use case. Remote file sources are intentionally out of scope. The package works from browser-provided files and durable image values; URL import, media library, and third-party source pickers should live in app code or a dedicated uploader. A recipe can be considered if it shows that handoff without adding source connectors here.
+```
+
+Resumable upload:
+
+```md
+Thanks for laying this out. Resumable or chunked upload orchestration is intentionally out of scope. This package keeps a small upload adapter contract for one image field; chunk sessions, retry queues, checkpoints, and provider-specific resumable protocols should be owned by the app or a dedicated uploader. A recipe can be considered if it preserves the explicit product-save boundary.
+```
+
 ## Semver policy
+
+Treat these as public contracts:
+
+- root, `/headless`, and `/style.css` subpaths
+- exported component props, hook options, hook return types, render props, message keys, and customization types
+- `ImageUploadValue` shape and persistable value helper behavior
+- upload adapter types, upload factory inputs and outputs, progress, abort, and upload error contracts
+- validation, budget, transform, and metadata helper inputs and outputs
+- documented error codes and fields used for product copy, telemetry, retries, or type narrowing
+
+Docs wording, examples, tests, private implementation layout, and non-exported internals are not public contracts as long as documented behavior stays the same.
 
 Patch:
 
@@ -75,6 +105,7 @@ Minor:
 - new helpers
 - new docs recipes
 - new optional public types
+- new optional props or hook options that preserve current defaults
 - new error codes when existing narrowing remains safe
 
 Major:
@@ -83,6 +114,9 @@ Major:
 - behavior changes in persistable guards
 - lifecycle phase changes that affect user code
 - removal or rename of public exports
-- stricter runtime requirements
+- changed default validation, transform, upload, or cleanup behavior that can alter existing app outcomes
+- new required peer, runtime, browser, or framework requirements
+
+Adding an error code is minor only when existing code that handles known codes remains type-compatible and has a safe fallback path. If a new code invalidates exhaustive handling or changes when an existing code appears, treat it as major.
 
 Docs-only recipes can ship in any patch or minor release according to release context. Public runtime behavior changes need changelog notes and tests.


### PR DESCRIPTION
## Summary

- align the feature request template with the maintenance governance checklist
- clarify scope boundaries, non-goals, and rejection templates for uploader/editor/storage drift
- tighten semver guidance for public contracts and add README links to governance policy

## Validation

- `git diff --check`
- issue template YAML parse
- `npm run verify`
- `npm run smoke:consumer`