### PR TITLE
docs: sync GitHub release surface checks

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -59,6 +59,10 @@
 - [ ] docs link from the npm README opens successfully
 - [ ] npm provenance is visible for the published version
 - [ ] npm provenance details point back to the expected GitHub workflow run
+- [ ] GitHub Release `v<version>` exists
+- [ ] GitHub Releases marks `v<version>` as Latest when it matches npm `dist-tags.latest`
+- [ ] GitHub release notes include the same release-facing highlights as `CHANGELOG.md`
+- [ ] GitHub release notes include the release verification summary
 - [ ] if this is the first trusted publish, the old npm automation token is revoked and removed from GitHub Actions secrets or environment secrets
 - [ ] if this is the first trusted publish, npm publishing access requires 2FA and disallows tokens
 - [ ] initial usage report follow-up is linked in Notes or explicitly queued

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -127,6 +127,14 @@ Use these sources for context:
    - provenance is visible for the published version
    - the provenance details point back to the expected GitHub workflow run
 
+   GitHub release surface:
+
+   - the GitHub release tag is `v` followed by the published npm version, for example `v0.3.3`
+   - the GitHub release title is the plain version tag, for example `v0.3.3`
+   - the GitHub release is marked as Latest when it matches `dist-tags.latest`
+   - the GitHub release notes include the same release-facing highlights as `CHANGELOG.md`
+   - the GitHub release notes include the verification summary from the release workflow
+
    Registry metadata commands:
 
    ```bash

--- a/docs/release-verification.md
+++ b/docs/release-verification.md
@@ -107,6 +107,30 @@ Manual checks:
 - repository and bugs links point to `mt4110/image-drop-input`.
 - provenance is visible for the published version.
 - provenance points back to the expected GitHub workflow run.
+- GitHub Releases latest matches the npm `dist-tags.latest` version.
+- GitHub release notes carry the same highlights as `CHANGELOG.md`.
+- GitHub release notes include the release verification summary.
+
+## GitHub release surface
+
+The npm registry, `package.json`, git tag, `CHANGELOG.md`, and GitHub Releases page are all public release surfaces. Keep them aligned for each published version.
+
+After publish, verify:
+
+```bash
+PACKAGE=image-drop-input
+VERSION="$(node -p 'require("./package.json").version')"
+
+test "$(npm view "$PACKAGE" dist-tags.latest)" = "$VERSION"
+gh release view "v$VERSION" --repo mt4110/image-drop-input --json tagName,name,publishedAt,url
+test "$(
+  gh release list --repo mt4110/image-drop-input --limit 1 --json tagName,isLatest \
+    --jq ".[0] | select(.tagName == \"v$VERSION\" and .isLatest == true) | .tagName"
+)" = "v$VERSION"
+gh release list --repo mt4110/image-drop-input --limit 5
+```
+
+The GitHub release for `v$VERSION` should be the latest release when npm `latest` points at the same version. If npm is already published but the GitHub release entry is missing, create or update the GitHub release without publishing a new npm version.
 
 ## Provenance verification
 


### PR DESCRIPTION
## Summary

- Add GitHub Release checks to the release PR template.
- Document GitHub Releases as a public release surface alongside npm, `package.json`, git tags, and `CHANGELOG.md`.
- Clarify that a missing GitHub Release entry should be repaired without publishing a new npm version.

## Why

`image-drop-input@0.3.3` is published on npm and tagged locally, while GitHub Releases still shows `v0.3.2` as Latest. This docs/checklist update makes that class of release-surface drift explicit in future releases.

## Validation

- `npm run publish:check`

## Follow-up

- Create or update GitHub Release `v0.3.3` and mark it as Latest so it matches npm `dist-tags.latest`.
