### PR TITLE
docs: strengthen public security threat model

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -32,7 +32,8 @@ Temporary `blob:` preview URLs are UI state only and should not be persisted as 
 
 ## Threat Model Notes
 
-The package helps with browser-side image intake, prepared bytes, explicit uploads, draft lifecycle state, and persistable payload guards. It does not make storage, product records, or server authorization safe by itself.
+The public product threat model is maintained in [docs/security.md](./docs/security.md).
+In short, the package helps with browser-side image intake, prepared bytes, explicit uploads, draft lifecycle state, and persistable payload guards. It does not make storage, product records, or server authorization safe by itself.
 
 Consuming applications should protect:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,7 +45,7 @@ Recipes:
 
 Security, privacy, and adoption:
 
-- [Security model](./security.md): storage credentials, signed URLs, drafts, and product save boundaries
+- [Security model](./security.md): practical threat model for temporary URLs, signed URLs, drafts, cleanup, and server authority
 - [Telemetry and privacy](./telemetry-and-privacy.md): safe error tags, redaction patterns, and product copy mapping
 - [Integration report](./integration-report.md): repo-maintained report for the single-image product form boundary
 - [Adoption evidence](./adoption-evidence.md): what repo-maintained examples, maintainer-owned demos, third-party reports, and production-adjacent case studies prove

--- a/docs/security.md
+++ b/docs/security.md
@@ -21,6 +21,20 @@ The consuming app still owns:
 - previous-image cleanup and expired-draft TTL cleanup
 - malware scanning, CDN invalidation, and audit logging when required
 
+## Practical threat model
+
+These are the product-image risks this package is designed to make visible. The client can help keep state separated, but the server remains the authority for storage, ownership, and product persistence.
+
+| Risk | What can go wrong | Product-safe response |
+| --- | --- | --- |
+| Temporary URL persistence | A local `blob:`, `data:`, or `filesystem:` URL is saved as product data and later fails to render, or leaks browser-only state into records. | Treat previews as UI state. Use `toPersistableImageValue()` before submit, and reject temporary URL schemes again in the server schema. Persist only durable `src` or `key` values. |
+| Signed URL leakage | A signed upload URL appears in analytics, error traces, screenshots, or product records while it can still grant storage access. | Create signed URLs on the app server, keep them short-lived and scoped, never log them, and never infer `publicUrl` from `uploadUrl`. |
+| Draft token leakage | A `draftToken` copied into logs, client errors, or rendered markup can be reused against commit or discard while it is valid. | Treat draft tokens as secrets. Send them only to commit/discard endpoints, keep them short-lived and single-purpose, and require a valid user session as well. |
+| Unauthorized commit | A client submits another user's `draftKey`, a stale `draftToken`, or a misleading `previousKey`. | Validate session, tenant, product permission, draft ownership, purpose, token, expiry, object existence, and current product state on the server. Treat browser-sent previous values as hints only. |
+| Previous cleanup timing | The previous committed image is deleted after upload but before the replacement is saved, leaving the product record without its last good image. | Enqueue previous cleanup only after the new image and product record are durably committed. Make cleanup idempotent, and do not roll back the new image if cleanup fails. |
+| Orphan drafts | The user closes the tab, loses network, cancels during navigation, or unmounts before client discard finishes. | Use client discard for a better steady state, but require server-side TTL cleanup for expired uncommitted drafts and draft metadata. |
+| Client metadata trust | A malicious or stale client sends incorrect MIME type, size, dimensions, purpose, or object identity. | Use client metadata for UX only. Re-check policy on the server and, before final commit, confirm the uploaded object bytes and server-side metadata match what the product accepts. |
+
 ## Sensitive values
 
 Do not log:


### PR DESCRIPTION
## Summary

- Add a practical product-image threat model to `docs/security.md`
- Cover temporary URLs, signed upload URLs, draft tokens, unauthorized commit, previous cleanup timing, orphan drafts, and client metadata trust
- Link the public security model from `SECURITY.md`
- Keep the scope limited to docs with no API, dependency, or package version changes

## Validation

- `npm run verify`
- `npm run smoke:consumer`
- `npm run publish:check`
- `git diff --check`

## Merge request

Ready for review and merge. This is a docs-only change based on `main` after PR #44 (`57839a1`).