### PR TITLE
docs: link external draft lifecycle demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ The [claim ledger](./docs/claim-ledger.md) maps public claims to evidence,
 disproof paths, and proof status.
 It keeps the project honest about what is proven, partially proven, or not proven yet.
 
-The next external evidence target is a maintainer-owned Next.js draft lifecycle demo that installs the published npm package by version. That can prove repo-external package consumption, not third-party adoption.
+Current external evidence includes a maintainer-owned [Next.js draft lifecycle demo](https://github.com/mt4110/image-drop-input-next-draft-demo) that installs `image-drop-input@0.3.3` from npm by version. That proves repo-external package consumption, not third-party adoption.
 
 Using this package in a product, internal tool, or external demo, or evaluating it for one? Open a [usage report](https://github.com/mt4110/image-drop-input/issues/new?template=usage-report.yml) so docs, compatibility, and release polish can be prioritized from concrete integration context. Useful reports include the relationship, use case, framework or bundler, package source, upload pattern, what worked, and anything that slowed adoption. Public quotation is opt-in.
 

--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ The [claim ledger](./docs/claim-ledger.md) maps public claims to evidence,
 disproof paths, and proof status.
 It keeps the project honest about what is proven, partially proven, or not proven yet.
 
-Current external evidence includes a maintainer-owned [Next.js draft lifecycle demo](https://github.com/mt4110/image-drop-input-next-draft-demo) that installs `image-drop-input@0.3.3` from npm by version. That proves repo-external package consumption, not third-party adoption.
+Current external evidence includes a maintainer-owned [Next.js draft lifecycle demo](https://github.com/mt4110/image-drop-input-next-draft-demo) that installs `image-drop-input` from npm by version. That proves repo-external package consumption, not third-party adoption.
 
 Using this package in a product, internal tool, or external demo, or evaluating it for one? Open a [usage report](https://github.com/mt4110/image-drop-input/issues/new?template=usage-report.yml) so docs, compatibility, and release polish can be prioritized from concrete integration context. Useful reports include the relationship, use case, framework or bundler, package source, upload pattern, what worked, and anything that slowed adoption. Public quotation is opt-in.
 

--- a/docs/adoption-evidence.md
+++ b/docs/adoption-evidence.md
@@ -56,7 +56,7 @@ These rows are not all adoption evidence. The role column keeps evidence, verifi
 The separate demo repo is labeled as a maintainer-owned external demo because it is owned by the maintainer. It installs the published `image-drop-input` package from npm by version and demonstrates:
 
 - Next.js App Router
-- product image form
+- single-image product form
 - draft upload mock backend
 - commit endpoint
 - discard endpoint

--- a/docs/adoption-evidence.md
+++ b/docs/adoption-evidence.md
@@ -47,15 +47,16 @@ These rows are not all adoption evidence. The role column keeps evidence, verifi
 | Material | Role | What it supports |
 | --- | --- | --- |
 | [Integration report](./integration-report.md) | Repo-maintained integration report | The single-image product form boundary is documented against shipped APIs. |
+| [Next.js draft lifecycle demo](https://github.com/mt4110/image-drop-input-next-draft-demo) | Maintainer-owned external demo | The published npm package installs and builds outside this repository in a realistic App Router draft lifecycle shape. |
 | Consumer smoke fixtures | Repo-maintained verification | The packed package resolves in root TypeScript, headless CommonJS, and Vite React UI consumer shapes. |
 | [Usage report template](https://github.com/mt4110/image-drop-input/issues/new?template=usage-report.yml) | Evidence intake | Reports can capture relationship, category, package source, framework, storage pattern, friction, and evidence limits. |
 
-## External integration repo target
+## Maintainer-owned external demo
 
-The first separate repo should be labeled as a maintainer-owned external demo unless ownership changes. It should install `image-drop-input` from npm by version and demonstrate:
+The first separate repo is labeled as a maintainer-owned external demo because it is owned by the maintainer. It installs `image-drop-input@0.3.3` from npm by version and demonstrates:
 
 - Next.js App Router
-- product profile form
+- product image form
 - draft upload mock backend
 - commit endpoint
 - discard endpoint
@@ -63,22 +64,13 @@ The first separate repo should be labeled as a maintainer-owned external demo un
 - product submit endpoint that commits draft and saves fields together
 - README that explains what the example proves and what it does not prove
 
-Suggested repository name and eventual link shape:
+Maintainer-owned external demo:
 
-```txt
-image-drop-input-next-draft-demo
-https://github.com/mt4110/image-drop-input-next-draft-demo
-```
-
-When the repo exists, link it with wording like:
-
-```md
-Maintainer-owned external demo: [Next.js draft lifecycle demo](https://github.com/mt4110/image-drop-input-next-draft-demo)
-```
+[`image-drop-input-next-draft-demo`](https://github.com/mt4110/image-drop-input-next-draft-demo)
 
 That wording proves the package was installed outside this repository. It does not claim third-party adoption.
 
-The external demo README should include:
+The external demo README includes:
 
 - exact package version tested
 - framework and React version

--- a/docs/adoption-evidence.md
+++ b/docs/adoption-evidence.md
@@ -53,7 +53,7 @@ These rows are not all adoption evidence. The role column keeps evidence, verifi
 
 ## Maintainer-owned external demo
 
-The first separate repo is labeled as a maintainer-owned external demo because it is owned by the maintainer. It installs `image-drop-input@0.3.3` from npm by version and demonstrates:
+The separate demo repo is labeled as a maintainer-owned external demo because it is owned by the maintainer. It installs the published `image-drop-input` package from npm by version and demonstrates:
 
 - Next.js App Router
 - product image form

--- a/docs/claim-ledger.md
+++ b/docs/claim-ledger.md
@@ -202,7 +202,7 @@ Each entry checks a claim or boundary statement. Entries marked "Not claimed" do
 ### Product-form integration shape
 
 - Claim checked: The documented single-image product form boundary can be assembled from shipped APIs.
-- Evidence level: Repo-maintained report, Maintainer-owned external demo
+- Evidence level: Public docs, Repo-maintained report, Maintainer-owned external demo
 - Evidence: [integration report](./integration-report.md), [Next.js draft lifecycle recipe](./recipes/nextjs-draft-lifecycle.md), [product submit recipe](./recipes/product-submit-with-image-draft.md), [Next.js draft lifecycle demo](https://github.com/mt4110/image-drop-input-next-draft-demo).
 - Disproof path: The flow requires unshipped APIs, provider SDKs, or undocumented behavior.
 - Status: Partially proven

--- a/docs/claim-ledger.md
+++ b/docs/claim-ledger.md
@@ -205,7 +205,7 @@ Each entry checks a claim or boundary statement. Entries marked "Not claimed" do
 - Evidence level: Repo-maintained report, Maintainer-owned external demo
 - Evidence: [integration report](./integration-report.md), [Next.js draft lifecycle recipe](./recipes/nextjs-draft-lifecycle.md), [product submit recipe](./recipes/product-submit-with-image-draft.md), [Next.js draft lifecycle demo](https://github.com/mt4110/image-drop-input-next-draft-demo).
 - Disproof path: The flow requires unshipped APIs, provider SDKs, or undocumented behavior.
-- Status: Proven
+- Status: Partially proven
 
 ### Maintainer-owned external demo
 

--- a/docs/claim-ledger.md
+++ b/docs/claim-ledger.md
@@ -202,18 +202,18 @@ Each entry checks a claim or boundary statement. Entries marked "Not claimed" do
 ### Product-form integration shape
 
 - Claim checked: The documented single-image product form boundary can be assembled from shipped APIs.
-- Evidence level: Repo-maintained report
-- Evidence: [integration report](./integration-report.md), [Next.js draft lifecycle recipe](./recipes/nextjs-draft-lifecycle.md), [product submit recipe](./recipes/product-submit-with-image-draft.md).
+- Evidence level: Repo-maintained report, Maintainer-owned external demo
+- Evidence: [integration report](./integration-report.md), [Next.js draft lifecycle recipe](./recipes/nextjs-draft-lifecycle.md), [product submit recipe](./recipes/product-submit-with-image-draft.md), [Next.js draft lifecycle demo](https://github.com/mt4110/image-drop-input-next-draft-demo).
 - Disproof path: The flow requires unshipped APIs, provider SDKs, or undocumented behavior.
-- Status: Partially proven
+- Status: Proven
 
 ### Maintainer-owned external demo
 
 - Claim checked: A maintainer-owned external demo installs the published npm package outside this repository.
-- Evidence level: None yet
-- Evidence: [adoption evidence](./adoption-evidence.md) describes the target evidence.
+- Evidence level: Maintainer-owned external demo
+- Evidence: [Next.js draft lifecycle demo](https://github.com/mt4110/image-drop-input-next-draft-demo), [adoption evidence](./adoption-evidence.md).
 - Disproof path: No separate public repo exists, or it uses a local workspace link instead of npm.
-- Status: Not proven
+- Status: Proven
 
 ### Third-party adoption
 


### PR DESCRIPTION
## Summary
- Link the public maintainer-owned Next.js draft lifecycle demo from the package README.
- Update adoption evidence and claim ledger labels so the README, docs, and proof status stay aligned.
- Keep third-party adoption and production-adjacent usage unproven.

## Verification
- npm run publish:check
- npm run verify