### PR TITLE
Add ROI estimate model

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ Core docs:
 - [Uploads](./uploads.md): adapter contracts, signed upload boundaries, progress, typed upload errors, and aborts
 - [Transforms](./transforms.md): compression, WebP conversion, return shapes, and MIME consistency
 - [Accessibility](./accessibility.md): keyboard, paste, status, dialog, and headless responsibilities
+- [ROI model](./roi-model.md): vendor-neutral byte, processing, and cost estimate for Zero Image-Processing Backend pilots
 
 Recipes:
 

--- a/docs/claim-ledger.md
+++ b/docs/claim-ledger.md
@@ -98,6 +98,14 @@ Each entry checks a claim or boundary statement. Entries marked "Not claimed" do
 - Disproof path: A successful result reports `size > outputMaxBytes` for a supported policy.
 - Status: Proven
 
+### ROI estimate model
+
+- Claim checked: The ROI calculator distinguishes measured inputs from assumptions and reports caveats instead of guaranteed savings.
+- Evidence level: Unit test, Public docs
+- Evidence: [ROI model](./roi-model.md), [ROI calculator template](./roi-calculator-template.md), `tests/docs/roi-calculator.test.mjs`.
+- Disproof path: Calculator output presents assumptions as measured, hides missing cost inputs, or describes savings as guaranteed.
+- Status: Proven
+
 ### Byte-identical browser output
 
 - Claim checked: Byte-budget output is byte-identical across browser engines.

--- a/docs/roi-calculator-template.md
+++ b/docs/roi-calculator-template.md
@@ -1,0 +1,31 @@
+# ROI calculator template
+
+Use this worksheet before sharing a cost-savings claim. Replace fake values with pilot data where possible.
+
+| Field | Value | Source |
+| --- | ---: | --- |
+| Monthly uploads | `50000` | Measured analytics or assumption |
+| Average raw bytes | `6000000` | Pilot sample |
+| Average prepared bytes | `750000` | Pilot sample |
+| Raw upload backend fraction | `1` | Architecture review |
+| Average server processing ms | `450` | Logs or trace sample |
+| Average transformation units per upload | `1` | Transformation logs or assumption |
+| Bandwidth cost per GB | `0.08` | Invoice or rate card |
+| Storage cost per GB-month | `0.023` | Invoice or rate card |
+| Transformation cost per unit | `0.001` | Invoice or rate card |
+| Measured fields | `averageRawBytes,averagePreparedBytes` | Pilot measurement |
+
+Run:
+
+```bash
+npm run roi:estimate -- --monthly-uploads=50000 --average-raw-bytes=6000000 --average-prepared-bytes=750000 --raw-upload-backend-fraction=1 --average-server-processing-ms=450 --average-transformation-units-per-upload=1 --bandwidth-cost-per-gb=0.08 --storage-cost-per-gb-month=0.023 --transformation-cost-per-unit=0.001 --measured=averageRawBytes,averagePreparedBytes --format=markdown
+```
+
+Before using the result externally, answer:
+
+- Which fields are measured rather than assumed?
+- Which provider rates came from actual invoices?
+- Does the current system store raw originals, larger derivatives, or both?
+- Are transformation units billed per upload, per derivative, per credit, or by another provider-specific rule?
+- Is backend image processing actually removed, or only moved to a different service?
+- Which caveats should be shown beside the estimate?

--- a/docs/roi-model.md
+++ b/docs/roi-model.md
@@ -1,0 +1,121 @@
+# ROI model
+
+The Zero Image-Processing Backend Pipeline claim should be measured, not assumed.
+
+This model estimates the effect of moving resize, compression, and byte-budget fitting work into the browser while keeping auth, policy, presign, commit, cleanup, and audit on the server.
+
+It is vendor-neutral. Provider invoices, rate cards, and transformation-unit definitions stay app-owned inputs.
+
+## Calculator
+
+Run the local calculator with fake or pilot-measured numbers:
+
+```bash
+npm run roi:estimate -- --monthly-uploads=50000 --average-raw-bytes=6000000 --average-prepared-bytes=750000 --raw-upload-backend-fraction=1 --average-server-processing-ms=450 --bandwidth-cost-per-gb=0.08 --storage-cost-per-gb-month=0.023 --transformation-cost-per-unit=0.001 --measured=averageRawBytes,averagePreparedBytes --format=markdown
+```
+
+The calculator uses decimal GB because most infrastructure invoices bill in GB-like units rather than binary GiB. Keep the same unit convention when comparing the output with invoices.
+
+## Inputs
+
+| Input | Meaning | Measured or assumed |
+| --- | --- | --- |
+| `monthlyUploads` | Count of image uploads for the target flow. | Prefer measured. |
+| `averageRawBytes` | Average source file size before browser preparation. | Prefer measured. |
+| `averagePreparedBytes` | Average output size after browser preparation. | Prefer measured. |
+| `rawUploadBackendFraction` | Fraction of raw uploads that currently reach backend image processing. Defaults to `1`. | Assumption unless traced. |
+| `averageServerProcessingMs` | Current backend/serverless image-processing time per upload. Defaults to `0`. | Prefer measured. |
+| `averageTransformationUnitsPerUpload` | Average billable transformation units avoided per upload. Defaults to `1`. | Assumption unless traced. |
+| `serverlessCostPerMs` | Effective cost per millisecond for current processing. | Assumption from invoice or rate card. |
+| `transformationCostPerUnit` | Effective cost per transformation unit or call. | Assumption from invoice or rate card. |
+| `storageCostPerGbMonth` | Cost for each avoidable GB-month. | Assumption from invoice or rate card. |
+| `bandwidthCostPerGb` | Cost for each avoidable GB transferred. | Assumption from invoice or rate card. |
+| `engineeringHoursSavedPerMonth` | Maintenance or support hours plausibly removed. | Assumption until a pilot proves it. |
+| `engineeringHourlyCost` | Blended hourly cost used with saved hours. | App-owned assumption. |
+| `abandonedDraftRate` | Fraction of drafts abandoned in the target flow. | Prefer measured. |
+| `supportTicketCost` | Cost per related support ticket. | App-owned assumption. |
+
+Mark measured fields explicitly:
+
+```bash
+--measured=monthlyUploads,averageRawBytes,averagePreparedBytes
+```
+
+Use `actualInvoices` and `beforeAfterInfrastructure` only after a pilot has invoice-backed before/after data:
+
+```bash
+--measured=monthlyUploads,averageRawBytes,averagePreparedBytes,beforeAfterInfrastructure,actualInvoices
+```
+
+## Output
+
+The calculator reports:
+
+- raw GB/month
+- prepared GB/month
+- avoided backend GB/month
+- avoided backend processing hours/month
+- avoided transformation units/month
+- estimated monthly savings when cost assumptions are supplied
+- confidence level
+- measured inputs
+- assumed inputs
+- caveats
+
+Draft support exposure is reported separately when `abandonedDraftRate` and `supportTicketCost` are provided. It is not counted as savings without incident data.
+
+## Confidence
+
+| Confidence | Rule |
+| --- | --- |
+| `low` | Raw/prepared byte averages are not both marked measured. |
+| `medium` | Raw/prepared byte averages are measured, but pricing or infrastructure impact is still estimated. |
+| `high` | Raw/prepared byte averages, before/after infrastructure data, and actual invoices are measured. |
+
+Do not present `low` or `medium` confidence output as guaranteed savings. Even `high` confidence means the pilot inputs are evidence-backed; it does not mean the same result will hold across every form, tenant, or provider contract.
+
+## Safe measurement fields
+
+Measurement hooks should collect only operational metadata:
+
+- `raw_bytes`
+- `prepared_bytes`
+- `reduction_ratio`
+- `prepare_duration_ms`
+- `decode_duration_ms`
+- `encode_duration_ms`
+- `upload_duration_ms`
+- `draft_recovered`
+- `draft_discarded`
+- `commit_failed`
+- `cleanup_failed`
+- `browser_family`
+- `policy_name`
+
+Do not collect file contents, upload URLs, draft tokens, OPFS paths, EXIF values, user PII, or full object keys unless the app explicitly owns and approves that telemetry.
+
+## Example
+
+Fake pilot input:
+
+```bash
+npm run roi:estimate -- --monthly-uploads=100000 --average-raw-bytes=8000000 --average-prepared-bytes=900000 --raw-upload-backend-fraction=1 --average-server-processing-ms=350 --bandwidth-cost-per-gb=0.08 --storage-cost-per-gb-month=0.023 --transformation-cost-per-unit=0.001 --measured=averageRawBytes,averagePreparedBytes
+```
+
+This can show avoided bytes and estimated cost categories, but the caveats still matter:
+
+- byte averages may be measured while provider rates remain assumed,
+- storage savings apply only if raw originals or larger derivatives are currently retained,
+- transformation savings depend on how the provider defines billable units,
+- multi-derivative pipelines should supply `averageTransformationUnitsPerUpload` instead of using the default,
+- invoices or vendor-specific rates are app-owned inputs.
+
+## Pilot threshold
+
+A pilot is worth continuing when it demonstrates at least two of these:
+
+- 70% or greater byte reduction for the target form,
+- no backend image processing in the target flow,
+- measurable drop in transformation calls,
+- draft recovery works in test cases,
+- implementation finishes without provider lock-in.

--- a/docs/roi-model.md
+++ b/docs/roi-model.md
@@ -64,6 +64,8 @@ The calculator reports:
 
 Draft support exposure is reported separately when `abandonedDraftRate` and `supportTicketCost` are provided. It is not counted as savings without incident data.
 
+Avoided backend GB/month can be negative when prepared images are larger than the original inputs. Negative byte deltas reduce bandwidth and storage savings instead of being clamped away.
+
 ## Confidence
 
 | Confidence | Rule |

--- a/docs/tools/roi-calculator.mjs
+++ b/docs/tools/roi-calculator.mjs
@@ -1,0 +1,613 @@
+#!/usr/bin/env node
+import { pathToFileURL } from 'node:url';
+
+const BYTES_PER_GB = 1_000_000_000;
+
+const numericInputFields = new Set([
+  'monthlyUploads',
+  'averageRawBytes',
+  'averagePreparedBytes',
+  'rawUploadBackendFraction',
+  'averageServerProcessingMs',
+  'averageTransformationUnitsPerUpload',
+  'serverlessCostPerMs',
+  'transformationCostPerUnit',
+  'storageCostPerGbMonth',
+  'bandwidthCostPerGb',
+  'engineeringHoursSavedPerMonth',
+  'engineeringHourlyCost',
+  'abandonedDraftRate',
+  'supportTicketCost'
+]);
+const evidenceMeasuredFields = new Set([
+  'actualInvoices',
+  'beforeAfterInfrastructure'
+]);
+const allowedMeasuredFields = new Set([
+  ...numericInputFields,
+  ...evidenceMeasuredFields
+]);
+
+const requiredInputFields = [
+  'monthlyUploads',
+  'averageRawBytes',
+  'averagePreparedBytes'
+];
+
+const measuredAliases = new Map([
+  ['monthlyUploadCount', 'monthlyUploads'],
+  ['uploadCount', 'monthlyUploads'],
+  ['rawBytes', 'averageRawBytes'],
+  ['raw_bytes', 'averageRawBytes'],
+  ['averageRawBytes', 'averageRawBytes'],
+  ['preparedBytes', 'averagePreparedBytes'],
+  ['prepared_bytes', 'averagePreparedBytes'],
+  ['averagePreparedBytes', 'averagePreparedBytes'],
+  ['invoice', 'actualInvoices'],
+  ['invoices', 'actualInvoices'],
+  ['actualInvoices', 'actualInvoices'],
+  ['beforeAfterInfrastructure', 'beforeAfterInfrastructure'],
+  ['before_after_infrastructure', 'beforeAfterInfrastructure'],
+  ['transformationCalls', 'beforeAfterInfrastructure'],
+  ['transformation_calls', 'beforeAfterInfrastructure']
+]);
+
+const inputLabels = {
+  monthlyUploads: 'Monthly uploads',
+  averageRawBytes: 'Average raw bytes',
+  averagePreparedBytes: 'Average prepared bytes',
+  rawUploadBackendFraction: 'Raw upload backend fraction',
+  averageServerProcessingMs: 'Average server processing ms',
+  averageTransformationUnitsPerUpload: 'Average transformation units per upload',
+  serverlessCostPerMs: 'Serverless cost per ms',
+  transformationCostPerUnit: 'Transformation cost per unit',
+  storageCostPerGbMonth: 'Storage cost per GB-month',
+  bandwidthCostPerGb: 'Bandwidth cost per GB',
+  engineeringHoursSavedPerMonth: 'Engineering hours saved per month',
+  engineeringHourlyCost: 'Engineering hourly cost',
+  abandonedDraftRate: 'Abandoned draft rate',
+  supportTicketCost: 'Support ticket cost',
+  actualInvoices: 'Actual invoices',
+  beforeAfterInfrastructure: 'Before/after infrastructure data'
+};
+
+function camelize(value) {
+  return value.replace(/[-_]([a-z0-9])/g, (_, character) =>
+    character.toUpperCase()
+  );
+}
+
+function roundNumber(value, digits = 9) {
+  if (!Number.isFinite(value)) {
+    return value;
+  }
+
+  const scale = 10 ** digits;
+  return Math.round((value + Number.EPSILON) * scale) / scale;
+}
+
+function bytesToGb(bytes) {
+  return bytes / BYTES_PER_GB;
+}
+
+function isObjectRecord(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function normalizeMeasuredFields(fields = []) {
+  if (!Array.isArray(fields)) {
+    throw new Error('measuredFields must be an array.');
+  }
+
+  const normalizedFields = Array.from(
+    new Set(
+      fields
+        .map((field) => field.trim())
+        .filter(Boolean)
+        .map(
+          (field) =>
+            measuredAliases.get(field) ??
+            measuredAliases.get(camelize(field)) ??
+            camelize(field)
+        )
+    )
+  );
+
+  for (const field of normalizedFields) {
+    if (!allowedMeasuredFields.has(field)) {
+      throw new Error(`Unknown measured field "${field}".`);
+    }
+  }
+
+  return normalizedFields;
+}
+
+function assertFiniteNonNegative(input, field) {
+  const value = input[field];
+
+  if (value === undefined) {
+    return;
+  }
+
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    throw new Error(`${field} must be a finite non-negative number.`);
+  }
+}
+
+function assertFinitePositive(input, field) {
+  const value = input[field];
+
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    throw new Error(`${field} must be a finite positive number.`);
+  }
+}
+
+function normalizeInput(input) {
+  if (!isObjectRecord(input)) {
+    throw new Error('ROI input must be an object.');
+  }
+
+  const normalized = {
+    ...input,
+    rawUploadBackendFraction: input.rawUploadBackendFraction ?? 1,
+    averageServerProcessingMs: input.averageServerProcessingMs ?? 0,
+    averageTransformationUnitsPerUpload:
+      input.averageTransformationUnitsPerUpload ?? 1
+  };
+
+  for (const field of requiredInputFields) {
+    if (normalized[field] === undefined) {
+      throw new Error(`${field} is required.`);
+    }
+  }
+
+  for (const field of numericInputFields) {
+    assertFiniteNonNegative(normalized, field);
+  }
+
+  for (const field of requiredInputFields) {
+    assertFinitePositive(normalized, field);
+  }
+
+  if (normalized.rawUploadBackendFraction > 1) {
+    throw new Error('rawUploadBackendFraction must be between 0 and 1.');
+  }
+
+  if (
+    normalized.abandonedDraftRate !== undefined &&
+    normalized.abandonedDraftRate > 1
+  ) {
+    throw new Error('abandonedDraftRate must be between 0 and 1.');
+  }
+
+  return normalized;
+}
+
+function assertMeasuredInputsHaveValues(input, measuredInputs) {
+  for (const field of measuredInputs) {
+    if (numericInputFields.has(field) && input[field] === undefined) {
+      throw new Error(
+        `Measured field "${field}" requires a corresponding input value.`
+      );
+    }
+  }
+}
+
+function getConfidence(measuredInputs) {
+  const measured = new Set(measuredInputs);
+  const hasMeasuredBytes =
+    measured.has('averageRawBytes') && measured.has('averagePreparedBytes');
+  const hasMeasuredInfrastructure = measured.has('beforeAfterInfrastructure');
+  const hasActualInvoices = measured.has('actualInvoices');
+
+  if (hasMeasuredBytes && hasMeasuredInfrastructure && hasActualInvoices) {
+    return 'high';
+  }
+
+  if (hasMeasuredBytes) {
+    return 'medium';
+  }
+
+  return 'low';
+}
+
+function getAssumedInputs(input, measuredInputs) {
+  const measured = new Set(measuredInputs);
+
+  return Object.keys(input)
+    .filter((field) => numericInputFields.has(field))
+    .filter((field) => !measured.has(field))
+    .sort();
+}
+
+function buildCaveats(input, measuredInputs, result) {
+  const caveats = ['This is a planning estimate, not a guarantee of savings.'];
+  const measured = new Set(measuredInputs);
+  const measuredBytes =
+    measured.has('averageRawBytes') && measured.has('averagePreparedBytes');
+
+  if (!measuredBytes) {
+    caveats.push(
+      'Raw and prepared byte averages are not both marked measured; confirm them with a pilot before using the estimate externally.'
+    );
+  }
+
+  if (result.estimatedMonthlySavings === undefined) {
+    caveats.push(
+      'No complete cost assumptions were supplied, so estimatedMonthlySavings is omitted.'
+    );
+  }
+
+  if (input.averagePreparedBytes > input.averageRawBytes) {
+    caveats.push(
+      'Prepared bytes exceed raw bytes; the pipeline may improve policy fit or privacy, but byte savings are not shown by these inputs.'
+    );
+  }
+
+  if (input.storageCostPerGbMonth !== undefined) {
+    caveats.push(
+      'Storage savings only apply when the current system stores raw originals or larger derivatives for the measured retention window.'
+    );
+  }
+
+  if (
+    input.serverlessCostPerMs !== undefined &&
+    input.averageServerProcessingMs === 0
+  ) {
+    caveats.push(
+      'Serverless cost per ms was supplied, but averageServerProcessingMs is zero, so processing savings are zero.'
+    );
+  }
+
+  if (
+    input.transformationCostPerUnit !== undefined &&
+    input.averageTransformationUnitsPerUpload === 1
+  ) {
+    caveats.push(
+      'Transformation savings assume one transformation unit per upload unless averageTransformationUnitsPerUpload is supplied.'
+    );
+  }
+
+  if (
+    (input.engineeringHoursSavedPerMonth === undefined) !==
+    (input.engineeringHourlyCost === undefined)
+  ) {
+    caveats.push(
+      'Engineering savings require both engineeringHoursSavedPerMonth and engineeringHourlyCost.'
+    );
+  }
+
+  if (
+    input.engineeringHoursSavedPerMonth !== undefined &&
+    input.engineeringHourlyCost !== undefined &&
+    (!measured.has('engineeringHoursSavedPerMonth') ||
+      !measured.has('engineeringHourlyCost'))
+  ) {
+    caveats.push(
+      'Engineering savings are assumptions unless both engineering fields are marked measured.'
+    );
+  }
+
+  if (input.rawUploadBackendFraction < 1) {
+    caveats.push(
+      'Only the raw-upload fraction that currently reaches backend processing is counted as avoidable backend work.'
+    );
+  }
+
+  if (result.estimatedMonthlyDraftSupportExposure !== undefined) {
+    caveats.push(
+      'Draft support exposure is reported separately and is not counted as savings without incident data.'
+    );
+  }
+
+  caveats.push(
+    'Vendor rates, transformation-unit definitions, and invoices are app-owned inputs; this calculator does not contact provider APIs or require secrets.'
+  );
+
+  return caveats;
+}
+
+export function estimateImagePipelineRoi(input, options = {}) {
+  const normalized = normalizeInput(input);
+  const measuredInputs = normalizeMeasuredFields(options.measuredFields ?? []);
+  assertMeasuredInputsHaveValues(input, measuredInputs);
+  const monthlyUploads = normalized.monthlyUploads;
+  const rawUploadBackendFraction = normalized.rawUploadBackendFraction;
+  const rawGbPerMonth = bytesToGb(monthlyUploads * normalized.averageRawBytes);
+  const preparedGbPerMonth = bytesToGb(
+    monthlyUploads * normalized.averagePreparedBytes
+  );
+  const avoidableRawGb = rawGbPerMonth * rawUploadBackendFraction;
+  const avoidablePreparedGb = preparedGbPerMonth * rawUploadBackendFraction;
+  const avoidedGbPerMonth = Math.max(0, avoidableRawGb - avoidablePreparedGb);
+  const avoidedBackendProcessingHours =
+    (monthlyUploads *
+      rawUploadBackendFraction *
+      normalized.averageServerProcessingMs) /
+    3_600_000;
+  const avoidedTransformationUnits =
+    monthlyUploads *
+    rawUploadBackendFraction *
+    normalized.averageTransformationUnitsPerUpload;
+  const costBreakdown = {};
+
+  if (normalized.bandwidthCostPerGb !== undefined) {
+    costBreakdown.bandwidth = avoidedGbPerMonth * normalized.bandwidthCostPerGb;
+  }
+
+  if (normalized.storageCostPerGbMonth !== undefined) {
+    costBreakdown.storage =
+      avoidedGbPerMonth * normalized.storageCostPerGbMonth;
+  }
+
+  if (
+    normalized.serverlessCostPerMs !== undefined &&
+    normalized.averageServerProcessingMs > 0
+  ) {
+    costBreakdown.serverlessProcessing =
+      monthlyUploads *
+      rawUploadBackendFraction *
+      normalized.averageServerProcessingMs *
+      normalized.serverlessCostPerMs;
+  }
+
+  if (normalized.transformationCostPerUnit !== undefined) {
+    costBreakdown.transformations =
+      avoidedTransformationUnits * normalized.transformationCostPerUnit;
+  }
+
+  if (
+    normalized.engineeringHoursSavedPerMonth !== undefined &&
+    normalized.engineeringHourlyCost !== undefined
+  ) {
+    costBreakdown.engineering =
+      normalized.engineeringHoursSavedPerMonth *
+      normalized.engineeringHourlyCost;
+  }
+
+  const estimatedMonthlySavings =
+    Object.keys(costBreakdown).length > 0
+      ? roundNumber(
+          Object.values(costBreakdown).reduce(
+            (total, value) => total + value,
+            0
+          ),
+          2
+        )
+      : undefined;
+  const roundedCostBreakdown = Object.fromEntries(
+    Object.entries(costBreakdown).map(([key, value]) => [
+      key,
+      roundNumber(value, 2)
+    ])
+  );
+  const estimatedMonthlyDraftSupportExposure =
+    normalized.abandonedDraftRate !== undefined &&
+    normalized.supportTicketCost !== undefined
+      ? roundNumber(
+          monthlyUploads *
+            normalized.abandonedDraftRate *
+            normalized.supportTicketCost,
+          2
+        )
+      : undefined;
+  const result = {
+    rawGbPerMonth: roundNumber(rawGbPerMonth),
+    preparedGbPerMonth: roundNumber(preparedGbPerMonth),
+    avoidedGbPerMonth: roundNumber(avoidedGbPerMonth),
+    avoidedBackendProcessingHours: roundNumber(avoidedBackendProcessingHours),
+    avoidedTransformationUnits: roundNumber(avoidedTransformationUnits),
+    estimatedMonthlySavings,
+    estimatedMonthlyDraftSupportExposure,
+    confidence: getConfidence(measuredInputs),
+    measuredInputs,
+    assumedInputs: getAssumedInputs(normalized, measuredInputs),
+    costBreakdown: roundedCostBreakdown,
+    caveats: []
+  };
+
+  result.caveats = buildCaveats(normalized, measuredInputs, result);
+
+  if (result.estimatedMonthlySavings === undefined) {
+    delete result.estimatedMonthlySavings;
+  }
+
+  if (result.estimatedMonthlyDraftSupportExposure === undefined) {
+    delete result.estimatedMonthlyDraftSupportExposure;
+  }
+
+  return result;
+}
+
+export function parseRoiArgs(argv) {
+  const input = {};
+  let format = 'json';
+  let measuredFields = [];
+
+  if (argv.includes('--help') || argv.includes('-h')) {
+    return {
+      input,
+      measuredFields,
+      format,
+      showHelp: true
+    };
+  }
+
+  for (const arg of argv) {
+    if (!arg.startsWith('--')) {
+      throw new Error(`Unsupported argument "${arg}". Use --name=value flags.`);
+    }
+
+    const separatorIndex = arg.indexOf('=');
+    if (separatorIndex === -1) {
+      throw new Error(`Missing value for "${arg}". Use --name=value.`);
+    }
+
+    const rawName = arg.slice(2, separatorIndex);
+    if (rawName === '') {
+      throw new Error('Argument name is required.');
+    }
+
+    const rawValue = arg.slice(separatorIndex + 1);
+    const name = camelize(rawName);
+
+    if (name === 'format') {
+      if (rawValue === '') {
+        throw new Error('--format requires json or markdown.');
+      }
+
+      if (rawValue !== 'json' && rawValue !== 'markdown') {
+        throw new Error('--format must be json or markdown.');
+      }
+
+      format = rawValue;
+      continue;
+    }
+
+    if (name === 'measured' || name === 'measuredInputs') {
+      if (rawValue === '') {
+        throw new Error('--measured requires a comma-separated field list.');
+      }
+
+      measuredFields = rawValue.split(',').filter(Boolean);
+      continue;
+    }
+
+    if (!numericInputFields.has(name)) {
+      throw new Error(`Unknown ROI input "${rawName}".`);
+    }
+
+    const numericValue = Number(rawValue);
+
+    if (rawValue === '' || !Number.isFinite(numericValue)) {
+      throw new Error(`${rawName} must be a number.`);
+    }
+
+    input[name] = numericValue;
+  }
+
+  return {
+    input,
+    measuredFields,
+    format,
+    showHelp: false
+  };
+}
+
+function formatMoney(value) {
+  if (value === undefined) {
+    return 'not estimated';
+  }
+
+  return `$${value.toFixed(2)}`;
+}
+
+function formatNumber(value) {
+  if (Number.isInteger(value)) {
+    return String(value);
+  }
+
+  const absoluteValue = Math.abs(value);
+
+  return value.toLocaleString('en-US', {
+    maximumFractionDigits: absoluteValue > 0 && absoluteValue < 0.001 ? 9 : 6,
+    minimumFractionDigits: 0,
+    useGrouping: false
+  });
+}
+
+export function formatRoiMarkdown(result) {
+  const costRows = Object.entries(result.costBreakdown);
+  const caveats = result.caveats.map((caveat) => `- ${caveat}`).join('\n');
+  const measuredRows =
+    result.measuredInputs.length === 0
+      ? '- None marked measured.'
+      : result.measuredInputs
+          .map((field) => `- ${inputLabels[field] ?? field}`)
+          .join('\n');
+  const assumedRows = result.assumedInputs
+    .map((field) => `- ${inputLabels[field] ?? field}`)
+    .join('\n') || '- None.';
+  const costBreakdown =
+    costRows.length === 0
+      ? 'No complete cost assumptions supplied.'
+      : costRows
+          .map(([key, value]) => `- ${key}: ${formatMoney(value)}`)
+          .join('\n');
+
+  return `# Image pipeline ROI estimate
+
+| Metric | Value |
+| --- | ---: |
+| Raw GB/month | ${formatNumber(result.rawGbPerMonth)} |
+| Prepared GB/month | ${formatNumber(result.preparedGbPerMonth)} |
+| Avoided backend GB/month | ${formatNumber(result.avoidedGbPerMonth)} |
+| Avoided backend processing hours/month | ${formatNumber(result.avoidedBackendProcessingHours)} |
+| Avoided transformation units/month | ${formatNumber(result.avoidedTransformationUnits)} |
+| Estimated monthly savings | ${formatMoney(result.estimatedMonthlySavings)} |
+| Confidence | ${result.confidence} |
+
+## Cost Breakdown
+
+${costBreakdown}
+
+## Measured Inputs
+
+${measuredRows}
+
+## Assumed Inputs
+
+${assumedRows}
+
+## Caveats
+
+${caveats}
+`;
+}
+
+function helpText() {
+  return `Usage:
+  npm run roi:estimate -- --monthly-uploads=50000 --average-raw-bytes=6000000 --average-prepared-bytes=750000
+
+Common options:
+  --raw-upload-backend-fraction=1
+  --average-server-processing-ms=450
+  --average-transformation-units-per-upload=1
+  --bandwidth-cost-per-gb=0.08
+  --storage-cost-per-gb-month=0.023
+  --serverless-cost-per-ms=0.0000000167
+  --transformation-cost-per-unit=0.001
+  --measured=averageRawBytes,averagePreparedBytes
+  --format=json|markdown
+
+All costs are app-owned assumptions. The calculator does not contact provider APIs.`;
+}
+
+function runCli(argv) {
+  try {
+    const { input, measuredFields, format, showHelp } = parseRoiArgs(argv);
+
+    if (showHelp) {
+      console.log(helpText());
+      return;
+    }
+
+    const result = estimateImagePipelineRoi(input, { measuredFields });
+
+    if (format === 'markdown') {
+      console.log(formatRoiMarkdown(result));
+      return;
+    }
+
+    console.log(JSON.stringify(result, null, 2));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    console.error('');
+    console.error(helpText());
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runCli(process.argv.slice(2));
+}

--- a/docs/tools/roi-calculator.mjs
+++ b/docs/tools/roi-calculator.mjs
@@ -83,7 +83,9 @@ function roundNumber(value, digits = 9) {
   }
 
   const scale = 10 ** digits;
-  const rounded = Math.round((value + Number.EPSILON) * scale) / scale;
+  const sign = Math.sign(value) || 1;
+  const rounded =
+    (sign * Math.round((Math.abs(value) + Number.EPSILON) * scale)) / scale;
 
   return Object.is(rounded, -0) ? 0 : rounded;
 }

--- a/docs/tools/roi-calculator.mjs
+++ b/docs/tools/roi-calculator.mjs
@@ -83,7 +83,9 @@ function roundNumber(value, digits = 9) {
   }
 
   const scale = 10 ** digits;
-  return Math.round((value + Number.EPSILON) * scale) / scale;
+  const rounded = Math.round((value + Number.EPSILON) * scale) / scale;
+
+  return Object.is(rounded, -0) ? 0 : rounded;
 }
 
 function bytesToGb(bytes) {
@@ -97,6 +99,12 @@ function isObjectRecord(value) {
 function normalizeMeasuredFields(fields = []) {
   if (!Array.isArray(fields)) {
     throw new Error('measuredFields must be an array.');
+  }
+
+  for (const [index, field] of fields.entries()) {
+    if (typeof field !== 'string') {
+      throw new Error(`measuredFields[${index}] must be a string.`);
+    }
   }
 
   const normalizedFields = Array.from(
@@ -220,7 +228,11 @@ function getAssumedInputs(input, measuredInputs) {
     .sort();
 }
 
-function buildCaveats(input, measuredInputs, result) {
+function hasOwnInput(input, field) {
+  return Object.prototype.hasOwnProperty.call(input, field);
+}
+
+function buildCaveats(input, providedInput, measuredInputs, result) {
   const caveats = ['This is a planning estimate, not a guarantee of savings.'];
   const measured = new Set(measuredInputs);
   const measuredBytes =
@@ -261,7 +273,7 @@ function buildCaveats(input, measuredInputs, result) {
 
   if (
     input.transformationCostPerUnit !== undefined &&
-    input.averageTransformationUnitsPerUpload === 1
+    !hasOwnInput(providedInput, 'averageTransformationUnitsPerUpload')
   ) {
     caveats.push(
       'Transformation savings assume one transformation unit per upload unless averageTransformationUnitsPerUpload is supplied.'
@@ -319,7 +331,7 @@ export function estimateImagePipelineRoi(input, options = {}) {
   );
   const avoidableRawGb = rawGbPerMonth * rawUploadBackendFraction;
   const avoidablePreparedGb = preparedGbPerMonth * rawUploadBackendFraction;
-  const avoidedGbPerMonth = Math.max(0, avoidableRawGb - avoidablePreparedGb);
+  const avoidedGbPerMonth = avoidableRawGb - avoidablePreparedGb;
   const avoidedBackendProcessingHours =
     (monthlyUploads *
       rawUploadBackendFraction *
@@ -406,7 +418,7 @@ export function estimateImagePipelineRoi(input, options = {}) {
     caveats: []
   };
 
-  result.caveats = buildCaveats(normalized, measuredInputs, result);
+  result.caveats = buildCaveats(normalized, input, measuredInputs, result);
 
   if (result.estimatedMonthlySavings === undefined) {
     delete result.estimatedMonthlySavings;
@@ -497,6 +509,10 @@ export function parseRoiArgs(argv) {
 function formatMoney(value) {
   if (value === undefined) {
     return 'not estimated';
+  }
+
+  if (value < 0) {
+    return `-$${Math.abs(value).toFixed(2)}`;
   }
 
   return `$${value.toFixed(2)}`;

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "browser:budget-lab": "npm run build:lib && node scripts/run-browser-budget-lab.mjs",
     "browser:budget-lab:install": "playwright install chromium firefox",
     "browser:budget-lab:install:webkit": "playwright install webkit",
+    "roi:estimate": "node docs/tools/roi-calculator.mjs",
     "publish:check": "node scripts/verify-release-workflow.mjs && node scripts/verify-pack-manifest.mjs",
     "release:pr:check": "npm run verify && npm run publish:check",
     "typecheck:examples": "npm run typecheck --workspace examples/vite && npm run typecheck --workspace examples/rsbuild",

--- a/tests/docs/roi-calculator.test.mjs
+++ b/tests/docs/roi-calculator.test.mjs
@@ -1,0 +1,234 @@
+import { describe, expect, it } from 'vitest';
+import {
+  estimateImagePipelineRoi,
+  formatRoiMarkdown,
+  parseRoiArgs
+} from '../../docs/tools/roi-calculator.mjs';
+
+describe('estimateImagePipelineRoi', () => {
+  it('rejects non-object input', () => {
+    expect(() => estimateImagePipelineRoi(null)).toThrow(
+      'ROI input must be an object.'
+    );
+  });
+
+  it('estimates avoided bytes, processing, and cost categories', () => {
+    const result = estimateImagePipelineRoi(
+      {
+        monthlyUploads: 1000,
+        averageRawBytes: 10_000_000,
+        averagePreparedBytes: 2_000_000,
+        rawUploadBackendFraction: 1,
+        averageServerProcessingMs: 500,
+        averageTransformationUnitsPerUpload: 2,
+        bandwidthCostPerGb: 0.1,
+        serverlessCostPerMs: 0.00000002,
+        transformationCostPerUnit: 0.001
+      },
+      {
+        measuredFields: ['averageRawBytes', 'averagePreparedBytes']
+      }
+    );
+
+    expect(result.rawGbPerMonth).toBe(10);
+    expect(result.preparedGbPerMonth).toBe(2);
+    expect(result.avoidedGbPerMonth).toBe(8);
+    expect(result.avoidedBackendProcessingHours).toBeCloseTo(0.138889, 6);
+    expect(result.costBreakdown).toEqual({
+      bandwidth: 0.8,
+      serverlessProcessing: 0.01,
+      transformations: 2
+    });
+    expect(result.estimatedMonthlySavings).toBe(2.81);
+    expect(result.confidence).toBe('medium');
+    expect(result.avoidedTransformationUnits).toBe(2000);
+  });
+
+  it('keeps savings undefined when no complete cost inputs are supplied', () => {
+    const result = estimateImagePipelineRoi({
+      monthlyUploads: 100,
+      averageRawBytes: 5_000_000,
+      averagePreparedBytes: 1_000_000
+    });
+
+    expect(result.estimatedMonthlySavings).toBeUndefined();
+    expect(result.confidence).toBe('low');
+    expect(result.caveats).toContain(
+      'No complete cost assumptions were supplied, so estimatedMonthlySavings is omitted.'
+    );
+  });
+
+  it('warns when engineering cost inputs are incomplete', () => {
+    const result = estimateImagePipelineRoi({
+      monthlyUploads: 100,
+      averageRawBytes: 5_000_000,
+      averagePreparedBytes: 1_000_000,
+      engineeringHoursSavedPerMonth: 2
+    });
+
+    expect(result.estimatedMonthlySavings).toBeUndefined();
+    expect(result.caveats).toContain(
+      'Engineering savings require both engineeringHoursSavedPerMonth and engineeringHourlyCost.'
+    );
+  });
+
+  it('requires invoice and infrastructure evidence for high confidence', () => {
+    const result = estimateImagePipelineRoi(
+      {
+        monthlyUploads: 100,
+        averageRawBytes: 5_000_000,
+        averagePreparedBytes: 1_000_000
+      },
+      {
+        measuredFields: [
+          'averageRawBytes',
+          'averagePreparedBytes',
+          'beforeAfterInfrastructure',
+          'actualInvoices'
+        ]
+      }
+    );
+
+    expect(result.confidence).toBe('high');
+  });
+
+  it('rejects unknown measured fields', () => {
+    expect(() =>
+      estimateImagePipelineRoi(
+        {
+          monthlyUploads: 100,
+          averageRawBytes: 5_000_000,
+          averagePreparedBytes: 1_000_000
+        },
+        {
+          measuredFields: ['averageRawByte']
+        }
+      )
+    ).toThrow('Unknown measured field "averageRawByte".');
+  });
+
+  it('rejects non-array measured field options', () => {
+    expect(() =>
+      estimateImagePipelineRoi(
+        {
+          monthlyUploads: 100,
+          averageRawBytes: 5_000_000,
+          averagePreparedBytes: 1_000_000
+        },
+        {
+          measuredFields: 'averageRawBytes'
+        }
+      )
+    ).toThrow('measuredFields must be an array.');
+  });
+
+  it('rejects measured numeric fields without matching input values', () => {
+    expect(() =>
+      estimateImagePipelineRoi(
+        {
+          monthlyUploads: 100,
+          averageRawBytes: 5_000_000,
+          averagePreparedBytes: 1_000_000
+        },
+        {
+          measuredFields: ['averageServerProcessingMs']
+        }
+      )
+    ).toThrow(
+      'Measured field "averageServerProcessingMs" requires a corresponding input value.'
+    );
+  });
+
+  it('rejects zero required inputs', () => {
+    expect(() =>
+      estimateImagePipelineRoi({
+        monthlyUploads: 0,
+        averageRawBytes: 5_000_000,
+        averagePreparedBytes: 1_000_000
+      })
+    ).toThrow('monthlyUploads must be a finite positive number.');
+  });
+
+  it('reports draft support exposure separately from savings', () => {
+    const result = estimateImagePipelineRoi({
+      monthlyUploads: 1000,
+      averageRawBytes: 5_000_000,
+      averagePreparedBytes: 1_000_000,
+      abandonedDraftRate: 0.05,
+      supportTicketCost: 20,
+      bandwidthCostPerGb: 0.1
+    });
+
+    expect(result.estimatedMonthlyDraftSupportExposure).toBe(1000);
+    expect(result.estimatedMonthlySavings).toBe(0.4);
+  });
+});
+
+describe('parseRoiArgs', () => {
+  it('parses kebab-case flags and measured fields', () => {
+    const parsed = parseRoiArgs([
+      '--monthly-uploads=1000',
+      '--average-raw-bytes=5000000',
+      '--average-prepared-bytes=1000000',
+      '--measured=raw_bytes,prepared_bytes',
+      '--format=markdown'
+    ]);
+
+    expect(parsed.input).toEqual({
+      monthlyUploads: 1000,
+      averageRawBytes: 5_000_000,
+      averagePreparedBytes: 1_000_000
+    });
+    expect(parsed.measuredFields).toEqual(['raw_bytes', 'prepared_bytes']);
+    expect(parsed.format).toBe('markdown');
+  });
+
+  it('rejects flags without explicit values', () => {
+    expect(() => parseRoiArgs(['--monthly-uploads'])).toThrow(
+      'Missing value for "--monthly-uploads". Use --name=value.'
+    );
+  });
+
+  it('lets help short-circuit other arguments', () => {
+    expect(parseRoiArgs(['--help', '--bad'])).toEqual({
+      input: {},
+      measuredFields: [],
+      format: 'json',
+      showHelp: true
+    });
+  });
+
+  it('rejects empty argument names', () => {
+    expect(() => parseRoiArgs(['--=1'])).toThrow(
+      'Argument name is required.'
+    );
+  });
+});
+
+describe('formatRoiMarkdown', () => {
+  it('renders a shareable estimate without secrets', () => {
+    const result = estimateImagePipelineRoi({
+      monthlyUploads: 100,
+      averageRawBytes: 5_000_000,
+      averagePreparedBytes: 1_000_000
+    });
+    const markdown = formatRoiMarkdown(result);
+
+    expect(markdown).toContain('# Image pipeline ROI estimate');
+    expect(markdown).toContain('Vendor rates');
+    expect(markdown).toContain('Raw GB/month | 0.5');
+  });
+
+  it('keeps tiny GB values distinguishable in markdown output', () => {
+    const result = estimateImagePipelineRoi({
+      monthlyUploads: 1,
+      averageRawBytes: 1000,
+      averagePreparedBytes: 500
+    });
+    const markdown = formatRoiMarkdown(result);
+
+    expect(markdown).toContain('Raw GB/month | 0.000001');
+    expect(markdown).toContain('Prepared GB/month | 0.0000005');
+    expect(markdown).toContain('Avoided backend GB/month | 0.0000005');
+  });
+});

--- a/tests/docs/roi-calculator.test.mjs
+++ b/tests/docs/roi-calculator.test.mjs
@@ -122,6 +122,21 @@ describe('estimateImagePipelineRoi', () => {
     ).toThrow('measuredFields must be an array.');
   });
 
+  it('rejects non-string measured field entries', () => {
+    expect(() =>
+      estimateImagePipelineRoi(
+        {
+          monthlyUploads: 100,
+          averageRawBytes: 5_000_000,
+          averagePreparedBytes: 1_000_000
+        },
+        {
+          measuredFields: [123]
+        }
+      )
+    ).toThrow('measuredFields[0] must be a string.');
+  });
+
   it('rejects measured numeric fields without matching input values', () => {
     expect(() =>
       estimateImagePipelineRoi(
@@ -161,6 +176,49 @@ describe('estimateImagePipelineRoi', () => {
 
     expect(result.estimatedMonthlyDraftSupportExposure).toBe(1000);
     expect(result.estimatedMonthlySavings).toBe(0.4);
+  });
+
+  it('preserves negative byte deltas in bandwidth and storage math', () => {
+    const result = estimateImagePipelineRoi({
+      monthlyUploads: 100,
+      averageRawBytes: 1_000_000,
+      averagePreparedBytes: 2_000_000,
+      bandwidthCostPerGb: 0.1,
+      storageCostPerGbMonth: 0.2
+    });
+
+    expect(result.avoidedGbPerMonth).toBe(-0.1);
+    expect(result.costBreakdown).toEqual({
+      bandwidth: -0.01,
+      storage: -0.02
+    });
+    expect(result.estimatedMonthlySavings).toBe(-0.03);
+    expect(result.caveats).toContain(
+      'Prepared bytes exceed raw bytes; the pipeline may improve policy fit or privacy, but byte savings are not shown by these inputs.'
+    );
+  });
+
+  it('only shows the default transformation-unit caveat when units are omitted', () => {
+    const omittedUnitsResult = estimateImagePipelineRoi({
+      monthlyUploads: 100,
+      averageRawBytes: 5_000_000,
+      averagePreparedBytes: 1_000_000,
+      transformationCostPerUnit: 0.001
+    });
+    const explicitOneUnitResult = estimateImagePipelineRoi({
+      monthlyUploads: 100,
+      averageRawBytes: 5_000_000,
+      averagePreparedBytes: 1_000_000,
+      averageTransformationUnitsPerUpload: 1,
+      transformationCostPerUnit: 0.001
+    });
+
+    expect(omittedUnitsResult.caveats).toContain(
+      'Transformation savings assume one transformation unit per upload unless averageTransformationUnitsPerUpload is supplied.'
+    );
+    expect(explicitOneUnitResult.caveats).not.toContain(
+      'Transformation savings assume one transformation unit per upload unless averageTransformationUnitsPerUpload is supplied.'
+    );
   });
 });
 
@@ -230,5 +288,18 @@ describe('formatRoiMarkdown', () => {
     expect(markdown).toContain('Raw GB/month | 0.000001');
     expect(markdown).toContain('Prepared GB/month | 0.0000005');
     expect(markdown).toContain('Avoided backend GB/month | 0.0000005');
+  });
+
+  it('formats negative savings clearly', () => {
+    const result = estimateImagePipelineRoi({
+      monthlyUploads: 100,
+      averageRawBytes: 1_000_000,
+      averagePreparedBytes: 2_000_000,
+      bandwidthCostPerGb: 0.1
+    });
+
+    expect(formatRoiMarkdown(result)).toContain(
+      'Estimated monthly savings | -$0.01'
+    );
   });
 });

--- a/tests/docs/roi-calculator.test.mjs
+++ b/tests/docs/roi-calculator.test.mjs
@@ -198,6 +198,21 @@ describe('estimateImagePipelineRoi', () => {
     );
   });
 
+  it('rounds negative half-cent cost totals away from zero', () => {
+    const result = estimateImagePipelineRoi({
+      monthlyUploads: 1,
+      averageRawBytes: 0.5,
+      averagePreparedBytes: 1,
+      bandwidthCostPerGb: 10_000_000
+    });
+
+    expect(result.avoidedGbPerMonth).toBe(-0.000000001);
+    expect(result.costBreakdown).toEqual({
+      bandwidth: -0.01
+    });
+    expect(result.estimatedMonthlySavings).toBe(-0.01);
+  });
+
   it('only shows the default transformation-unit caveat when units are omitted', () => {
     const omittedUnitsResult = estimateImagePipelineRoi({
       monthlyUploads: 100,


### PR DESCRIPTION
## Summary

- Add a vendor-neutral ROI model for Zero Image-Processing Backend pilots.
- Add a local `npm run roi:estimate` calculator with JSON and Markdown output.
- Track measured inputs separately from assumptions, confidence, caveats, and cost breakdowns.
- Add tests for CLI parsing, boundary validation, confidence levels, and tiny-value formatting.
- Register the ROI estimate claim in the claim ledger.

## Why

The cost-reduction narrative needs a measurable proof path instead of a guaranteed-savings claim. This keeps provider rates, invoices, and transformation-unit definitions as app-owned inputs while giving pilots a repeatable way to compare raw bytes, prepared bytes, backend work, and cost assumptions.

## Validation

- `npm test -- tests/docs/roi-calculator.test.mjs`
- `npm run verify`
- `npm run publish:check`
