### PR TITLE
Document public surface verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes for `image-drop-input` are tracked here.
 ### Changed
 
 - Changed the release workflow to publish only from manual `workflow_dispatch` runs with `publish=true`, preventing GitHub Release publication from attempting a duplicate npm publish.
+- Documented public release surface cache checks and package scanner score triage for post-release review.
 
 ## 0.3.4 - 2026-05-08
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,8 +54,8 @@ Security, privacy, and adoption:
 - [Durable image boundary](./durable-image-boundary.md): public category narrative, evidence map, and non-goals
 - [Integration report](./integration-report.md): repo-maintained report for the single-image product form boundary
 - [Adoption evidence](./adoption-evidence.md): what repo-maintained examples, maintainer-owned demos, third-party reports, and production-adjacent case studies prove
-- [Release verification](./release-verification.md): packed package, npm metadata, provenance, and local verification checks
-- [Supply-chain security](./supply-chain-security.md): dependency review, CodeQL, release gates, and runtime dependency limits
+- [Release verification](./release-verification.md): packed package, npm metadata, provenance, public release surfaces, and cache checks
+- [Supply-chain security](./supply-chain-security.md): dependency review, CodeQL, release gates, scanner score triage, and runtime dependency limits
 - [Maintenance governance](./maintenance-governance.md): scope decisions, non-goals, and semver policy
 
 The package stays single-image first. Use Uppy, FilePond, Uploady, or provider widgets when you need queues, remote sources, resumable uploads, image editing, or storage-as-a-service. Use this package when one image field must keep temporary preview state, draft upload state, and persisted product state separate.

--- a/docs/release-verification.md
+++ b/docs/release-verification.md
@@ -147,6 +147,46 @@ The GitHub release for `v$VERSION` should be the latest release when npm `latest
 
 GitHub Releases are release notes and discovery surfaces, not the npm publish trigger. Publish to npm through the manual `Release` workflow first, then create or update the GitHub Release for the already-published version.
 
+## Public surface cache checks
+
+Review tools and package pages can show stale repository metadata after a release. Treat API and registry checks as the source of truth before changing release state.
+
+Use this check when a public page appears to show an older version, tag, release, or repository description:
+
+```bash
+PACKAGE=image-drop-input
+VERSION="$(node -p 'require("./package.json").version')"
+
+git fetch origin --tags --prune --prune-tags
+test "$(npm view "$PACKAGE" dist-tags.latest)" = "$VERSION"
+test "$(npm view "$PACKAGE@$VERSION" version)" = "$VERSION"
+git ls-remote --tags origin "v$VERSION"
+gh release view "v$VERSION" --repo mt4110/image-drop-input --json tagName,name,publishedAt,url
+test "$(
+  gh release list --repo mt4110/image-drop-input --limit 1 --json tagName,isLatest \
+    --jq ".[0] | select(.tagName == \"v$VERSION\" and .isLatest == true) | .tagName"
+)" = "v$VERSION"
+gh repo view mt4110/image-drop-input --json description,latestRelease,url
+npm view "$PACKAGE@$VERSION" repository.url
+npm view "$PACKAGE@$VERSION" engines.node
+npm view "$PACKAGE@$VERSION" dist.integrity
+```
+
+The repository About description should remain:
+
+```text
+Product-safe React image field for durable image state.
+```
+
+If the checks above pass but a browser page still shows older metadata, assume a cache or indexing delay first. Do not republish to npm to fix a stale GitHub, Socket, npm, or browser view.
+
+Manual follow-up checks:
+
+- hard-refresh the stale page or retry it in a private browser session
+- verify the npm README with `npm view image-drop-input readme | head -40`
+- verify the GitHub Pages demo with a cache-busting URL such as `https://mt4110.github.io/image-drop-input/?v=$VERSION`
+- wait and re-check third-party package scanners after their cache window passes
+
 ## Provenance verification
 
 The npm package page should show provenance for the published version. The provenance details should link to the source commit and the release workflow run that published the tarball.

--- a/docs/supply-chain-security.md
+++ b/docs/supply-chain-security.md
@@ -26,6 +26,20 @@ If Scorecard is added later, document:
 - which score changes block releases
 - which findings are accepted as project policy
 
+## Package scanner scores
+
+External package scanners are useful triage signals, not release correctness signals. A lower score on a newly published package can reflect package age, recent release timing, one-maintainer status, download count, or scanner cache state rather than a code vulnerability.
+
+When reviewing a scanner score:
+
+- open the underlying alerts before changing code
+- separate runtime dependency risk from dev-tooling metadata
+- re-check recently published versions after 24 hours, 72 hours, and 7 days
+- compare the scanner's visible version with `npm view image-drop-input dist-tags.latest`
+- prefer release evidence, provenance, signed tags, consumer smoke tests, and third-party usage reports over score chasing
+
+Do not distort the package to improve a scanner score. In particular, do not add fake maintainers, remove normal dev dependencies through publish-time hacks, add runtime security packages, or commit generated SBOM files without an owner and maintenance policy.
+
 ## Runtime dependency rule
 
 Security tooling may add dev dependencies, GitHub workflow checks, or repository-level checks. It must not add runtime dependencies to the browser package unless a release explicitly justifies the change.


### PR DESCRIPTION
## Summary
- document post-release public surface cache checks for npm, GitHub Releases, tags, About, and package metadata
- add package scanner score triage guidance without changing runtime dependencies
- update the docs index and changelog for the new release review guidance

## Validation
- npm run publish:check
- git diff --check
- npm/GitHub public surface checks for image-drop-input@0.3.4

## Notes
- npm latest, GitHub latest release, signed tag, and repository About already resolve to 0.3.4 / the product-safe description through CLI checks
- issue #51 remains open as the intake point for a future external non-maintainer usage report; no third-party evidence is claimed here