### PR TITLE
Publish releases only from manual workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -47,6 +47,7 @@
 - [ ] confirm the publish run resolved exactly one package tarball before `npm publish`
 - [ ] confirm `npm publish` used the explicit resolved tarball path
 - [ ] confirm the publish job used the `npm-publish` environment
+- [ ] create or update GitHub Release `v<version>` after npm publish succeeds
 
 ## Post-publish Checks
 
@@ -65,6 +66,7 @@
 - [ ] npm provenance details point back to the expected GitHub workflow run
 - [ ] GitHub Release `v<version>` exists
 - [ ] GitHub Releases marks `v<version>` as Latest when it matches npm `dist-tags.latest`
+- [ ] publishing or editing the GitHub Release did not start an npm publish run
 - [ ] GitHub release notes include the same release-facing highlights as `CHANGELOG.md`
 - [ ] GitHub release notes include the release verification summary
 - [ ] GitHub release notes include the tarball summary from the release checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
 name: Release
 
 on:
-  release:
-    types:
-      - published
   workflow_dispatch:
     inputs:
       publish:
@@ -79,7 +76,7 @@ jobs:
 
   publish:
     needs: verify
-    if: ${{ github.event_name == 'release' || github.event.inputs.publish == 'true' }}
+    if: ${{ github.event.inputs.publish == 'true' }}
     runs-on: ubuntu-latest
     environment: npm-publish
     permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes for `image-drop-input` are tracked here.
 
 ## Unreleased
 
+### Changed
+
+- Changed the release workflow to publish only from manual `workflow_dispatch` runs with `publish=true`, preventing GitHub Release publication from attempting a duplicate npm publish.
+
 ## 0.3.4 - 2026-05-08
 
 ### Added

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -100,12 +100,14 @@ Use these sources for context:
    Use a short release branch and a neutral title such as `release/0.2.0` and `release: 0.2.0`.
    If you create a GitHub release entry, keep that title plain too, for example `v0.2.0`.
 
-5. After the release PR is merged to `main`, run the GitHub `Release` workflow:
+5. After the release PR is merged to `main`, run the GitHub `Release` workflow manually:
 
    - first with `publish` turned off for a rehearsal; this runs the verification job, confirms there is exactly one package tarball, and stores that checked tarball as a short-lived workflow artifact
    - then with `publish` turned on for the real publish; this enters the `npm-publish` environment, confirms the downloaded artifact still contains exactly one package tarball, and publishes that resolved tarball path with OIDC
    - after publish, the workflow reads npm registry metadata for the package version, `latest` dist-tag, repository URL, and Node engine floor
    - use the workflow summary as the source for the release verification summary
+
+   Do not use GitHub Release publication as the npm publish trigger. The GitHub Release should be created or updated after the manual publish workflow succeeds, using the already-pushed signed tag.
 
 6. After publishing, complete the release follow-up checklist.
 
@@ -133,6 +135,7 @@ Use these sources for context:
    - the GitHub release tag is `v` followed by the published npm version, for example `v0.3.3`
    - the GitHub release title is the plain version tag, for example `v0.3.3`
    - the GitHub release is marked as Latest when it matches `dist-tags.latest`
+   - publishing or editing the GitHub release does not attempt to publish the same package version to npm
    - the GitHub release notes include the same release-facing highlights as `CHANGELOG.md`
    - the GitHub release notes include the verification summary from the release workflow
    - the GitHub release notes include the tarball summary from `npm run publish:check`

--- a/docs/release-verification.md
+++ b/docs/release-verification.md
@@ -49,6 +49,8 @@ Keep these stable unless a release intentionally changes them:
 `.github/workflows/release.yml` should keep these properties:
 
 - release concurrency is enabled with `cancel-in-progress: false`
+- the publish job runs only from `workflow_dispatch` with `publish=true`
+- publishing a GitHub Release does not attempt to publish the same package version to npm
 - publish waits for verify
 - verify creates exactly one tarball
 - publish downloads exactly one tarball
@@ -142,6 +144,8 @@ gh release list --repo mt4110/image-drop-input --limit 5
 ```
 
 The GitHub release for `v$VERSION` should be the latest release when npm `latest` points at the same version. If npm is already published but the GitHub release entry is missing, create or update the GitHub release without publishing a new npm version.
+
+GitHub Releases are release notes and discovery surfaces, not the npm publish trigger. Publish to npm through the manual `Release` workflow first, then create or update the GitHub Release for the already-published version.
 
 ## Provenance verification
 

--- a/scripts/verify-release-workflow.mjs
+++ b/scripts/verify-release-workflow.mjs
@@ -58,6 +58,88 @@ function getBlock(headerPattern, label) {
   return lines.slice(startIndex, endIndex).join('\n');
 }
 
+function stripYamlComment(line) {
+  let quote;
+
+  for (let index = 0; index < line.length; index += 1) {
+    const character = line[index];
+
+    if (quote) {
+      if (character === quote) {
+        quote = undefined;
+      }
+
+      continue;
+    }
+
+    if (character === '"' || character === "'") {
+      quote = character;
+      continue;
+    }
+
+    if (character === '#') {
+      return line.slice(0, index);
+    }
+  }
+
+  return line;
+}
+
+function getTopLevelKeyBlock(key, label) {
+  const keyPattern = new RegExp(`^${key}\\s*:`);
+  const startIndex = lines.findIndex((line) => {
+    return getIndent(line) === 0 && keyPattern.test(stripYamlComment(line).trim());
+  });
+
+  if (startIndex === -1) {
+    fail(`Expected release workflow to include ${label}.`);
+    return '';
+  }
+
+  let endIndex = lines.length;
+
+  for (let index = startIndex + 1; index < lines.length; index += 1) {
+    const line = lines[index];
+
+    if (line.trim() && getIndent(line) === 0) {
+      endIndex = index;
+      break;
+    }
+  }
+
+  return lines.slice(startIndex, endIndex).join('\n');
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function hasYamlTrigger(triggerBlock, triggerName) {
+  const escapedTriggerName = escapeRegExp(triggerName);
+  const quotedTriggerName = `(?:"${escapedTriggerName}"|'${escapedTriggerName}'|${escapedTriggerName})`;
+  const mappingKeyPattern = new RegExp(`^${quotedTriggerName}\\s*:`);
+  const listItemPattern = new RegExp(`^[-?]\\s*${quotedTriggerName}(?:\\s*:|\\s|$|,)`);
+  const inlineMappingPattern = new RegExp(`(?:^|[{,])\\s*${quotedTriggerName}\\s*:`);
+  const inlineListPattern = new RegExp(`\\[(?:[^\\]]*,\\s*)*${quotedTriggerName}(?:\\s*,|\\s*\\])`);
+  const scalarOnPattern = new RegExp(`^on\\s*:\\s*${quotedTriggerName}\\s*$`);
+
+  return triggerBlock.split(/\r?\n/).some((line) => {
+    const trimmedLine = stripYamlComment(line).trim();
+
+    if (!trimmedLine) {
+      return false;
+    }
+
+    return (
+      mappingKeyPattern.test(trimmedLine) ||
+      listItemPattern.test(trimmedLine) ||
+      inlineMappingPattern.test(trimmedLine) ||
+      inlineListPattern.test(trimmedLine) ||
+      scalarOnPattern.test(trimmedLine)
+    );
+  });
+}
+
 function requireIncludes(source, expected, message) {
   if (!source.includes(expected)) {
     fail(message);
@@ -70,9 +152,18 @@ function requireAbsent(source, denied, message) {
   }
 }
 
+const triggerBlock = getTopLevelKeyBlock('on', 'workflow triggers');
 const concurrencyBlock = getBlock(/^concurrency:\s*$/, 'top-level concurrency');
 const verifyJob = getBlock(/^  verify:\s*$/, 'verify job');
 const publishJob = getBlock(/^  publish:\s*$/, 'publish job');
+
+if (!hasYamlTrigger(triggerBlock, 'workflow_dispatch')) {
+  fail('Expected release workflow to be manually dispatchable.');
+}
+
+if (hasYamlTrigger(triggerBlock, 'release')) {
+  fail('Release workflow must not publish from GitHub Release events; use workflow_dispatch publish=true instead.');
+}
 
 requireIncludes(
   concurrencyBlock,
@@ -102,6 +193,11 @@ requireIncludes(
 );
 
 requireIncludes(publishJob, 'needs: verify', 'Expected publish job to depend on verify.');
+requireIncludes(
+  publishJob,
+  "if: ${{ github.event.inputs.publish == 'true' }}",
+  'Expected publish job to run only when workflow_dispatch publish=true is selected.'
+);
 requireIncludes(
   publishJob,
   'id-token: write',


### PR DESCRIPTION
## Summary

- remove the GitHub Release `published` trigger from the npm release workflow
- require npm publish to run only from manual `workflow_dispatch` with `publish=true`
- update release verification docs, checklist, and workflow verification script so this stays guarded
## Why

Publishing a GitHub Release after npm publish can otherwise start a second release workflow for the same package version. This keeps GitHub Releases as release notes/discovery surfaces and keeps npm publishing in the explicit manual workflow path.
## Validation

- `git diff --check`
- `npm run publish:check`
