### PR TITLE
feat: complete persistable error taxonomy guard

### DIFF
--- a/consumer-fixtures/headless-cjs/index.cjs
+++ b/consumer-fixtures/headless-cjs/index.cjs
@@ -7,6 +7,7 @@ const expectedRootExports = [
   'ImageUploadError',
   'ImageValidationError',
   'assertPersistableImageValue',
+  'isImagePersistableValueError',
   'isImageUploadError',
   'isImageValidationError',
   'isPersistableImageValue',
@@ -28,6 +29,7 @@ const expectedHeadlessExports = [
   'getImageMetadata',
   'isImageBudgetError',
   'isImageDraftLifecycleError',
+  'isImagePersistableValueError',
   'isImageUploadError',
   'isImageValidationError',
   'isPersistableImageValue',
@@ -54,6 +56,7 @@ const requiredFunctions = [
   'ImageUploadError',
   'isImageUploadError',
   'ImagePersistableValueError',
+  'isImagePersistableValueError',
   'toPersistableImageValue',
   'assertPersistableImageValue',
   'isPersistableImageValue',
@@ -101,6 +104,11 @@ const lifecycleError = new headless.ImageDraftLifecycleError(
   'Draft uploads must return draftKey or key.',
   { phase: 'uploading-draft' }
 );
+const persistableError = new headless.ImagePersistableValueError(
+  'src_is_temporary',
+  'Temporary image src cannot be persisted.',
+  { field: 'src', srcProtocol: 'blob:' }
+);
 
 if (!headless.isImageUploadError(uploadError)) {
   throw new Error('Expected headless isImageUploadError to narrow ImageUploadError.');
@@ -116,6 +124,10 @@ if (!headless.isImageBudgetError(budgetError)) {
 
 if (!headless.isImageDraftLifecycleError(lifecycleError)) {
   throw new Error('Expected headless isImageDraftLifecycleError to narrow ImageDraftLifecycleError.');
+}
+
+if (!headless.isImagePersistableValueError(persistableError)) {
+  throw new Error('Expected headless isImagePersistableValueError to narrow ImagePersistableValueError.');
 }
 
 const persistableValue = headless.toPersistableImageValue({

--- a/consumer-fixtures/root-types/src/index.tsx
+++ b/consumer-fixtures/root-types/src/index.tsx
@@ -4,6 +4,7 @@ import {
   ImageUploadError,
   ImageValidationError,
   assertPersistableImageValue,
+  isImagePersistableValueError,
   isPersistableImageValue,
   isImageUploadError,
   isTemporaryImageSrc,
@@ -75,6 +76,7 @@ const persistableError = new ImagePersistableValueError(
 
 void node;
 void isImageUploadError(uploadError);
+void isImagePersistableValueError(persistableError);
 void isTemporaryImageSrc('blob:preview');
 void isPersistableImageValue(persistableValue);
 void assertPersistableImageValue(persistableValue);

--- a/docs/error-taxonomy.md
+++ b/docs/error-taxonomy.md
@@ -21,10 +21,10 @@ import { isImageValidationError } from 'image-drop-input';
 
 ## Persistable value errors
 
-Import the class and code types from the root entry:
+Import the guard from the root or `/headless` entry:
 
 ```ts
-import { ImagePersistableValueError } from 'image-drop-input';
+import { isImagePersistableValueError } from 'image-drop-input';
 ```
 
 | Code | Meaning |

--- a/docs/persistable-value.md
+++ b/docs/persistable-value.md
@@ -50,13 +50,16 @@ By default, the helper rejects values that cannot safely represent product state
 - invalid metadata such as negative `size` or `width: 0`
 
 ```tsx
-import { ImagePersistableValueError, toPersistableImageValue } from 'image-drop-input';
+import {
+  isImagePersistableValueError,
+  toPersistableImageValue
+} from 'image-drop-input';
 
 try {
   const image = toPersistableImageValue(value);
   await save({ image });
 } catch (error) {
-  if (error instanceof ImagePersistableValueError) {
+  if (isImagePersistableValueError(error)) {
     // Show product-specific copy or log error.code.
   }
 }

--- a/docs/telemetry-and-privacy.md
+++ b/docs/telemetry-and-privacy.md
@@ -64,7 +64,7 @@ function bucketBytes(size: number | undefined): SafeImageFieldTelemetry['sizeBuc
 
 ```ts
 import {
-  ImagePersistableValueError,
+  isImagePersistableValueError,
   isImageUploadError,
   isImageValidationError
 } from 'image-drop-input';
@@ -115,7 +115,7 @@ function toSafeImageTelemetry(error: unknown): SafeImageFieldTelemetry | null {
     };
   }
 
-  if (error instanceof ImagePersistableValueError) {
+  if (isImagePersistableValueError(error)) {
     return {
       package: 'image-drop-input',
       event: 'image.persistable_guard_failed',

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -66,7 +66,7 @@ import { isImageValidationError } from 'image-drop-input';
 
 function toMessage(error: Error) {
   if (!isImageValidationError(error)) {
-    return error.message;
+    return 'Could not prepare this image.';
   }
 
   switch (error.code) {
@@ -75,7 +75,7 @@ function toMessage(error: Error) {
     case 'invalid_type':
       return 'Choose a supported image type.';
     default:
-      return error.message;
+      return 'Choose a different image.';
   }
 }
 ```

--- a/src/core/persistable-image-value.ts
+++ b/src/core/persistable-image-value.ts
@@ -50,10 +50,61 @@ export class ImagePersistableValueError extends Error {
   }
 }
 
+const imagePersistableValueErrorCodeList = [
+  'preview_src_not_persistable',
+  'src_is_temporary',
+  'empty_reference',
+  'invalid_metadata'
+] as const satisfies readonly ImagePersistableValueErrorCode[];
+
+const imagePersistableValueErrorCodes = new Set<ImagePersistableValueErrorCode>(
+  imagePersistableValueErrorCodeList
+);
+
 const temporarySrcSchemes = new Set(['blob', 'filesystem', 'data']);
 
 function isObjectRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (!isObjectRecord(value)) {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+
+  return prototype === Object.prototype || prototype === null;
+}
+
+function hasOptionalString(
+  details: Record<string, unknown>,
+  key: keyof ImagePersistableValueErrorDetails
+): boolean {
+  return typeof details[key] === 'undefined' || typeof details[key] === 'string';
+}
+
+export function isImagePersistableValueError(
+  error: unknown
+): error is ImagePersistableValueError {
+  if (!isObjectRecord(error)) {
+    return false;
+  }
+
+  if (
+    error.name !== 'ImagePersistableValueError' ||
+    typeof error.message !== 'string' ||
+    typeof error.code !== 'string' ||
+    !imagePersistableValueErrorCodes.has(error.code as ImagePersistableValueErrorCode) ||
+    !isPlainRecord(error.details)
+  ) {
+    return false;
+  }
+
+  return (
+    hasOptionalString(error.details, 'field') &&
+    hasOptionalString(error.details, 'srcProtocol')
+  );
 }
 
 function getLowercaseScheme(src: string): string | null {

--- a/src/headless.ts
+++ b/src/headless.ts
@@ -48,6 +48,7 @@ export type {
 export {
   assertPersistableImageValue,
   ImagePersistableValueError,
+  isImagePersistableValueError,
   isPersistableImageValue,
   isTemporaryImageSrc,
   toPersistableImageValue

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ export { ImageValidationError, isImageValidationError } from './core/validate-im
 export {
   assertPersistableImageValue,
   ImagePersistableValueError,
+  isImagePersistableValueError,
   isPersistableImageValue,
   isTemporaryImageSrc,
   toPersistableImageValue

--- a/tests/core/persistable-image-value.test.ts
+++ b/tests/core/persistable-image-value.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   assertPersistableImageValue,
   ImagePersistableValueError,
+  isImagePersistableValueError,
   isPersistableImageValue,
   isTemporaryImageSrc,
   toPersistableImageValue
@@ -249,6 +250,61 @@ describe('persistable image value guards', () => {
     expect(() => assertPersistableImageValue({ src: 'data:image/png;base64,abc' })).toThrow(
       ImagePersistableValueError
     );
+  });
+
+  it('narrows persistable value errors without relying on instanceof', () => {
+    const error = new ImagePersistableValueError(
+      'src_is_temporary',
+      'Temporary image src cannot be persisted.',
+      {
+        field: 'src',
+        srcProtocol: 'blob:'
+      }
+    );
+
+    expect(isImagePersistableValueError(error)).toBe(true);
+    expect(
+      isImagePersistableValueError({
+        name: 'ImagePersistableValueError',
+        message: 'Persistable image values need a durable src or key.',
+        code: 'empty_reference',
+        details: {}
+      })
+    ).toBe(true);
+    expect(
+      isImagePersistableValueError({
+        name: 'ImagePersistableValueError',
+        message: 'Unknown code.',
+        code: 'unknown',
+        details: {}
+      })
+    ).toBe(false);
+    expect(
+      isImagePersistableValueError({
+        name: 'ImagePersistableValueError',
+        message: 'Invalid details.',
+        code: 'invalid_metadata',
+        details: {
+          field: 42
+        }
+      })
+    ).toBe(false);
+    expect(
+      isImagePersistableValueError({
+        name: 'ImagePersistableValueError',
+        message: 'Invalid details.',
+        code: 'invalid_metadata',
+        details: []
+      })
+    ).toBe(false);
+    expect(
+      isImagePersistableValueError({
+        name: 'ImagePersistableValueError',
+        message: 'Invalid details.',
+        code: 'invalid_metadata',
+        details: new Date()
+      })
+    ).toBe(false);
   });
 
   it('rejects undefined from assertPersistableImageValue before narrowing', () => {

--- a/tests/entrypoints.test.ts
+++ b/tests/entrypoints.test.ts
@@ -23,6 +23,7 @@ describe('package entrypoints', () => {
         "ImageUploadError",
         "ImageValidationError",
         "assertPersistableImageValue",
+        "isImagePersistableValueError",
         "isImageUploadError",
         "isImageValidationError",
         "isPersistableImageValue",
@@ -46,6 +47,7 @@ describe('package entrypoints', () => {
         "getImageMetadata",
         "isImageBudgetError",
         "isImageDraftLifecycleError",
+        "isImagePersistableValueError",
         "isImageUploadError",
         "isImageValidationError",
         "isPersistableImageValue",
@@ -70,6 +72,7 @@ describe('package entrypoints', () => {
     expect(root.ImageUploadError).toBeTypeOf('function');
     expect(root.isImageUploadError).toBeTypeOf('function');
     expect(root.ImagePersistableValueError).toBeTypeOf('function');
+    expect(root.isImagePersistableValueError).toBeTypeOf('function');
     expect(root.toPersistableImageValue).toBeTypeOf('function');
     expect(root.assertPersistableImageValue).toBeTypeOf('function');
     expect(root.isPersistableImageValue).toBeTypeOf('function');
@@ -97,6 +100,7 @@ describe('package entrypoints', () => {
     expect(headless.ImageUploadError).toBeTypeOf('function');
     expect(headless.isImageUploadError).toBeTypeOf('function');
     expect(headless.ImagePersistableValueError).toBeTypeOf('function');
+    expect(headless.isImagePersistableValueError).toBeTypeOf('function');
     expect(headless.toPersistableImageValue).toBeTypeOf('function');
     expect(headless.assertPersistableImageValue).toBeTypeOf('function');
     expect(headless.isPersistableImageValue).toBeTypeOf('function');


### PR DESCRIPTION
## Summary

- Add `isImagePersistableValueError()` for the persistable value error family.
- Export the guard from both the root and `/headless` entrypoints alongside `ImagePersistableValueError`.
- Update entrypoint tests, persistable error tests, consumer fixtures, and docs examples to use code-based typed narrowing.

## Why

Persistable value errors already had stable codes and a public error class, but lacked the matching family guard available for validation, budget, upload, and draft lifecycle errors. This completes the taxonomy parity without changing existing error codes or broadening upload/provider scope.

## Validation

- `npm test -- tests/core/persistable-image-value.test.ts tests/entrypoints.test.ts`
- `npm run verify`
- `npm run smoke:consumer`
- `git diff --check`