### PR TITLE
release: 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 Notable changes for `image-drop-input` are tracked here.
 
+## 0.3.3 - 2026-05-07
+
+### Added
+
+- Added server-side persistable image schema recipes and a transaction-focused product submit recipe for draft image replacement flows.
+- Added public security, telemetry/privacy, adoption evidence, and maintenance governance docs for product-safe image field usage.
+- Added `ImagePersistableValueError` and `isImagePersistableValueError()` for stable persistable payload guard handling.
+
+### Changed
+
+- Hardened the byte-budget solver internals while preserving the public API and deterministic failure reporting.
+- Strengthened draft lifecycle docs around commit/save consistency, previous cleanup timing, and orphan draft cleanup.
+- Tightened release and package-face verification for packed package metadata and release workflow gates.
+
 ## 0.3.2 - 2026-05-03
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "image-drop-input",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "image-drop-input",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "license": "MIT",
       "workspaces": [
         "examples/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "image-drop-input",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Product-safe React image field for durable image state, byte-budget preparation, explicit uploads, and draft lifecycle.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

- release version: 0.3.3
- dist-tag: latest
- scope: product-safe boundary hardening, public docs, release verification, and persistable guard handling

## Highlights

- Adds server-side persistable image schema recipes and a transaction-focused product submit recipe for draft replacement flows
- Adds public security, telemetry/privacy, adoption evidence, and maintenance governance docs
- Adds `ImagePersistableValueError` and `isImagePersistableValueError()` for stable persistable payload guard handling
- Hardens byte-budget solver internals while preserving the public API
- Tightens release and package-face verification for packed package metadata and release workflow gates

## Verification Summary

- Local checks: `npm run release:pr:check`, `npm run smoke:consumer`, `git diff --check`
- Release rehearsal: Release run `25498244649` passed with `publish=false` and resolved exactly one tarball: `./artifacts/image-drop-input-0.3.3.tgz`
- Publish: Release run `25498335118` passed with `publish=true`, used the `npm-publish` environment, and published the explicit tarball path
- Registry metadata: exact version, `dist-tags.latest`, `repository.url`, and `engines.node` matched `package.json`
- Provenance: npm registry exposes SLSA provenance for `image-drop-input@0.3.3`; `npm audit signatures --include-attestations` verified registry signatures and attestation

## Checks

- [x] `package.json` and `package-lock.json` carry the intended version
- [x] `CHANGELOG.md` includes the release-facing notes
- [x] release-facing notes are included in the PR body
- [x] `npm run release:pr:check`
- [x] packed package contains the English canonical `README.md`, docs, license, dist files, and no local-only files
- [x] consumer smoke and UI fixture build passed

## Publish Readiness

- [x] npm Trusted Publisher is configured for `mt4110/image-drop-input`, workflow filename `release.yml`, and environment `npm-publish`
- [x] the release workflow uses OIDC for publish and does not depend on `NPM_TOKEN` or `NODE_AUTH_TOKEN`

## Publish Plan

- [x] merge to `main`
- [x] run the `Release` workflow from `main` with `publish` off and confirm the rehearsal passed
- [x] confirm the rehearsal resolved exactly one package tarball artifact
- [x] rerun the `Release` workflow from `main` with `publish` on
- [x] confirm the publish run resolved exactly one package tarball before `npm publish`
- [x] confirm `npm publish` used the explicit resolved tarball path
- [x] confirm the publish job used the `npm-publish` environment

## Post-publish Checks

- [x] npm package page version matches `package.json` on `main`
- [x] `npm view image-drop-input@0.3.3 version` matches `package.json`
- [x] `npm view image-drop-input dist-tags.latest` matches the released version
- [x] `npm view image-drop-input@0.3.3 repository.url` matches `package.json`
- [x] `npm view image-drop-input@0.3.3 engines.node` matches `package.json`
- [x] npm package README starts with the English canonical `README.md`
- [x] npm install snippet is `npm install image-drop-input react`
- [x] npm homepage metadata points to the GitHub Pages demo
- [x] npm repository metadata points to `mt4110/image-drop-input`
- [x] npm bugs metadata points to the GitHub issue tracker
- [x] docs link is present in the npm README
- [x] npm provenance is visible for the published version
- [x] npm provenance details point back to the expected GitHub workflow run and `main` commit

## Notes

- breaking changes: none
- follow-up work: optional npm package page visual spot-check in browser