### PR TITLE
release: 0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Notable changes for `image-drop-input` are tracked here.
 
 ## Unreleased
 
+## 0.3.4 - 2026-05-08
+
 ### Added
 
 - Added a claim ledger, durable image boundary narrative, draft lifecycle state machine, and lifecycle model invariant tests.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "image-drop-input",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "image-drop-input",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "MIT",
       "workspaces": [
         "examples/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "image-drop-input",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Product-safe React image field for durable image state, byte-budget preparation, explicit uploads, and draft lifecycle.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

- release version: `0.3.4`
- dist-tag: `latest`
- scope: claim ledger taxonomy, WebKit exploratory lab notes, external usage report intake, and release surface docs from the merged evidence hardening work

## Highlights

- Refines claim ledger statuses so positioning and public-boundary claims are not treated as behavioral proof.
- Records the WebKit exploratory browser budget result as unproven after the local Playwright WebKit run failed on WebP encoding.
- Links the public external usage report request while keeping it explicitly labeled as intake, not third-party evidence.
- Adds a WebKit browser install helper for exploratory browser budget lab runs.

## Verification Summary

- Local checks: `npm run release:pr:check`, `npm run smoke:consumer`, `npm run browser:budget-lab -- --browsers=chromium,firefox`
- Release rehearsal: pending until merged to `main`
- Publish path: npm Trusted Publishing / OIDC via `release.yml` after merge
- Registry metadata: pending publish
- Provenance: pending publish
- Tarball summary: 58 files, `image-drop-input-0.3.4.tgz`, packed 215672 bytes, unpacked 615085 bytes
- Browser budget lab: Chromium and Firefox passed; WebKit remains exploratory and unproven

## Checks

- [x] `package.json` and `package-lock.json` carry the intended version
- [x] `CHANGELOG.md` includes the release-facing notes
- [x] release-facing notes are included in the PR body
- [x] `npm run release:pr:check`
- [x] `npm run browser:budget-lab -- --browsers=chromium,firefox`
- [x] packed package contains the English canonical `README.md`, docs, license, dist files, and no local-only files
- [x] release notes include tarball file count, tarball filename, packed size, and unpacked size from `npm run publish:check`
- [x] `npm run smoke:consumer`

## Publish Readiness

- [x] npm Trusted Publisher is configured for `mt4110/image-drop-input`, workflow filename `release.yml`, and environment `npm-publish`
- [x] the release workflow uses OIDC for publish and does not depend on `NPM_TOKEN` or `NODE_AUTH_TOKEN`

## Publish Plan

- [ ] merge to `main`
- [ ] run the `Release` workflow from `main` with `publish` off and confirm the rehearsal passed
- [ ] confirm the rehearsal resolved exactly one package tarball artifact
- [ ] create signed tag `v0.3.4` on the merged release commit
- [ ] create GitHub Release `v0.3.4` and publish it to trigger npm publish
- [ ] confirm `npm publish` used the explicit resolved tarball path
- [ ] confirm the publish job used the `npm-publish` environment

## Notes

- breaking changes: none
- follow-up work: external non-maintainer usage report is still pending; issue #51 is only intake, not evidence.
