### PR TITLE
chore: tighten package face verification

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -69,7 +69,7 @@ Use these sources for context:
    ```
 
    This includes release workflow gate checks, the packed package face check, temporary tarball creation, README inclusion,
-   package metadata links, exact tarball count, and deny-list validation for files that must stay out of the published tarball.
+   package description, core keywords, metadata links, exact tarball count, and deny-list validation for files that must stay out of the published tarball.
 
    To isolate the tarball gate locally:
 

--- a/docs/release-verification.md
+++ b/docs/release-verification.md
@@ -18,7 +18,7 @@ What they cover:
 | --- | --- |
 | `npm run verify` | Typecheck, unit tests, example builds, package linting, and type resolution checks. |
 | `npm run smoke:consumer` | Packs the package and installs it into root type, headless CJS, and Vite React UI consumer fixtures. |
-| `npm run publish:check` | Verifies release workflow gates, then creates a temporary package tarball and checks manifest metadata, included docs, exact tarball count, metadata links, and deny-listed files. |
+| `npm run publish:check` | Verifies release workflow gates, then creates a temporary package tarball and checks package description, core keywords, included docs, exact tarball count, metadata links, and deny-listed files. |
 
 To reproduce the release workflow tarball gate locally:
 

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "keywords": [
     "react",
     "react-component",
+    "product-safe-image-field",
     "product-image-field",
     "image-field",
     "image-input",
@@ -69,6 +70,7 @@
     "object-storage",
     "webp",
     "avatar-upload",
+    "durable-image-state",
     "cms"
   ],
   "sideEffects": [

--- a/scripts/verify-pack-manifest.mjs
+++ b/scripts/verify-pack-manifest.mjs
@@ -16,6 +16,8 @@ const expectedPackageTarballName = packageJson.name.replace(/^@/, '').replace('/
 const expectedTarballFilename = `${expectedPackageTarballName}-${packageJson.version}.tgz`;
 const tempDirectoryPrefix = packageJson.name.replace(/[^a-zA-Z0-9._-]/g, '-');
 const packDestination = mkdtempSync(join(tmpdir(), `${tempDirectoryPrefix}-pack-`));
+const canonicalPackageDescription =
+  'Product-safe React image field for durable image state, byte-budget preparation, explicit uploads, and draft lifecycle.';
 const npmPackArgs = [
   'pack',
   '--json',
@@ -24,6 +26,7 @@ const npmPackArgs = [
   '--workspaces=false'
 ];
 const expectedMetadata = [
+  ['description', packageJson.description, canonicalPackageDescription],
   ['homepage', packageJson.homepage, 'https://mt4110.github.io/image-drop-input/'],
   ['repository.type', packageJson.repository?.type, 'git'],
   [
@@ -67,6 +70,14 @@ const deniedPatterns = [
 ];
 const canonicalReadmeTitle = '# image-drop-input';
 const canonicalReadmeSummary = 'A product-safe React image field.';
+const requiredKeywords = new Set([
+  'product-safe-image-field',
+  'image-field',
+  'persistable-image',
+  'image-draft',
+  'byte-budget',
+  'durable-image-state'
+]);
 const failures = [];
 
 function fail(message) {
@@ -240,6 +251,19 @@ function verifyPackageJsonMetadata() {
   }
 }
 
+function verifyPackageKeywords() {
+  if (!Array.isArray(packageJson.keywords)) {
+    fail('Expected package.json keywords to be an array.');
+    return;
+  }
+
+  for (const keyword of requiredKeywords) {
+    if (!packageJson.keywords.includes(keyword)) {
+      fail(`Expected package.json keywords to include ${keyword}.`);
+    }
+  }
+}
+
 function verifyReadmeFace(files) {
   if (!files.has('README.md')) {
     fail('Expected README.md to be included in the packed package.');
@@ -300,6 +324,7 @@ if (packResult) {
   verifyPackMetadata(packResult);
   verifyTarballArtifact(packResult);
   verifyPackageJsonMetadata();
+  verifyPackageKeywords();
   verifyFiles(files);
   verifyReadmeFace(files);
 


### PR DESCRIPTION
## Summary
- add product-safe image field keywords to package metadata
- verify package description and core keywords during publish checks
- align release docs with the stronger package face check

## Verification
- npm run verify
- npm run smoke:consumer
- npm run publish:check
- git diff --check

## Notes
- no version or public API changes
- no release or publish action performed
- .private_docs remains unstaged and unmodified