### PR TITLE
Harden evidence ledger and WebKit lab notes

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -13,7 +13,7 @@ body:
     attributes:
       label: Package version
       description: The installed image-drop-input version.
-      placeholder: "0.2.x"
+      placeholder: "0.3.x"
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/usage-report.yml
+++ b/.github/ISSUE_TEMPLATE/usage-report.yml
@@ -8,6 +8,7 @@ body:
         Thanks for sharing concrete image-drop-input usage or integration evidence. These reports help prioritize docs, compatibility, and release polish. They are prioritization signals, not a showcase requirement.
 
         Please label the relationship honestly. A maintainer-owned demo that installs the published npm package can prove that the package works outside this repository, but it is not third-party adoption.
+        If you are outside the maintainer workflow, friction and missing-docs notes are especially useful. Critical reports can still be third-party usage evidence.
   - type: dropdown
     id: evidence-category
     attributes:
@@ -26,6 +27,7 @@ body:
     id: reporter-relationship
     attributes:
       label: Reporter relationship
+      description: Choose Maintainer or Project contributor if that is your relationship, even when the report is for an external demo or owner-created proof.
       options:
         - External user or evaluator
         - Project contributor
@@ -65,7 +67,7 @@ body:
     attributes:
       label: Package version
       description: Use the installed version, or write "Not installed yet" / "Not sure" if the report is still an evaluation.
-      placeholder: "0.3.2"
+      placeholder: "0.3.x"
     validations:
       required: true
   - type: dropdown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,14 @@ Notable changes for `image-drop-input` are tracked here.
 - Added a browser byte-budget lab for Chromium and Firefox with a manual GitHub Actions workflow.
 - Added backend reference protocol docs for atomic submit, idempotency, stale previous defense, and cleanup workers.
 - Added supply-chain security docs, dependency review workflow coverage, and CodeQL default setup guidance.
+- Added a WebKit browser install helper for exploratory browser budget lab runs.
+- Added links to the public external usage report request and tightened usage report intake copy.
 
 ### Changed
 
 - Strengthened release verification docs, release checklist, and package manifest output with tarball summary details.
+- Refined claim ledger statuses to separate positioning and public-boundary claims from behavioral proof.
+- Recorded the WebKit exploratory browser budget result as unproven because Playwright WebKit 26.4 could not encode the lab's WebP policy in the local run.
 
 ## 0.3.3 - 2026-05-07
 

--- a/README.md
+++ b/README.md
@@ -468,7 +468,9 @@ It keeps the project honest about what is proven, partially proven, or not prove
 
 Current external evidence includes a maintainer-owned [Next.js draft lifecycle demo](https://github.com/mt4110/image-drop-input-next-draft-demo) that installs `image-drop-input` from npm by version. That proves repo-external package consumption, not third-party adoption.
 
-Using this package in a product, internal tool, or external demo, or evaluating it for one? Open a [usage report](https://github.com/mt4110/image-drop-input/issues/new?template=usage-report.yml) so docs, compatibility, and release polish can be prioritized from concrete integration context. Useful reports include the relationship, use case, framework or bundler, package source, upload pattern, what worked, and anything that slowed adoption. Public quotation is opt-in.
+No public non-maintainer usage report is linked yet. The project should not claim third-party adoption or production-adjacent usage until a report from outside the maintainer workflow supports that label.
+
+Using this package in a product, internal tool, or external demo, or evaluating it for one? Open a [usage report](https://github.com/mt4110/image-drop-input/issues/new?template=usage-report.yml) or respond from the [external usage report request](https://github.com/mt4110/image-drop-input/issues/51) so docs, compatibility, and release polish can be prioritized from concrete integration context. Useful reports include the relationship, use case, framework or bundler, package source, upload pattern, what worked, and anything that slowed adoption. Critical feedback is welcome, and public quotation is opt-in.
 
 See [docs/adoption-evidence.md](./docs/adoption-evidence.md) for what repo-maintained examples, maintainer-owned demos, third-party reports, and production-adjacent case studies prove.
 

--- a/docs/adoption-evidence.md
+++ b/docs/adoption-evidence.md
@@ -50,6 +50,15 @@ These rows are not all adoption evidence. The role column keeps evidence, verifi
 | [Next.js draft lifecycle demo](https://github.com/mt4110/image-drop-input-next-draft-demo) | Maintainer-owned external demo | The published npm package installs and builds outside this repository in a realistic App Router draft lifecycle shape. |
 | Consumer smoke fixtures | Repo-maintained verification | The packed package resolves in root TypeScript, headless CommonJS, and Vite React UI consumer shapes. |
 | [Usage report template](https://github.com/mt4110/image-drop-input/issues/new?template=usage-report.yml) | Evidence intake | Reports can capture relationship, category, package source, framework, storage pattern, friction, and evidence limits. |
+| [External usage report request](https://github.com/mt4110/image-drop-input/issues/51) | Evidence intake | Public request for a non-maintainer report. The request itself is not third-party evidence. |
+
+## Current third-party status
+
+No public non-maintainer usage report is linked yet.
+
+Current public evidence stops at the maintainer-owned external demo level until a report arrives from someone outside the maintainer workflow. Maintainer-created reports, owner-created issues, and maintainer-owned demo repositories can still be useful evidence, but they must not satisfy the third-party usage report gate.
+
+This status is intentional. It keeps the evidence ladder useful without turning a request for feedback into an adoption claim.
 
 ## Maintainer-owned external demo
 
@@ -99,3 +108,27 @@ Public quotation is opt-in. Company, project name, and URL should stay optional.
 Reports should also say whether the package came from the published npm registry, a packed tarball, or a local workspace link. Published npm installs are stronger external evidence than local links.
 
 Good reports are allowed to include friction. "This was confusing" is more useful than vague praise because it points to docs, compatibility, or API boundaries that need work.
+
+## First external request
+
+Use a request that asks for a concrete workflow and leaves room for critical feedback:
+
+```txt
+Could you try the product-safe replacement flow in a small form and open a usage report with what confused you?
+Praise is optional. Friction is more useful.
+```
+
+Ask for a public usage report when the reporter is comfortable sharing one. Do not ask for stars, endorsements, or private praise as a substitute for integration context.
+
+## After a third-party report arrives
+
+Keep the update sequence evidence-led:
+
+1. Confirm the reporter relationship is outside the maintainer workflow.
+2. Confirm the report names the package version, package source, framework or bundler, React version when known, use case, upload pattern, friction, and evidence limits.
+3. Link follow-up docs, tests, or issues that came from the report. Critical feedback is valid evidence when it changes the project.
+4. Update this page with a new row under current public materials using the label `Third-party usage report`.
+5. Update [claim ledger](./claim-ledger.md) only for the claim the report actually supports. A third-party evaluation can prove that a non-maintainer evaluated the package; it does not prove production use.
+6. Update the README adoption evidence section with the same label and limitations. Do not describe the report as customer adoption, production maturity, or endorsement unless the report explicitly supports that.
+
+If the report comes from a maintainer, contributor, or maintainer-owned repository, keep it below the third-party usage report level and say so.

--- a/docs/browser-budget-lab.md
+++ b/docs/browser-budget-lab.md
@@ -11,7 +11,7 @@ Byte-identical output across browsers is not claimed.
 
 ## Command
 
-Install the default Playwright browsers once:
+Install the Chromium and Firefox browsers once:
 
 ```bash
 npm run browser:budget-lab:install

--- a/docs/browser-budget-lab.md
+++ b/docs/browser-budget-lab.md
@@ -11,7 +11,7 @@ Byte-identical output across browsers is not claimed.
 
 ## Command
 
-Install the Playwright browsers once:
+Install the default Playwright browsers once:
 
 ```bash
 npm run browser:budget-lab:install
@@ -26,6 +26,7 @@ npm run browser:budget-lab
 To include WebKit in an exploratory run:
 
 ```bash
+npm run browser:budget-lab:install:webkit
 npm run browser:budget-lab -- --browsers=chromium,firefox,webkit
 ```
 
@@ -89,6 +90,30 @@ npm run browser:budget-lab -- --browsers=chromium,firefox
 | Firefox | transparent png resize | passed | image/png | 2574 | 256x256 | resize | 1 |
 | Firefox | tiny image is not upscaled | passed | image/webp | 72 | 48x32 | quality-search | 1 |
 | Firefox | budget-unreachable reports attempts | passed | image/webp | 0 | 0x0 | expected-error | 3 |
+
+## Current WebKit exploratory run
+
+Run date: 2026-05-08 JST.
+
+Setup:
+
+```bash
+npm run browser:budget-lab:install:webkit
+```
+
+Command:
+
+```bash
+npm run browser:budget-lab -- --browsers=chromium,firefox,webkit --json-output=.artifacts/browser-budget-lab-webkit.json --markdown-output=.artifacts/browser-budget-lab-webkit.md
+```
+
+Result:
+
+| Engine | Status | Finding | Claim impact |
+| --- | --- | --- | --- |
+| WebKit 26.4 (Playwright `webkit` v2272) | failed | `ImageBudgetError: This browser cannot encode image/webp.` | WebKit is not part of the verified browser budget matrix. Do not market WebKit byte-budget support yet. |
+
+This is a useful negative result. It shows that the WebP policies used by the current lab are not portable to this WebKit environment, so the WebKit claim should stay unproven until a stable pass path exists or WebKit-specific policy limits are documented.
 
 ## CI policy
 

--- a/docs/claim-ledger.md
+++ b/docs/claim-ledger.md
@@ -8,7 +8,9 @@ It is deliberately conservative. A claim can be useful without being fully prove
 
 | Status | Meaning |
 | --- | --- |
-| Proven | Covered by shipped API behavior, tests, and public docs inside the stated package boundary. |
+| Positioned | Public docs and package metadata consistently define the category. This is a positioning claim, not behavioral proof. |
+| Publicly bounded | Public docs define a scope boundary or non-goal. This limits marketing language, but is not a runtime proof. |
+| Proven | Covered by shipped API behavior, tests, package metadata, or another directly inspectable artifact inside the stated package boundary. |
 | Partially proven | Supported by repo-maintained docs or tests, but missing broader evidence such as browser matrix, model tests, or external usage. |
 | Not proven | No qualifying evidence yet. The project should not market this as true. |
 | Not claimed | The checked claim is deliberately outside the package scope. |
@@ -23,6 +25,7 @@ It is deliberately conservative. A claim can be useful without being fully prove
 | Consumer smoke | Verified through packed-package consumer fixtures. |
 | Repo-maintained report | A maintainer-authored report tying shipped APIs together. |
 | Maintainer-owned external demo | Separate maintainer-owned repo installing the published npm package. |
+| Exploratory local run | Dated maintainer run that can reveal support gaps, but does not upgrade a matrix claim by itself. |
 | Third-party report | Usage report from someone outside the maintainer workflow. |
 | Production-adjacent case study | Real app or internal tool report with workflow, constraints, and evidence limits. |
 | None yet | No qualifying evidence exists yet. |
@@ -33,11 +36,11 @@ Each entry checks a claim or boundary statement. Entries marked "Not claimed" do
 
 ### Product-safe image field category
 
-- Claim checked: The package is a product-safe React image field for single-image forms.
-- Evidence level: Public docs
-- Evidence: [README](../README.md), [docs index](./README.md), [maintenance governance](./maintenance-governance.md).
+- Claim checked: Public docs position the package as a product-safe React image field for single-image forms.
+- Evidence level: Public docs, Package metadata
+- Evidence: [README](../README.md), [docs index](./README.md), [maintenance governance](./maintenance-governance.md), [package metadata](../package.json).
 - Disproof path: Public docs or defaults reposition it as a generic queue, editor, provider SDK, or multi-file uploader.
-- Status: Proven
+- Status: Positioned
 
 ### Preview state boundary
 
@@ -69,7 +72,7 @@ Each entry checks a claim or boundary statement. Entries marked "Not claimed" do
 - Evidence level: Public docs
 - Evidence: [persistable value guard](./persistable-value.md), [backend contracts](./backend-contracts.md), [security model](./security.md).
 - Disproof path: Docs imply client validation replaces server authorization, storage checks, or product persistence rules.
-- Status: Proven
+- Status: Publicly bounded
 
 ### Provider SDK boundary
 
@@ -114,9 +117,9 @@ Each entry checks a claim or boundary statement. Entries marked "Not claimed" do
 ### WebKit browser budget matrix
 
 - Claim checked: Browser byte-budget behavior has been verified across WebKit.
-- Evidence level: None yet
-- Evidence: WebKit is available as an exploratory `--browsers=webkit` target but is not part of the current documented pass matrix.
-- Disproof path: No stable WebKit lab run exists, or WebKit fails the documented success/error expectations.
+- Evidence level: Exploratory local run
+- Evidence: [browser budget lab](./browser-budget-lab.md). A 2026-05-08 JST WebKit 26.4 exploratory run failed with `ImageBudgetError: This browser cannot encode image/webp.` WebKit remains outside the current documented pass matrix.
+- Disproof path: The recorded exploratory WebKit run cannot encode the WebP policies used by the lab, no stable WebKit pass artifact exists, or WebKit fails the documented success/error expectations.
 - Status: Not proven
 
 ### Upload and durable state boundary
@@ -215,12 +218,20 @@ Each entry checks a claim or boundary statement. Entries marked "Not claimed" do
 - Disproof path: No separate public repo exists, or it uses a local workspace link instead of npm.
 - Status: Proven
 
+### Third-party usage report
+
+- Claim checked: A non-maintainer usage report exists.
+- Evidence level: None yet
+- Evidence: [usage report template](https://github.com/mt4110/image-drop-input/issues/new?template=usage-report.yml), [external usage report request](https://github.com/mt4110/image-drop-input/issues/51), [adoption evidence](./adoption-evidence.md). No public non-maintainer usage report is linked yet; the request issue is intake, not evidence.
+- Disproof path: No non-maintainer usage report or downstream integration evidence exists.
+- Status: Not proven
+
 ### Third-party adoption
 
-- Claim checked: Third-party adoption exists.
+- Claim checked: Third-party product integration exists.
 - Evidence level: None yet
-- Evidence: [usage report template](https://github.com/mt4110/image-drop-input/issues/new?template=usage-report.yml), [adoption evidence](./adoption-evidence.md).
-- Disproof path: No non-maintainer usage report or downstream integration evidence exists.
+- Evidence: [adoption evidence](./adoption-evidence.md) defines the evidence level and report update path. No third-party product integration report is linked yet.
+- Disproof path: No non-maintainer report describes a product, internal tool, public demo, or downstream integration that used the package.
 - Status: Not proven
 
 ### Production-adjacent usage
@@ -251,4 +262,4 @@ Each entry checks a claim or boundary statement. Entries marked "Not claimed" do
 
 Update this ledger when a public claim changes, when new tests prove a boundary, or when external evidence arrives.
 
-Do not upgrade an adoption claim from "not proven" without a linked maintainer-owned external demo, third-party report, or production-adjacent case study.
+Do not upgrade a third-party or production-adjacent claim from "not proven" without a linked non-maintainer usage report or production-adjacent case study. Keep maintainer-owned external demos in their own evidence level.

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "smoke:consumer": "npm run pack:consumer-smoke && npm run smoke:consumer:root-types && npm run smoke:consumer:headless-cjs && npm run smoke:consumer:vite-react-ui:run",
     "browser:budget-lab": "npm run build:lib && node scripts/run-browser-budget-lab.mjs",
     "browser:budget-lab:install": "playwright install chromium firefox",
+    "browser:budget-lab:install:webkit": "playwright install webkit",
     "publish:check": "node scripts/verify-release-workflow.mjs && node scripts/verify-pack-manifest.mjs",
     "release:pr:check": "npm run verify && npm run publish:check",
     "typecheck:examples": "npm run typecheck --workspace examples/vite && npm run typecheck --workspace examples/rsbuild",


### PR DESCRIPTION
## Summary

- refine the claim ledger status taxonomy so category positioning and public boundaries are not treated as behavioral proof
- document the WebKit exploratory browser budget result as unproven after the local Playwright WebKit run failed on WebP encoding
- link the external usage report request while keeping it clearly labeled as intake, not third-party evidence
- add a WebKit Playwright install helper and refresh issue template package version placeholders

## Self-review notes

- Kept third-party usage and production-adjacent claims at `Not proven`; issue #51 is explicitly not evidence.
- Avoided broad WebKit support claims by limiting the finding to the recorded exploratory run.
- Kept `Product-safe image field category` as `Positioned` instead of `Proven` because it is a category claim.
## Validation

- `git diff --check`
- `npm run verify`
- `npm run browser:budget-lab -- --browsers=chromium,firefox`
- `npm run publish:check`
- `npm run smoke:consumer`
